### PR TITLE
BMS-1743 Fixing exception in the getLocationByIds method when provided a null …

### DIFF
--- a/src/main/java/org/generationcp/middleware/dao/LocationDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/LocationDAO.java
@@ -530,6 +530,11 @@ public class LocationDAO extends GenericDAO<Location, Integer> {
 	}
 
 	public List<Location> getLocationByIds(Collection<Integer> ids) throws MiddlewareQueryException {
+
+		if(ids == null || ids.isEmpty()) {
+			return new ArrayList<>();
+		}
+
 		try {
 			return this.getSession().createCriteria(Location.class).add(Restrictions.in(LocationDAO.LOCID, ids))
 					.addOrder(Order.asc(LocationDAO.LNAME)).list();

--- a/src/test/java/org/generationcp/middleware/manager/LocationDataManagerImplTest.java
+++ b/src/test/java/org/generationcp/middleware/manager/LocationDataManagerImplTest.java
@@ -12,6 +12,7 @@
 package org.generationcp.middleware.manager;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -98,18 +99,34 @@ public class LocationDataManagerImplTest extends IntegrationTestBase {
 			ids.add(ls.getLocid());
 
 			// only get subset of locations
-			if (ids.size() < 5) {
+			if (ids.size() == 5) {
 				break;
 			}
 		}
 
 		List<Location> results = this.manager.getLocationsByIDs(ids);
-		Assert.assertTrue(results != null);
-		Assert.assertTrue(results.size() < 5);
+		Assert.assertTrue("Result set must not be null", results != null && !results.isEmpty());
+		Assert.assertTrue("Test must only return five results", results.size() == 5);
 
-		Debug.println(IntegrationTestBase.INDENT, "testGetLocationsByIDs(): ");
-		Debug.printObjects(IntegrationTestBase.INDENT, results);
+		for (final Location location : results) {
+			Assert.assertTrue("Make sure location id received is in the actual requested set.", ids.contains(location.getLocid()));
+		}
 	}
+
+	@Test
+	public void testHandlingOfNullOrEmptyLocationIdsInGetLocationsByIDs() throws Exception {
+
+		final List<Location> locationsByIdEmptyTest = this.manager.getLocationsByIDs(Collections.<Integer>emptyList());
+		Assert.assertTrue("Returned result must not be null and must be an empty list", locationsByIdEmptyTest != null
+				&& locationsByIdEmptyTest.isEmpty());
+
+		final List<Location> locationsByIdNullTest = this.manager.getLocationsByIDs(null);
+		Assert.assertTrue("Returned result must not be null and must be an empty list", locationsByIdNullTest != null
+				&& locationsByIdNullTest.isEmpty());
+
+	}
+
+
 
 	@Test
 	public void testGetAllCountry() throws Exception {


### PR DESCRIPTION
…or empty list of LocationId's

The LocationDAO's getLocationByIds now validates method parameters. It returns an empty list when provided a null or an empty list of location ids.

Also added in tests to make sure this case is catered for. Improved the existing getLocationByIds test.

issue: BMS-1742
reviewer: none
