### PR TITLE
BMS-3079 - Added a missing index and fixed change set order

### DIFF
--- a/src/main/resources/liquibase/crop_changelog/4_0_0_BETA_10.xml
+++ b/src/main/resources/liquibase/crop_changelog/4_0_0_BETA_10.xml
@@ -12,7 +12,7 @@
 		<!-- De-duplication of the UDFLDs in wheat database so that unique constraint (see next changeset) can be applied successfully. -->
 		<preConditions onFail="CONTINUE">
 			<sqlCheck expectedResult="1">select case when 'ibdbv2_wheat_merged' = DATABASE() then 1 else 0 end from dual;</sqlCheck>
-		</preConditions>
+		</preConditions>	
 		<sql dbms="mysql" splitStatements="true">
 			DELETE from udflds where fldno=1550;
 			DELETE from udflds where fldno=634;
@@ -21,7 +21,22 @@
 			UPDATE udflds set fcode='EUACC' where fldno = 500000004;			
 		</sql>
 	</changeSet>
-
+	
+	<!-- 
+		This change has been added in BETA.15. This change should have been in beta 10 but we forgot to add it in.
+		The change helps clean up duplicates in the ibdbv2_rice_merged database. 
+	-->
+	<changeSet author="darla" id="1">
+		<!-- De-duplication of the UDFLDs in rice database so that unique constraint 
+			(see changeset 3) can be applied successfully. -->
+		<preConditions onFail="MARK_RAN">
+			<sqlCheck expectedResult="1">select case when 'ibdbv2_rice_merged' = DATABASE() then 1 else 0 end from dual;</sqlCheck>
+		</preConditions>
+		<sql dbms="mysql" splitStatements="true">
+			DELETE from udflds where fldno in (2002, 2003, 2004, 2005);
+		</sql>
+	</changeSet>
+	
 	<changeSet author="naymesh" id="2">
 		<preConditions onFail="MARK_RAN">
 			<sqlCheck expectedResult="0">SELECT count(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME = 'udflds' AND CONSTRAINT_NAME='udflds_uc1' and TABLE_SCHEMA = DATABASE();</sqlCheck>

--- a/src/main/resources/liquibase/crop_changelog/4_0_0_BETA_15.xml
+++ b/src/main/resources/liquibase/crop_changelog/4_0_0_BETA_15.xml
@@ -6,15 +6,19 @@
 		http://www.liquibase.org/xml/ns/dbchangelog-ext
 		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
-	<changeSet author="darla" id="1">
-		<!-- De-duplication of the UDFLDs in rice database so that unique constraint 
-			(see changeset 3) can be applied successfully. -->
-		<preConditions onFail="CONTINUE">
-			<sqlCheck expectedResult="1">select case when 'ibdbv2_rice_merged' = DATABASE() then 1 else 0 end from dual;</sqlCheck>
+	<changeSet author="akhilm" id="1">
+		<preConditions onFail="MARK_RAN">
+			<sqlCheck expectedResult="1">select case when
+				'workbench' !=
+				DATABASE() then 1 else 0 end from dual;
+			</sqlCheck>
+			<not>
+				<indexExists indexName="idx_listnms_projectid" />
+			</not>
 		</preConditions>
-		<sql dbms="mysql" splitStatements="true">
-			DELETE from udflds where fldno in (2002, 2003, 2004, 2005);
-		</sql>
+		<createIndex indexName="idx_listnms_projectid" tableName="listnms"
+			unique="false">
+			<column name="projectid" type="int" />
+		</createIndex>
 	</changeSet>
-
 </databaseChangeLog>


### PR DESCRIPTION
The query created in org.generationcp.middleware.dao.dms.ExperimentPropertyDao.getFieldMapLabels is non performant due to a missing index. This index has been added in the BETA.15 change set.

Move a change set from BETA.15 to BETA.10 as this is its correct location. Note we can add complete new change sets to existing files but cannot amend existing change sets.

issue: BMS-3079, BMS-2994
reviewer: MatthewB
