### PR TITLE
IBP-3760 enable the use lot UUID to external clients

### DIFF
--- a/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
@@ -476,12 +476,18 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 				query.append("and lot.lotid IN (").append(Joiner.on(",").join(lotsSearchDto.getLotIds())).append(") ");
 			}
 
+			if (lotsSearchDto.getLotUUIds() != null && !lotsSearchDto.getLotUUIds().isEmpty()) {
+				query.append("and lot.lot_uuid IN ('").append(Joiner.on("','").join(lotsSearchDto.getLotUUIds().toArray())).append("') ");
+			}
+
 			if (lotsSearchDto.getGids() != null && !lotsSearchDto.getGids().isEmpty()) {
-				query.append("and lot.eid IN (").append(Joiner.on(",").join(lotsSearchDto.getGids())).append(") and lot.etype = 'GERMPLSM' ");
+				query.append("and lot.eid IN (").append(Joiner.on(",").join(lotsSearchDto.getGids()))
+					.append(") and lot.etype = 'GERMPLSM' ");
 			}
 
 			if (lotsSearchDto.getMgids() != null && !lotsSearchDto.getMgids().isEmpty()) {
-				query.append("and g.mgid IN (").append(Joiner.on(",").join(lotsSearchDto.getMgids())).append(") and lot.etype = 'GERMPLSM' ");
+				query.append("and g.mgid IN (").append(Joiner.on(",").join(lotsSearchDto.getMgids()))
+					.append(") and lot.etype = 'GERMPLSM' ");
 			}
 
 			if (lotsSearchDto.getLocationIds() != null && !lotsSearchDto.getLocationIds().isEmpty()) {

--- a/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
@@ -476,8 +476,8 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 				query.append("and lot.lotid IN (").append(Joiner.on(",").join(lotsSearchDto.getLotIds())).append(") ");
 			}
 
