### PR TITLE
Ticket 2623: Searching for Germplasm which returns an irrelevant error message

### DIFF
--- a/src/main/java/org/generationcp/middleware/manager/GermplasmDataManagerImpl.java
+++ b/src/main/java/org/generationcp/middleware/manager/GermplasmDataManagerImpl.java
@@ -1034,6 +1034,7 @@ public class GermplasmDataManagerImpl extends DataManager implements GermplasmDa
 	 * Overload the previous method to accommodate the added parameter.
 	 */
 	@Override
+	@Transactional(readOnly = true)
 	public List<Germplasm> searchForGermplasm(final String q, final Operation o, final boolean includeParents,
 			final boolean withInventoryOnly, final boolean includeMGMembers) {
 		return this.getGermplasmDao().searchForGermplasms(q, o, includeParents, withInventoryOnly, includeMGMembers);


### PR DESCRIPTION
Searching for Germplasm which returns an error shows irrelevant error message

declaring that the transaction for the search query is readonly
