### PR TITLE
BMS-2238 Fix error in jasper report

### DIFF
--- a/src/main/java/org/generationcp/middleware/service/ReportServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/service/ReportServiceImpl.java
@@ -106,9 +106,7 @@ public class ReportServiceImpl extends Service implements ReportService {
 
 		for (final MeasurementVariable condition : originalConditions) {
 			final TermId term = TermId.getById(condition.getTermId());
-			if (term == TermId.LOCATION_ID) {
-				locationId = Integer.parseInt(condition.getValue());
-			}
+			locationId = this.retrieveLocationIdFromCondition(condition, term);
 		}
 
 		if (locationId == null) {
@@ -137,6 +135,23 @@ public class ReportServiceImpl extends Service implements ReportService {
 			return variables;
 
 		}
+	}
+
+	/***
+	 * Retrieves the Location ID from condition variable; Returns null if the condition value is an empty string
+	 * 
+	 * @param locationId
+	 * @param condition
+	 * @param termId
+	 * @return
+	 */
+	Integer retrieveLocationIdFromCondition(final MeasurementVariable condition, final TermId termId) {
+		Integer locationId = null;
+		final String conditionValue = condition.getValue().trim();
+		if (termId == TermId.LOCATION_ID && conditionValue.length() > 0) {
+			locationId = Integer.parseInt(conditionValue);
+		}
+		return locationId;
 	}
 
 	@Override

--- a/src/test/java/org/generationcp/middleware/service/ReportServiceImplTest.java
+++ b/src/test/java/org/generationcp/middleware/service/ReportServiceImplTest.java
@@ -1,0 +1,31 @@
+
+package org.generationcp.middleware.service;
+
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ReportServiceImplTest {
+
+	private final ReportServiceImpl reportService = new ReportServiceImpl();
+
+	@Test
+	public void testRetrieveLocationIdFromConditionReturnsNullForEmptyString() {
+		final MeasurementVariable condition = new MeasurementVariable();
+		condition.setTermId(TermId.LOCATION_ID.getId());
+		condition.setValue("");
+		Assert.assertNull("Expecting a null for location id when the value of LOCATION ID variable is empty string.",
+				this.reportService.retrieveLocationIdFromCondition(condition, TermId.LOCATION_ID));
+	}
+
+	@Test
+	public void testRetrieveLocationIdFromConditionReturnsAnIntegerForValidNumber() {
+		final MeasurementVariable condition = new MeasurementVariable();
+		condition.setTermId(TermId.LOCATION_ID.getId());
+		final int locationId = 1;
+		condition.setValue(String.valueOf(locationId));
+		Assert.assertEquals("Expecting an integer for location id when the value of LOCATION ID variable is a valid number > 0.",
+				locationId, this.reportService.retrieveLocationIdFromCondition(condition, TermId.LOCATION_ID).intValue());
+	}
+}


### PR DESCRIPTION
The fix covers the java.lang.NumberFormatException: For input string: "" error when exporting jasper report of trial created by basic template
