### PR TITLE
BMS-3253 Changing datatype of duplicate_notes in listdata_project

### DIFF
--- a/src/main/resources/liquibase/crop_changelog/4_0_0_BETA_17.xml
+++ b/src/main/resources/liquibase/crop_changelog/4_0_0_BETA_17.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd
+		http://www.liquibase.org/xml/ns/dbchangelog-ext
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+	<changeSet author="clarysabel" id="beta17-1">
+		<modifyDataType tableName="listdata_project" columnName="duplicate_notes" newDataType="varchar(600)"/>
+	</changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/crop_master.xml
+++ b/src/main/resources/liquibase/crop_master.xml
@@ -15,5 +15,6 @@
 	<include file="crop_changelog/4_0_0_BETA_14.xml" relativeToChangelogFile="true"/>
 	<include file="crop_changelog/4_0_0_BETA_15.xml" relativeToChangelogFile="true"/>
 	<include file="crop_changelog/4_0_0_BETA_16.xml" relativeToChangelogFile="true"/>
+	<include file="crop_changelog/4_0_0_BETA_17.xml" relativeToChangelogFile="true"/>
 
  </databaseChangeLog>


### PR DESCRIPTION
Due to some imported crosses with many plot and pedigrees duplicated that could not be saved because of the length of duplicate_notes attr in listdata_project, we are changing the datatype fron varchar(200) to varchar(600) (it does not have any index)

Tagging @amehra and @matthewb22 