### PR TITLE
BMS-2724 - Added back removed test query

### DIFF
--- a/src/main/java/org/generationcp/middleware/hibernate/DataSourceProperties.java
+++ b/src/main/java/org/generationcp/middleware/hibernate/DataSourceProperties.java
@@ -21,6 +21,8 @@ public class DataSourceProperties {
 	static final String CONNECTIONPOOL_MAX_IDLE_TIME = "connectionpool.max.idle.time";
 
 	static final String CONNECTIONPOOL_REAP_TIMEOUT = "connectionpool.reap.timeout";
+	
+	static final String CONNECTIONPOOL_TEST_QUERY = "connectionpool.test.query";
 
 	static final String CONNECTIONPOOL_XADRIVER_NAME = "connectionpool.xadriver.name";
 
@@ -46,6 +48,12 @@ public class DataSourceProperties {
 
 	private String port = "3306";
 
+	/**
+	 * Test query is essential to make sure that we can recover from erroneous connections. Even thought this property is deprecated 
+	 * by Atomikos please do not remove.
+	 */
+	private String testQuery = "Select 1";
+	
 	private String userName = "root";
 
 	private String password = "";
@@ -62,6 +70,7 @@ public class DataSourceProperties {
 
 	private static final Logger LOG = LoggerFactory.getLogger(DataSourceProperties.class);
 
+
 	public DataSourceProperties(final Properties properties) {
 
 		this.host = this.getPropertyValue(properties, this.host, DataSourceProperties.DB_HOST);
@@ -75,6 +84,7 @@ public class DataSourceProperties {
 						DataSourceProperties.CONNECTIONPOOL_BORROW_CONNECTION_TIMEOUT);
 		this.maintenanceInterval =
 				this.getPropertyValue(properties, this.maintenanceInterval, DataSourceProperties.CONNECTIONPOOL_MAINTENANCE_INTERVAL);
+		this.testQuery = this.getPropertyValue(properties, this.testQuery, DataSourceProperties.CONNECTIONPOOL_TEST_QUERY);
 		this.minPoolSize = this.getPropertyValue(properties, this.minPoolSize, DataSourceProperties.CONNECTIONPOOL_MIN_POOL_SIZE);
 		this.maxPoolSize = this.getPropertyValue(properties, this.maxPoolSize, DataSourceProperties.CONNECTIONPOOL_MAX_POOL_SIZE);
 		this.maxIdleTime = this.getPropertyValue(properties, this.maxIdleTime, DataSourceProperties.CONNECTIONPOOL_MAX_IDLE_TIME);
@@ -134,6 +144,13 @@ public class DataSourceProperties {
 	 */
 	public String getPort() {
 		return this.port;
+	}
+
+	/**
+	 * @return the testQuery
+	 */
+	String getTestQuery() {
+		return this.testQuery;
 	}
 
 	/**

--- a/src/main/java/org/generationcp/middleware/hibernate/XABeanDefinition.java
+++ b/src/main/java/org/generationcp/middleware/hibernate/XABeanDefinition.java
@@ -18,6 +18,10 @@ import com.google.common.collect.ImmutableMap;
 
 public class XABeanDefinition {
 
+	static final String CHARACTER_ENCODING = "characterEncoding";
+
+	static final String USE_UNICODE = "useUnicode";
+
 	static final String CACHE_PREP_STMTS = "cachePrepStmts";
 
 	static final String USE_SERVER_PREP_STMTS = "useServerPrepStmts";
@@ -43,6 +47,8 @@ public class XABeanDefinition {
 	static final String XA_PROPERTIES = "xaProperties";
 
 	static final String BORROW_CONNECTION_TIMEOUT = "borrowConnectionTimeout";
+	
+	static final String TEST_QUERY = "testQuery";
 	
 	static final String REAP_TIMEOUT = "reapTimeout";
 
@@ -144,6 +150,7 @@ public class XABeanDefinition {
 		dataSourceBeanDefinitionProperties.put(XABeanDefinition.MAX_POOL_SIZE, xaDataSourceProperties.getMaxPoolSize());
 		dataSourceBeanDefinitionProperties.put(XABeanDefinition.MIN_POOL_SIZE, xaDataSourceProperties.getMinPoolSize());
 		dataSourceBeanDefinitionProperties.put(XABeanDefinition.REAP_TIMEOUT, xaDataSourceProperties.getReapTimeout());
+		dataSourceBeanDefinitionProperties.put(XABeanDefinition.TEST_QUERY, xaDataSourceProperties.getTestQuery());
 
 		dataSourceBeanDefinitionProperties.put(XABeanDefinition.BORROW_CONNECTION_TIMEOUT,
 				xaDataSourceProperties.getBorrowConnectionTimeout());
@@ -168,6 +175,8 @@ public class XABeanDefinition {
 		databaseConnectionProperties.setProperty(XABeanDefinition.PIN_GLOBAL_TX_TO_PHYSICAL_CONNECTION, "true");
 		databaseConnectionProperties.setProperty(USE_SERVER_PREP_STMTS, "true");
 		databaseConnectionProperties.setProperty(CACHE_PREP_STMTS, "true");
+		databaseConnectionProperties.setProperty(USE_UNICODE, "true");
+		databaseConnectionProperties.setProperty(CHARACTER_ENCODING, "UTF-8");
 
 		return databaseConnectionProperties;
 	}

--- a/src/test/java/org/generationcp/middleware/hibernate/DataSourcePropertiesTest.java
+++ b/src/test/java/org/generationcp/middleware/hibernate/DataSourcePropertiesTest.java
@@ -12,6 +12,10 @@ public class DataSourcePropertiesTest {
 
 	private final Properties properties = Mockito.mock(Properties.class);
 
+	/**
+	 * This test makes sure that the DataSourceProperties constructor overrides default properties when specified in a property file.
+	 * 
+	 */
 	@Test
 	public void testXADataSourceProperties() throws Exception {
 
@@ -30,6 +34,7 @@ public class DataSourcePropertiesTest {
 		Assert.assertEquals(xaDataSourceProperties.getMinPoolSize(), XATestUtility.CONNECTIONPOOL_MIN_POOL_SIZE);
 		Assert.assertEquals(xaDataSourceProperties.getMaxPoolSize(), XATestUtility.CONNECTIONPOOL_MAX_POOL_SIZE);
 		Assert.assertEquals(xaDataSourceProperties.getMaxIdleTime(), XATestUtility.CONNECTIONPOOL_MAX_IDLE_TIME);
+		Assert.assertEquals(xaDataSourceProperties.getTestQuery(), XATestUtility.CONNECTIONPOOL_TEST_QUERY);
 
 		Assert.assertEquals(xaDataSourceProperties.getHibernateConfigurationLocation(), "classpath:ibpmidware_hib.cfg.xml");
 
@@ -53,6 +58,7 @@ public class DataSourcePropertiesTest {
 		Assert.assertEquals(xaDataSourceProperties.getMinPoolSize(), "3");
 		Assert.assertEquals(xaDataSourceProperties.getMaxPoolSize(), "100");
 		Assert.assertEquals(xaDataSourceProperties.getMaxIdleTime(), "120");
+		Assert.assertEquals(xaDataSourceProperties.getTestQuery(), "Select 1");
 
 		Assert.assertEquals(xaDataSourceProperties.getHibernateConfigurationLocation(), "classpath:ibpmidware_hib.cfg.xml");
 

--- a/src/test/java/org/generationcp/middleware/hibernate/XABeanDefinitionTest.java
+++ b/src/test/java/org/generationcp/middleware/hibernate/XABeanDefinitionTest.java
@@ -33,7 +33,10 @@ public class XABeanDefinitionTest {
 		Assert.assertEquals("jdbc:mysql://" + this.xaDataSourceProperties.getHost() + ":" + this.xaDataSourceProperties.getPort() + "/"
 				+ this.cropDatabaseName, databaseConnectionProperties.getProperty(XABeanDefinition.URL));
 		Assert.assertEquals("true", databaseConnectionProperties.getProperty(XABeanDefinition.PIN_GLOBAL_TX_TO_PHYSICAL_CONNECTION));
-
+		Assert.assertEquals("UTF-8", databaseConnectionProperties.getProperty(XABeanDefinition.CHARACTER_ENCODING));
+		Assert.assertEquals("true", databaseConnectionProperties.getProperty(XABeanDefinition.USE_UNICODE));
+		Assert.assertEquals("true", databaseConnectionProperties.getProperty(XABeanDefinition.USE_SERVER_PREP_STMTS));
+		Assert.assertEquals("true", databaseConnectionProperties.getProperty(XABeanDefinition.CACHE_PREP_STMTS));
 	}
 
 	@Test
@@ -57,6 +60,8 @@ public class XABeanDefinitionTest {
 		Assert.assertEquals(XATestUtility.CONNECTIONPOOL_MIN_POOL_SIZE,
 				dataSourceBeanDefinitionProperties.get(XABeanDefinition.MIN_POOL_SIZE));
 		Assert.assertEquals(XATestUtility.CONNECTIONPOOL_REAP_TIMEOUT, dataSourceBeanDefinitionProperties.get(XABeanDefinition.REAP_TIMEOUT));
+		Assert.assertEquals(XATestUtility.CONNECTIONPOOL_TEST_QUERY, dataSourceBeanDefinitionProperties.get(XABeanDefinition.TEST_QUERY));
+
 		Assert.assertEquals(XATestUtility.CONNECTIONPOOL_BORROW_CONNECTION_TIMEOUT,
 				dataSourceBeanDefinitionProperties.get(XABeanDefinition.BORROW_CONNECTION_TIMEOUT));
 
@@ -65,8 +70,10 @@ public class XABeanDefinitionTest {
 		Assert.assertEquals(XATestUtility.CONNECTIONPOOL_BORROW_CONNECTION_TIMEOUT,
 				dataSourceBeanDefinitionProperties.get(XABeanDefinition.BORROW_CONNECTION_TIMEOUT));
 		Assert.assertTrue(dataSourceBeanDefinitionProperties.get(XABeanDefinition.XA_PROPERTIES).getClass().equals(Properties.class));
+
 	}
 
+	
 	@Test
 	public void testCreateAllXADataSources() throws Exception {
 

--- a/src/test/java/org/generationcp/middleware/hibernate/XATestUtility.java
+++ b/src/test/java/org/generationcp/middleware/hibernate/XATestUtility.java
@@ -19,6 +19,7 @@ public class XATestUtility {
 	public static final Object CONNECTIONPOOL_MIN_POOL_SIZE = "50";
 	public static final Object CONNECTIONPOOL_MAX_POOL_SIZE = "100";
 	public static final Object CONNECTIONPOOL_MAX_IDLE_TIME = "300";
+	public static final Object CONNECTIONPOOL_TEST_QUERY = "Select 1";
 
 	static DataSourceProperties mockProperties() {
 		final Properties properties = Mockito.mock(Properties.class);
@@ -40,7 +41,11 @@ public class XATestUtility {
 		Mockito.when(properties.get(DataSourceProperties.CONNECTIONPOOL_MAX_POOL_SIZE)).thenReturn(
 				XATestUtility.CONNECTIONPOOL_MAX_POOL_SIZE);
 		Mockito.when(properties.get(DataSourceProperties.CONNECTIONPOOL_MAX_IDLE_TIME)).thenReturn(
+		
 				XATestUtility.CONNECTIONPOOL_MAX_IDLE_TIME);
+		Mockito.when(properties.get(DataSourceProperties.CONNECTIONPOOL_TEST_QUERY)).thenReturn(
+				XATestUtility.CONNECTIONPOOL_TEST_QUERY);
+		
 
 		final DataSourceProperties xaDataSourceProperties = new DataSourceProperties(properties);
 		return xaDataSourceProperties;


### PR DESCRIPTION
Added back removed test query. Test query is essential to make sure that we can recover from erroneous connections. Even though this property is deprecated
by Atomikos please do not remove.

Also added in connection property useUnicode and characterEncoding as these
are standard practice for any MySql Connection.

issue: BMS-2724
reviewer: NaymeshM
