### PR TITLE
BMS 4112 Fix Generation of Group ID for Previous Crosses

### DIFF
--- a/src/main/java/org/generationcp/middleware/service/impl/GermplasmGroupingServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/service/impl/GermplasmGroupingServiceImpl.java
@@ -423,14 +423,14 @@ public class GermplasmGroupingServiceImpl implements GermplasmGroupingService {
 							// TODO Flowchart says warn user for this case - this will require returning flag back to the caller from
 							// service.
 
-							if (applyNewGroupToPreviousCrosses) {
-								LOG.info("Applying the new mgid {} to the previous crosses as well.", cross.getMgid());
-								for (final Germplasm previousCross : previousCrosses) {
-									previousCross.setMgid(cross.getMgid());
-									this.germplasmDAO.save(previousCross);
-								}
-							}
+						}
 
+						if (applyNewGroupToPreviousCrosses) {
+							LOG.info("Applying the new mgid {} to the previous crosses as well.", cross.getMgid());
+							for (final Germplasm previousCross : previousCrosses) {
+								previousCross.setMgid(cross.getMgid());
+								this.germplasmDAO.save(previousCross);
+							}
 						}
 					}
 					this.germplasmDAO.save(cross);


### PR DESCRIPTION
If "apply grouping to new crosses only" option is disabled, the groupId should be applied to previous crosses if they are available.

BMS-4112