### PR TITLE
BMS-1771 Fixed Incorrect Variable Usage Count

### DIFF
--- a/src/main/java/org/generationcp/middleware/service/Measurements.java
+++ b/src/main/java/org/generationcp/middleware/service/Measurements.java
@@ -33,7 +33,8 @@ public class Measurements {
 	 * @param observations list of observations to save
 	 */
 	void saveMeasurements(final List<MeasurementRow> observations) {
-		// Changing the fulsh mode will have huge performance implications. Please be careful when doing this. The current stratergy below
+		// Changing the fulsh mode will have huge performance implications.
+		// Please be careful when doing this. The current stratergy below
 		// facilitates batch inserts.
 		final FlushMode originalFlushMode = this.session.getFlushMode();
 		try {
@@ -89,9 +90,10 @@ public class Measurements {
 			}
 			for (final MeasurementData measurementData : dataList) {
 
-				// TODO Change the UI so that we are never send back any data which is null
-				if (!measurementData.isEditable() || StringUtils.isBlank(measurementData.getcValueId())
-						&& StringUtils.isBlank(measurementData.getValue())) {
+				// TODO Change the UI so that we are never send back any data
+				// which is null
+				if (!measurementData.isEditable() || (measurementData.getPhenotypeId() == null || measurementData.getPhenotypeId() == 0)
+						&& StringUtils.isBlank(measurementData.getcValueId()) && StringUtils.isBlank(measurementData.getValue())) {
 					continue;
 				}
 				final MeasurementVariable measurementVariable = measurementData.getMeasurementVariable();
@@ -102,6 +104,11 @@ public class Measurements {
 				this.phenotypeSaver.saveOrUpdate(measurementRow.getExperimentId(), measurementVariable.getTermId(),
 						measurementData.getcValueId() != null && !"".equals(measurementData.getcValueId()) ? measurementData.getcValueId()
 								: measurementData.getValue(), phenotype, measurementData.getMeasurementVariable().getDataTypeId());
+				// This is not great but essential because the workbook
+				// object must be updated so that it has new phenotype id. This
+				// id is then piped back to the UI and is used in subsequent calls to
+				// determine if we need to update or add phenotype values
+				measurementData.setPhenotypeId(phenotype.getPhenotypeId());
 
 			}
 

--- a/src/test/java/org/generationcp/middleware/service/MeasurementsTest.java
+++ b/src/test/java/org/generationcp/middleware/service/MeasurementsTest.java
@@ -17,6 +17,8 @@ import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
+import edu.umd.cs.findbugs.annotations.When;
+
 public class MeasurementsTest {
 
 	private static final int TEST_DATA_TYPE_ID = 200;
@@ -27,10 +29,14 @@ public class MeasurementsTest {
 
 	private PhenotypeSaver mockPhenotypeSaver;
 
+	private Measurements measurements;
+
 	@Before
 	public void setup() {
 		this.mockPhenotypeSaver = Mockito.mock(PhenotypeSaver.class);
 		this.mockHibernateSessiong = Mockito.mock(Session.class);
+		measurements = new Measurements(this.mockHibernateSessiong, this.mockPhenotypeSaver);
+
 	}
 
 	@Test()
@@ -38,7 +44,6 @@ public class MeasurementsTest {
 		final MeasurementData measurementData = this.getTestMeasurementData();
 		measurementData.setValue("Test Value");
 
-		final Measurements measurements = new Measurements(this.mockHibernateSessiong, this.mockPhenotypeSaver);
 		final Phenotype phenotypeFromMeasurement = measurements.createPhenotypeFromMeasurement(measurementData);
 
 		Assert.assertEquals("We do not map the assay id and thus it should be null", null, phenotypeFromMeasurement.getAssayId());
@@ -58,7 +63,6 @@ public class MeasurementsTest {
 		measurementData.setCustomCategoricalValue(true);
 		measurementData.setcValueId("1");
 
-		final Measurements measurements = new Measurements(this.mockHibernateSessiong, this.mockPhenotypeSaver);
 		final Phenotype phenotypeFromMeasurement = measurements.createPhenotypeFromMeasurement(measurementData);
 
 		Assert.assertEquals("Phenotype value is mapped incorrectly", measurementData.getcValueId(), phenotypeFromMeasurement.getcValueId()
@@ -66,35 +70,44 @@ public class MeasurementsTest {
 	}
 
 	@Test
-	public void testUneditiableMeasurementDataAreSkipped() throws Exception {
-		final Measurements measurements = new Measurements(this.mockHibernateSessiong, this.mockPhenotypeSaver);
-		final MeasurementRow measurementRow = new MeasurementRow();
-		measurementRow.setExperimentId(1);
+	public void testUneditableMeasurementDataAreSkipped() throws Exception {
+		final MeasurementRow measurementRow = getMeasurementRow();
 		final MeasurementData testMeasurementData = this.getTestMeasurementData();
 		testMeasurementData.setEditable(false);
+		testSkippingOfNonCreatedPhenotypes(measurementRow, testMeasurementData);
+	}
+
+	@Test
+	public void testNullValueMeasurementDataAreSkippedWhenPhenotypeIdNull() throws Exception {
+		final MeasurementRow measurementRow = getMeasurementRow();
+		final MeasurementData testMeasurementData = this.getTestMeasurementData();
+		testMeasurementData.setPhenotypeId(null);
+		testSkippingOfNonCreatedPhenotypes(measurementRow, testMeasurementData);
+	}
+	
+	@Test
+	public void testNullValueMeasurementDataAreSkippedWhenPhenotypeIdIsZero() throws Exception {
+		final MeasurementRow measurementRow = getMeasurementRow();
+		final MeasurementData testMeasurementData = this.getTestMeasurementData();
+		testMeasurementData.setPhenotypeId(0);
+		testSkippingOfNonCreatedPhenotypes(measurementRow, testMeasurementData);
+	}
+
+	
+	private void testSkippingOfNonCreatedPhenotypes(
+			final MeasurementRow measurementRow,
+			final MeasurementData testMeasurementData) {
 		measurementRow.setDataList(Collections.<MeasurementData>singletonList(testMeasurementData));
 		measurements.saveMeasurementData(Collections.<MeasurementRow>singletonList(measurementRow));
+		// We have a lot of any matchers because we are verifying that the method is never called.
 		Mockito.verify(this.mockPhenotypeSaver, Mockito.times(0)).saveOrUpdate(Matchers.anyInt(), Matchers.anyInt(), Matchers.anyString(),
 				(Phenotype) Matchers.anyObject(), Matchers.anyInt());
 	}
 
-	@Test
-	public void testNullValueMeasurementDataAreSkipped() throws Exception {
-		final Measurements measurements = new Measurements(this.mockHibernateSessiong, this.mockPhenotypeSaver);
-		final MeasurementRow measurementRow = new MeasurementRow();
-		measurementRow.setExperimentId(1);
-		final MeasurementData testMeasurementData = this.getTestMeasurementData();
-		measurementRow.setDataList(Collections.<MeasurementData>singletonList(testMeasurementData));
-		measurements.saveMeasurementData(Collections.<MeasurementRow>singletonList(measurementRow));
-		Mockito.verify(this.mockPhenotypeSaver, Mockito.times(0)).saveOrUpdate(Matchers.anyInt(), Matchers.anyInt(), Matchers.anyString(),
-				(Phenotype) Matchers.anyObject(), Matchers.anyInt());
-	}
 
 	@Test
 	public void makeSureCorrectHibernateFlushTypeIsUsed() throws Exception {
-		final Measurements measurements = new Measurements(this.mockHibernateSessiong, this.mockPhenotypeSaver);
-		final MeasurementRow measurementRow = new MeasurementRow();
-		measurementRow.setExperimentId(1);
+		final MeasurementRow measurementRow = getMeasurementRow();
 		final MeasurementData testMeasurementData = this.getTestMeasurementData();
 		measurementRow.setDataList(Collections.<MeasurementData>singletonList(testMeasurementData));
 		Mockito.when(this.mockHibernateSessiong.getFlushMode()).thenReturn(FlushMode.AUTO);
@@ -114,6 +127,30 @@ public class MeasurementsTest {
 	public void testCategoricalMeasurementDataAreSavedAsPhenotypes() throws Exception {
 		this.testSavingMeasurements("Categorical Value", true);
 	}
+	
+	/**
+	 * Simple test to ensure that the Phenotype id is set into the measurement data so that the UI does not recreate data. The test does not
+	 * do any logical validation but just ensures that the measurement data is updated with a phenotype id when created. Without this saving
+	 * an updating of measurement data is broken.
+	 */
+	@Test
+	public void testPhenotypeIdSetOnSave() {
+		final Measurements measurements = new Measurements(this.mockHibernateSessiong, this.mockPhenotypeSaver);
+		final MeasurementData testMeasurementData = Mockito.mock(MeasurementData.class);
+		final MeasurementRow measurementRow = getMeasurementRow();
+		measurementRow.setDataList(Collections.<MeasurementData>singletonList(testMeasurementData));
+		
+		// Set up measurement data so that it actually tries to save something.
+		Mockito.when(testMeasurementData.isEditable()).thenReturn(true);
+		Mockito.when(testMeasurementData.getValue()).thenReturn("Test Data");
+		Mockito.when(testMeasurementData.getMeasurementVariable()).thenReturn(Mockito.mock(MeasurementVariable.class));
+		
+		int testPhenotypeId = 245;
+		Mockito.when(testMeasurementData.getPhenotypeId()).thenReturn(testPhenotypeId);
+
+		measurements.saveMeasurementData(Collections.<MeasurementRow>singletonList(measurementRow));
+		Mockito.verify(testMeasurementData).setPhenotypeId(245);
+	}
 
 	private void testSavingMeasurements(final String value, final boolean isCategorical) {
 
@@ -126,15 +163,19 @@ public class MeasurementsTest {
 			testMeasurementData.setValue(value);
 		}
 
-		final MeasurementRow measurementRow = new MeasurementRow();
-		measurementRow.setExperimentId(1);
+		final MeasurementRow measurementRow = getMeasurementRow();
 		measurementRow.setDataList(Collections.<MeasurementData>singletonList(testMeasurementData));
 
 		measurements.saveMeasurementData(Collections.<MeasurementRow>singletonList(measurementRow));
-
 		Mockito.verify(this.mockPhenotypeSaver, Mockito.times(1)).saveOrUpdate(Matchers.eq(measurementRow.getExperimentId()),
 				Matchers.eq(MeasurementsTest.TEST_TERM_ID), Matchers.eq(value), (Phenotype) Matchers.anyObject(),
 				Matchers.eq(MeasurementsTest.TEST_DATA_TYPE_ID));
+	}
+	
+	private MeasurementRow getMeasurementRow() {
+		final MeasurementRow measurementRow = new MeasurementRow();
+		measurementRow.setExperimentId(1);
+		return measurementRow;
 	}
 
 	private MeasurementData getTestMeasurementData() {
@@ -149,7 +190,6 @@ public class MeasurementsTest {
 						"Variable Method", "Variable Property", "1", "Variable Value", "Variable Lable");
 		measurementVariable.setDataTypeId(MeasurementsTest.TEST_DATA_TYPE_ID);
 		measurementData.setMeasurementVariable(measurementVariable);
-		measurementData.setPhenotypeId(123);
 		measurementData.setVariable(new Variable());
 		return measurementData;
 	}


### PR DESCRIPTION
Saving of trials or nurseries let to adding of an additional row in the phenotype table. This was because after adding a phenotype record we did not update the phenotype id in the UI. This is now achieved by setting in the phenotype id into each measurement data on creation or updating.

issue: BMS-1771
reviewer: MatthewB
