### PR TITLE
IBP-3802-SetObservationVariableId

### DIFF
--- a/src/main/java/org/generationcp/middleware/dao/dms/PhenotypeDao.java
+++ b/src/main/java/org/generationcp/middleware/dao/dms/PhenotypeDao.java
@@ -1016,9 +1016,8 @@ public class PhenotypeDao extends GenericDAO<Phenotype, Integer> {
 				final Integer ndExperimentId = (Integer) result[0];
 
 				final PhenotypeSearchObservationDTO observation = new PhenotypeSearchObservationDTO();
-				final String variableId =
-					(result[5] != null && !((String) result[5]).isEmpty()) ? (String) result[5] : String.valueOf(result[2]);
-				observation.setObservationVariableDbId(variableId);
+
+				observation.setObservationVariableDbId(String.valueOf(result[2]));
 				observation.setObservationVariableName((String) result[3]);
 				observation.setObservationDbId(String.valueOf((Integer) result[1]));
 				observation.setValue((String) result[4]);

--- a/src/main/java/org/generationcp/middleware/dao/dms/PhenotypeDao.java
+++ b/src/main/java/org/generationcp/middleware/dao/dms/PhenotypeDao.java
@@ -142,9 +142,9 @@ public class PhenotypeDao extends GenericDAO<Phenotype, Integer> {
 
 				for (final Object[] row : list) {
 					final Integer id = (Integer) row[0];
-					final Long locationCount = ((BigInteger) row[1]).longValue();
-					final Long germplasmCount = ((BigInteger) row[2]).longValue();
-					final Long observationCount = ((BigInteger) row[3]).longValue();
+					final long locationCount = ((BigInteger) row[1]).longValue();
+					final long germplasmCount = ((BigInteger) row[2]).longValue();
+					final long observationCount = ((BigInteger) row[3]).longValue();
 					final Double minValue = (Double) row[4];
 					final Double maxValue = (Double) row[5];
 
@@ -399,11 +399,11 @@ public class PhenotypeDao extends GenericDAO<Phenotype, Integer> {
 			for (final Object[] row : list) {
 				final Integer traitId = (Integer) row[0];
 				final Integer cValueId = (Integer) row[1];
-				final Long count = ((BigInteger) row[2]).longValue();
+				final long count = ((BigInteger) row[2]).longValue();
 
 				for (final CategoricalTraitInfo traitInfo : traitInfoList) {
 					if (traitInfo.getId() == traitId) {
-						traitInfo.addValueCount(new CategoricalValue(cValueId), count.longValue());
+						traitInfo.addValueCount(new CategoricalValue(cValueId), count);
 						break;
 					}
 				}

--- a/src/test/java/org/generationcp/middleware/dao/dms/PhenotypeDaoIntegrationTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/dms/PhenotypeDaoIntegrationTest.java
@@ -17,6 +17,7 @@ import org.generationcp.middleware.IntegrationTestBase;
 import org.generationcp.middleware.dao.GermplasmDAO;
 import org.generationcp.middleware.dao.ProjectDAO;
 import org.generationcp.middleware.dao.oms.CVTermDao;
+import org.generationcp.middleware.dao.oms.CvTermPropertyDao;
 import org.generationcp.middleware.data.initializer.CVTermTestDataInitializer;
 import org.generationcp.middleware.data.initializer.DMSVariableTestDataInitializer;
 import org.generationcp.middleware.data.initializer.GermplasmTestDataInitializer;
@@ -42,6 +43,7 @@ import org.generationcp.middleware.pojos.dms.Phenotype;
 import org.generationcp.middleware.pojos.dms.ProjectProperty;
 import org.generationcp.middleware.pojos.dms.StockModel;
 import org.generationcp.middleware.pojos.oms.CVTerm;
+import org.generationcp.middleware.pojos.oms.CVTermProperty;
 import org.generationcp.middleware.pojos.workbench.CropType;
 import org.generationcp.middleware.pojos.workbench.Project;
 import org.generationcp.middleware.service.api.phenotype.PhenotypeSearchDTO;
@@ -84,6 +86,7 @@ public class PhenotypeDaoIntegrationTest extends IntegrationTestBase {
 	private CVTermDao cvTermDao;
 	private ProjectPropertyDao projectPropertyDao;
 	private ProjectDAO workbenchProjectDao;
+	private CvTermPropertyDao cvTermPropertyDao;
 
 	private DmsProject study;
 	private CVTerm trait;
@@ -133,6 +136,11 @@ public class PhenotypeDaoIntegrationTest extends IntegrationTestBase {
 		if (this.cvTermDao == null) {
 			this.cvTermDao = new CVTermDao();
 			this.cvTermDao.setSession(this.sessionProvder.getSession());
+		}
+
+		if(this.cvTermPropertyDao == null) {
+			this.cvTermPropertyDao = new CvTermPropertyDao();
+			this.cvTermPropertyDao.setSession(this.sessionProvder.getSession());
 		}
 
 		if (this.projectPropertyDao == null) {
@@ -365,6 +373,16 @@ public class PhenotypeDaoIntegrationTest extends IntegrationTestBase {
 				this.study, this.study);
 		final CVTerm trait2 = CVTermTestDataInitializer.createTerm(RandomStringUtils.randomAlphanumeric(50), CvId.VARIABLES.getId());
 		this.cvTermDao.save(trait2);
+
+		//Create cvTermproperty for trait 2
+		final CVTermProperty cvTermProperty = new CVTermProperty();
+		cvTermProperty.setCvTermPropertyId(1);
+		cvTermProperty.setCvTermId(trait2.getCvTermId());
+		cvTermProperty.setTypeId(TermId.CROP_ONTOLOGY_ID.getId());
+		cvTermProperty.setRank(1);
+		cvTermProperty.setValue("CO:1200");
+		this.cvTermPropertyDao.save(cvTermProperty);
+
 		final List<Integer> traitIds = Arrays.asList(this.trait.getCvTermId(), trait2.getCvTermId());
 		this.createProjectProperties(plot, traitIds);
 		final Integer environment1 = this.createEnvironmentData(plot, 1, traitIds, true);


### PR DESCRIPTION
Remove checking if cvtermprop.value is empty condition 
Use cvterm_id as observationVariableId 
Modify Existing unit test: add cvtermprop value 
