### PR TITLE
Removed the <property name="sessionProvider" ref="cropSessionProvider…

### DIFF
--- a/src/test/resources/testContext.xml
+++ b/src/test/resources/testContext.xml
@@ -87,6 +87,7 @@
     </bean> 
     
     <bean id="inventoryService" class="org.generationcp.middleware.service.InventoryServiceImpl">
+        <constructor-arg ref="cropSessionProvider"/>
     </bean> 
     
     <bean id="presetDataManager" class="org.generationcp.middleware.manager.PresetDataManagerImpl">


### PR DESCRIPTION
Removed the sessionProvider in InventoryService bean config. This caused the test context to not load properly.
