### PR TITLE
IBP-3706 IBP-3665 Fix performance of lot label printing

### DIFF
--- a/src/main/java/org/generationcp/middleware/service/api/inventory/LotService.java
+++ b/src/main/java/org/generationcp/middleware/service/api/inventory/LotService.java
@@ -7,16 +7,22 @@ import org.generationcp.middleware.domain.inventory.manager.LotItemDto;
 import org.generationcp.middleware.domain.inventory.manager.LotUpdateRequestDto;
 import org.generationcp.middleware.domain.inventory.manager.LotSearchMetadata;
 import org.generationcp.middleware.domain.inventory.manager.LotsSearchDto;
+import org.generationcp.middleware.pojos.UserDefinedField;
 import org.generationcp.middleware.pojos.workbench.CropType;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
 
 public interface LotService {
 
 	List<ExtendedLotDto> searchLots(LotsSearchDto lotsSearchDto, Pageable pageable);
 
 	long countSearchLots(LotsSearchDto lotsSearchDto);
+
+	List<UserDefinedField> getGermplasmAttributeTypes(LotsSearchDto searchDto);
+
+	Map<Integer, Map<Integer, String>> getGermplasmAttributeValues(LotsSearchDto searchDto);
 
 	Integer saveLot(CropType cropType, Integer userId, LotGeneratorInputDto lotDto);
 

--- a/src/main/java/org/generationcp/middleware/service/impl/inventory/LotServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/service/impl/inventory/LotServiceImpl.java
@@ -19,6 +19,7 @@ import org.generationcp.middleware.manager.api.InventoryDataManager;
 import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
 import org.generationcp.middleware.manager.ontology.daoElements.VariableFilter;
 import org.generationcp.middleware.pojos.Location;
+import org.generationcp.middleware.pojos.UserDefinedField;
 import org.generationcp.middleware.pojos.ims.Lot;
 import org.generationcp.middleware.pojos.ims.Transaction;
 import org.generationcp.middleware.pojos.ims.TransactionStatus;
@@ -71,6 +72,16 @@ public class LotServiceImpl implements LotService {
 	@Override
 	public long countSearchLots(final LotsSearchDto lotsSearchDto) {
 		return this.daoFactory.getLotDao().countSearchLots(lotsSearchDto);
+	}
+
+	@Override
+	public List<UserDefinedField> getGermplasmAttributeTypes(final LotsSearchDto searchDto) {
+		return this.daoFactory.getLotDao().getGermplasmAttributeTypes(searchDto);
+	}
+
+	@Override
+	public Map<Integer, Map<Integer, String>> getGermplasmAttributeValues(final LotsSearchDto searchDto) {
+		return this.daoFactory.getLotDao().getGermplasmAttributeValues(searchDto);
 	}
 
 	@Override


### PR DESCRIPTION
- Previous approach won't scale for a large list of gids
- Instead of sending list of gids as parameter, take advantage of lot
query and lotSearch filters.
- Middleware: Wrap lot search query and join atributs by gid
in a new query

New approach can export ~ 100.000 rows in ~ 20s
For excel export this will result in an error because it can only handle
65535 rows.