### PR TITLE
IBP-2137 Does not remove the highlight of the derived trait values even after the calculation

### DIFF
--- a/src/main/java/org/generationcp/middleware/operation/saver/PhenotypeSaver.java
+++ b/src/main/java/org/generationcp/middleware/operation/saver/PhenotypeSaver.java
@@ -130,10 +130,7 @@ public class PhenotypeSaver extends Saver {
 			final ExperimentModel experiment = new ExperimentModel();
 			experiment.setNdExperimentId(experimentId);
 			phenotype.setExperiment(experiment);
-			final int val = this.getPhenotypeDao().updatePhenotypesByExperimentIdAndObervableId(experimentId, phenotype.getObservableId(), phenotype.getValue());
-			if(val == 0) {
-				this.getPhenotypeDao().save(phenotype);
-			}
+			this.getPhenotypeDao().merge(phenotype);
 		}
 	}
 


### PR DESCRIPTION
Hi @nahuel-soldevilla and @clarysabel 
In this PR I Revert  the commit 892ea66ed64d1597197d9fca38177312785518c9 because broken the behavior to remove the highlight. This change was applied by [BMS-5177](https://leafnode.atlassian.net/browse/BMS-5177).

Please, Review
Regards, Diego