-			if (lotsSearchDto.getLotUUIds() != null && !lotsSearchDto.getLotUUIds().isEmpty()) {
-				query.append("and lot.lot_uuid IN ('").append(Joiner.on("','").join(lotsSearchDto.getLotUUIds().toArray())).append("') ");
+			if (lotsSearchDto.getLotUUIDs() != null && !lotsSearchDto.getLotUUIDs().isEmpty()) {
+				query.append("and lot.lot_uuid IN ('").append(Joiner.on("','").join(lotsSearchDto.getLotUUIDs().toArray())).append("') ");
 			}
 
 			if (lotsSearchDto.getGids() != null && !lotsSearchDto.getGids().isEmpty()) {

--- a/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
@@ -448,6 +448,11 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 				query.append(" and lot.lotid IN (").append(Joiner.on(",").join(transactionsSearchDto.getLotIds())).append(") ");
 			}
 
+			if (transactionsSearchDto.getLotUUIDs() != null && !transactionsSearchDto.getLotUUIDs().isEmpty()) {
+				query.append("and lot.lot_uuid IN ('").append(Joiner.on("','").join(transactionsSearchDto.getLotUUIDs().toArray()))
+					.append("') ");
+			}
+
 			if (transactionsSearchDto.getTransactionIds() != null && !transactionsSearchDto.getTransactionIds().isEmpty()) {
 				query.append(" and trnid IN (").append(Joiner.on(",").join(transactionsSearchDto.getTransactionIds())).append(") ");
 			}

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotDepositRequestDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotDepositRequestDto.java
@@ -9,17 +9,17 @@ import java.util.Map;
 @AutoProperty
 public class LotDepositRequestDto {
 
-	private SearchCompositeDto<Integer, Integer> selectedLots;
+	private SearchCompositeDto<Integer, String> selectedLots;
 
 	private Map<String, Double> depositsPerUnit;
 
 	private String notes;
 
-	public SearchCompositeDto<Integer, Integer> getSelectedLots() {
+	public SearchCompositeDto<Integer, String> getSelectedLots() {
 		return selectedLots;
 	}
 
-	public void setSelectedLots(final SearchCompositeDto<Integer, Integer> selectedLots) {
+	public void setSelectedLots(final SearchCompositeDto<Integer, String> selectedLots) {
 		this.selectedLots = selectedLots;
 	}
 

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotUpdateRequestDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotUpdateRequestDto.java
@@ -11,7 +11,7 @@ public class LotUpdateRequestDto {
 	private Integer locationId;
 	private Integer unitId;
 	private String notes;
-	private SearchCompositeDto<Integer, Integer> searchComposite;
+	private SearchCompositeDto<Integer, String> searchComposite;
 
 	public Integer getGid() {
 		return gid;
@@ -45,11 +45,11 @@ public class LotUpdateRequestDto {
 		this.notes = notes;
 	}
 
-	public SearchCompositeDto<Integer, Integer> getSearchComposite() {
+	public SearchCompositeDto<Integer, String> getSearchComposite() {
 		return searchComposite;
 	}
 
-	public void setSearchComposite(final SearchCompositeDto<Integer, Integer> searchComposite) {
+	public void setSearchComposite(final SearchCompositeDto<Integer, String> searchComposite) {
 		this.searchComposite = searchComposite;
 	}
 

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotWithdrawalInputDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotWithdrawalInputDto.java
@@ -60,7 +60,7 @@ public class LotWithdrawalInputDto {
 	}
 
 
-	private SearchCompositeDto<Integer, Integer> selectedLots;
+	private SearchCompositeDto<Integer, String> selectedLots;
 
 	private Map<String, WithdrawalAmountInstruction> withdrawalsPerUnit;
 
@@ -82,11 +82,11 @@ public class LotWithdrawalInputDto {
 		this.notes = notes;
 	}
 
-	public SearchCompositeDto<Integer, Integer> getSelectedLots() {
+	public SearchCompositeDto<Integer, String> getSelectedLots() {
 		return selectedLots;
 	}
 
-	public void setSelectedLots(final SearchCompositeDto<Integer, Integer> selectedLots) {
+	public void setSelectedLots(final SearchCompositeDto<Integer, String> selectedLots) {
 		this.selectedLots = selectedLots;
 	}
 

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotsSearchDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotsSearchDto.java
@@ -17,6 +17,8 @@ public class LotsSearchDto extends SearchRequestDto {
 
 	private List<Integer> lotIds;
 
+	private List<String> lotUUIds;
+
 	private String stockId;
 
 	private List<Integer> gids;
@@ -89,6 +91,14 @@ public class LotsSearchDto extends SearchRequestDto {
 
 	public void setLotIds(final List<Integer> lotIds) {
 		this.lotIds = lotIds;
+	}
+
+	public List<String> getLotUUIds() {
+		return lotUUIds;
+	}
+
+	public void setLotUUIds(final List<String> lotUUIds) {
+		this.lotUUIds = lotUUIds;
 	}
 
 	public String getStockId() {

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotsSearchDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotsSearchDto.java
@@ -17,7 +17,7 @@ public class LotsSearchDto extends SearchRequestDto {
 
 	private List<Integer> lotIds;
 
-	private List<String> lotUUIds;
+	private List<String> lotUUIDs;
 
 	private String stockId;
 
@@ -93,12 +93,12 @@ public class LotsSearchDto extends SearchRequestDto {
 		this.lotIds = lotIds;
 	}
 
-	public List<String> getLotUUIds() {
-		return lotUUIds;
+	public List<String> getLotUUIDs() {
+		return lotUUIDs;
 	}
 
-	public void setLotUUIds(final List<String> lotUUIds) {
-		this.lotUUIds = lotUUIds;
+	public void setLotUUIDs(final List<String> lotUUIDs) {
+		this.lotUUIDs = lotUUIDs;
 	}
 
 	public String getStockId() {

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/TransactionsSearchDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/TransactionsSearchDto.java
@@ -21,6 +21,7 @@ public class TransactionsSearchDto extends SearchRequestDto {
 	private List<Integer> transactionStatus;
 	private String notes;
 	private List<Integer> lotIds;
+	private List<String> lotUUIDs;
 	private List<Integer> gids;
 	private List<Integer> unitIds;
 	private Double minAmount;
@@ -172,6 +173,14 @@ public class TransactionsSearchDto extends SearchRequestDto {
 
 	public void setTransactionStatus(final List<Integer> transactionStatus) {
 		this.transactionStatus = transactionStatus;
+	}
+
+	public List<String> getLotUUIDs() {
+		return lotUUIDs;
+	}
+
+	public void setLotUUIDs(final List<String> lotUUIDs) {
+		this.lotUUIDs = lotUUIDs;
 	}
 
 	@Override

--- a/src/main/java/org/generationcp/middleware/service/api/inventory/LotService.java
+++ b/src/main/java/org/generationcp/middleware/service/api/inventory/LotService.java
@@ -24,7 +24,7 @@ public interface LotService {
 
 	Map<Integer, Map<Integer, String>> getGermplasmAttributeValues(LotsSearchDto searchDto);
 
-	Integer saveLot(CropType cropType, Integer userId, LotGeneratorInputDto lotDto);
+	String saveLot(CropType cropType, Integer userId, LotGeneratorInputDto lotDto);
 
 	void updateLots(List<ExtendedLotDto> lotDtos, LotUpdateRequestDto lotRequest);
 

--- a/src/main/java/org/generationcp/middleware/service/impl/inventory/LotServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/service/impl/inventory/LotServiceImpl.java
@@ -93,7 +93,7 @@ public class LotServiceImpl implements LotService {
 	}
 
 	@Override
-	public Integer saveLot(final CropType cropType, final Integer userId, final LotGeneratorInputDto lotDto) {
+	public String saveLot(final CropType cropType, final Integer userId, final LotGeneratorInputDto lotDto) {
 
 		final Lot lot = new Lot();
 		lot.setUserId(userId);
@@ -110,7 +110,7 @@ public class LotServiceImpl implements LotService {
 		this.inventoryDataManager.generateLotIds(cropType, Lists.newArrayList(lot));
 		this.daoFactory.getLotDao().save(lot);
 
-		return lot.getId();
+		return lot.getLotUuId();
 	}
 
 	@Override


### PR DESCRIPTION

- Adding Filter query by LotUUID in TransactionDAO.
- Adding Filter query by LotUUID in LotDAO.
- Replacing the using lotId and use the lotUUID instead.

Includes:
https://github.com/IntegratedBreedingPlatform/InventoryManager/pull/49
https://github.com/IntegratedBreedingPlatform/BMSAPI/pull/348

Please, Review