### PR TITLE
Bms 3807 fix for missing plot code prefix value in back up and restore

### DIFF
--- a/src/test/java/org/generationcp/middleware/data/initializer/ProjectTestDataInitializer.java
+++ b/src/test/java/org/generationcp/middleware/data/initializer/ProjectTestDataInitializer.java
@@ -1,0 +1,20 @@
+package org.generationcp.middleware.data.initializer;
+
+import java.util.Date;
+
+import org.generationcp.middleware.pojos.workbench.CropType;
+import org.generationcp.middleware.pojos.workbench.Project;
+
+public class ProjectTestDataInitializer {
+
+	public Project createProject() {
+		final Project project = new Project();
+		project.setProjectId((long) 1);
+		project.setProjectName("Project");
+		project.setStartDate(new Date());
+		project.setUniqueID("UNIQUEID00001");
+		project.setLastOpenDate(new Date());
+		project.setCropType(new CropType("maize"));
+		return project;
+	}
+}


### PR DESCRIPTION
Kindly review. Thanks!

Low/Medium, just added code to accommodate the addition of the plot_code_prefix column in the workbench_crop table.