### PR TITLE
Fix testSearchForGermplasmsContainsGermplasmName

### DIFF
--- a/src/test/java/org/generationcp/middleware/data/initializer/GermplasmTestDataInitializer.java
+++ b/src/test/java/org/generationcp/middleware/data/initializer/GermplasmTestDataInitializer.java
@@ -63,7 +63,8 @@ public class GermplasmTestDataInitializer {
 		germplasm.setReferenceId(referenceId);
 		germplasm.setMethodName(methodName);
 		germplasm.setLocationName(locationName);
-		germplasm.setPreferredName(GermplasmTestDataInitializer.createGermplasmName(ThreadLocalRandom.current().nextInt(1, 100)));
+		germplasm.setPreferredName(GermplasmTestDataInitializer.createGermplasmName(ThreadLocalRandom.current().nextInt(1, Integer
+			.MAX_VALUE)));
 		return germplasm;
 	}
 


### PR DESCRIPTION
@clarysabel Please review

This test was randomly failing because duplicated names obtained while getting a random int.
Use Integer.MAX_VALUE to decrease probability of collision