### PR TITLE
IBP-3247 IBP-3244 fix workbook parse infinite loop

### DIFF
--- a/src/main/java/org/generationcp/middleware/operation/parser/WorkbookParser.java
+++ b/src/main/java/org/generationcp/middleware/operation/parser/WorkbookParser.java
@@ -751,6 +751,9 @@ public class WorkbookParser {
 
 	private void incrementDescriptionSheetRowIndex(final Workbook workbook) {
 		while (WorkbookParser.rowIsEmpty(workbook, WorkbookParser.DESCRIPTION_SHEET, this.rowIndex, NUMBER_OF_COLUMNS)) {
+			if (this.rowIndex >= this.getLastRowNumber(workbook, WorkbookParser.DESCRIPTION_SHEET)) {
+				break;
+			}
 			this.rowIndex++;
 		}
 	}

--- a/src/main/java/org/generationcp/middleware/operation/parser/WorkbookParser.java
+++ b/src/main/java/org/generationcp/middleware/operation/parser/WorkbookParser.java
@@ -765,7 +765,6 @@ public class WorkbookParser {
 			if (value != null && !"".equals(value)) {
 				return false;
 			}
-			col++;
 		}
 		return true;
 	}


### PR DESCRIPTION
I'm not sure why the extra `col++` was there in https://github.com/IntegratedBreedingPlatform/Workbench/commit/cb35c7de98bb609f73755a9889d61360b39bc0ca#diff-4e08472cc8c6b075252ffd97a0b97eaeR288, maybe it was a while loop at some point?
In other (similar) legacy code is not there: https://github.com/menghuinantang/Fieldbook/blob/cc26ea7c8629265ac51be79ca1eb4d0d96f2d83f/src/main/java/com/efficio/fieldbook/web/nursery/service/impl/ImportGermplasmFileServiceImpl.java#L611