### PR TITLE
IBP-3847-UseCategoricalValue

### DIFF
--- a/src/main/java/org/generationcp/middleware/dao/dms/ProjectPropertyDao.java
+++ b/src/main/java/org/generationcp/middleware/dao/dms/ProjectPropertyDao.java
@@ -245,7 +245,7 @@ public class ProjectPropertyDao extends GenericDAO<ProjectProperty, Integer> {
 			+ " pp.project_id = :studyId "
 			+ " AND pp.variable_id NOT IN (:excludedIds) "
 				//Exclude Variables with scale PersonId (1901)
-			+ " AND scale.object_id != 1901 ";
+			+ " AND scale.object_id != " + TermId.PERSON_ID.getId();
 
 		try {
 			final Query query =

--- a/src/main/java/org/generationcp/middleware/dao/dms/ProjectPropertyDao.java
+++ b/src/main/java/org/generationcp/middleware/dao/dms/ProjectPropertyDao.java
@@ -231,11 +231,20 @@ public class ProjectPropertyDao extends GenericDAO<ProjectProperty, Integer> {
 		excludedIds.add(TermId.SEASON_VAR.getId());
 		excludedIds.add(TermId.LOCATION_ID.getId());
 		final String sql = " SELECT  "
-			+ "     cvterm.definition AS name, pp.value AS value "
+			+ "     cvterm.definition AS name,"
+			+ "		(CASE WHEN category.object_id = " + TermId.CATEGORICAL_VARIABLE.getId()
+			+ "			THEN (SELECT incvterm.definition FROM cvterm incvterm WHERE incvterm.cvterm_id = pp.value) "
+			+ "			ELSE pp.value "
+			+ "		END) value "
 			+ " FROM "
 			+ "     projectprop pp "
 			+ "         INNER JOIN "
 			+ "     cvterm cvterm ON cvterm.cvterm_id = pp.variable_id "
+			+ "			LEFT JOIN "
+			+ "			(SELECT scale.object_id as object_id, relation.subject_id as subject_id FROM cvterm_relationship relation "
+			+ "				INNER JOIN cvterm_relationship scale ON scale.subject_id = relation.object_id AND scale.type_id = " + TermId.HAS_TYPE.getId()
+			+ "			 WHERE relation.type_id = " + TermId.HAS_SCALE.getId()
+			+ "			) category ON category.subject_id = pp.variable_id"
 			+ " WHERE "
 			+ "     pp.project_id = :studyId "
 			+ "         AND pp.variable_id NOT IN (:excludedIds) "

--- a/src/main/java/org/generationcp/middleware/dao/dms/ProjectPropertyDao.java
+++ b/src/main/java/org/generationcp/middleware/dao/dms/ProjectPropertyDao.java
@@ -230,22 +230,21 @@ public class ProjectPropertyDao extends GenericDAO<ProjectProperty, Integer> {
 		final List<Integer> excludedIds = new ArrayList<>(excludedVariableIds);
 		excludedIds.add(TermId.SEASON_VAR.getId());
 		excludedIds.add(TermId.LOCATION_ID.getId());
-		final String sql = " SELECT  "
+		final String sql =
+			"	SELECT  "
 			+ "     cvterm.definition AS name,"
 			+ "		(CASE WHEN scale_type.object_id = " + TermId.CATEGORICAL_VARIABLE.getId()
-			+ "			THEN (SELECT incvterm.definition FROM cvterm incvterm WHERE incvterm.cvterm_id = pp.value) "
-			+ "			ELSE pp.value "
+			+ "		THEN (SELECT incvterm.definition FROM cvterm incvterm WHERE incvterm.cvterm_id = pp.value) "
+			+ "		ELSE pp.value "
 			+ "		END) value "
-			+ " FROM "
-			+ "     projectprop pp "
-			+ "         INNER JOIN "
-			+ "     cvterm cvterm ON cvterm.cvterm_id = pp.variable_id "
+			+ " FROM projectprop pp "
+			+ " INNER JOIN cvterm cvterm ON cvterm.cvterm_id = pp.variable_id "
 			+ " INNER JOIN cvterm_relationship scale ON scale.subject_id = pp.variable_id AND scale.type_id = " + TermId.HAS_SCALE.getId()
 			+ " INNER JOIN cvterm_relationship scale_type ON scale_type.subject_id = scale.object_id AND scale_type.type_id = " + TermId.HAS_TYPE.getId()
 			+ " WHERE "
-			+ "     pp.project_id = :studyId "
-			+ "         AND pp.variable_id NOT IN (:excludedIds) "
-			//Exclude Variables with scale PersonId (1901)
+			+ " pp.project_id = :studyId "
+			+ " AND pp.variable_id NOT IN (:excludedIds) "
+				//Exclude Variables with scale PersonId (1901)
 			+ " AND scale.object_id != 1901 ";
 
 		try {

--- a/src/main/java/org/generationcp/middleware/domain/oms/TermId.java
+++ b/src/main/java/org/generationcp/middleware/domain/oms/TermId.java
@@ -164,6 +164,8 @@ public enum TermId {
 	//TODO : Should find a way not to hard code
 	, PROJECT_PREFIX(3001)
 	, HABITAT_DESIGNATION(3002)
+
+	, PERSON_ID(1901)
 	;
 
 	private final int id;

--- a/src/test/java/org/generationcp/middleware/dao/dms/ProjectPropertyDaoTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/dms/ProjectPropertyDaoTest.java
@@ -404,7 +404,7 @@ public class ProjectPropertyDaoTest extends IntegrationTestBase {
 
 		final CVTermRelationship personIdRelationship = new CVTermRelationship();
 		personIdRelationship.setSubjectId(personId.getCvTermId());
-		personIdRelationship.setObjectId(1901);
+		personIdRelationship.setObjectId(TermId.PERSON_ID.getId());
 		personIdRelationship.setTypeId(TermId.HAS_SCALE.getId());
 		this.cvTermRelationshipDao.save(personIdRelationship);
 
@@ -464,7 +464,7 @@ public class ProjectPropertyDaoTest extends IntegrationTestBase {
 
 		final CVTermRelationship personIdRelationship = new CVTermRelationship();
 		personIdRelationship.setSubjectId(personId.getCvTermId());
-		personIdRelationship.setObjectId(1901);
+		personIdRelationship.setObjectId(TermId.PERSON_ID.getId());
 		personIdRelationship.setTypeId(TermId.HAS_SCALE.getId());
 		this.cvTermRelationshipDao.save(personIdRelationship);
 

--- a/src/test/java/org/generationcp/middleware/dao/dms/ProjectPropertyDaoTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/dms/ProjectPropertyDaoTest.java
@@ -15,6 +15,7 @@ import org.generationcp.middleware.DataSetupTest;
 import org.generationcp.middleware.GermplasmTestDataGenerator;
 import org.generationcp.middleware.IntegrationTestBase;
 import org.generationcp.middleware.dao.oms.CVTermDao;
+import org.generationcp.middleware.dao.oms.CVTermRelationshipDao;
 import org.generationcp.middleware.data.initializer.CVTermTestDataInitializer;
 import org.generationcp.middleware.domain.oms.CvId;
 import org.generationcp.middleware.domain.oms.TermId;
@@ -28,6 +29,7 @@ import org.generationcp.middleware.pojos.dms.DatasetType;
 import org.generationcp.middleware.pojos.dms.DmsProject;
 import org.generationcp.middleware.pojos.dms.ProjectProperty;
 import org.generationcp.middleware.pojos.oms.CVTerm;
+import org.generationcp.middleware.pojos.oms.CVTermRelationship;
 import org.generationcp.middleware.service.api.DataImportService;
 import org.generationcp.middleware.service.api.FieldbookService;
 import org.junit.Assert;
@@ -56,6 +58,7 @@ public class ProjectPropertyDaoTest extends IntegrationTestBase {
 	private DmsProjectDao projectDao;
 	private ProjectPropertyDao projectPropDao;
 	private CVTermDao cvTermDao;
+	private CVTermRelationshipDao cvTermRelationshipDao;
 
 	private DaoFactory daoFactory;
 
@@ -100,6 +103,8 @@ public class ProjectPropertyDaoTest extends IntegrationTestBase {
 			this.projectDao.save(this.study);
 		}
 
+		this.cvTermRelationshipDao = new CVTermRelationshipDao();
+		this.cvTermRelationshipDao.setSession(this.sessionProvder.getSession());
 	}
 
 	@Test
@@ -355,6 +360,66 @@ public class ProjectPropertyDaoTest extends IntegrationTestBase {
 				parentGermplasm);
 
 		return this.dataSetupTest.createNurseryForGermplasm(programUUID, gids, cropPrefix);
+	}
+
+
+	@Test
+	public void testGetProjectPropsAndValuesByStudy() {
+		final CVTerm categoricalScale = CVTermTestDataInitializer.createTerm("Categorical Scale", CvId.SCALES.getId());
+		final CVTerm textScale = CVTermTestDataInitializer.createTerm("Text Scale", CvId.VARIABLES.getId());
+		final CVTerm variable1 = CVTermTestDataInitializer.createTerm("Categorical Option", CvId.SCALES.getId());
+		final CVTerm variable2 = CVTermTestDataInitializer.createTerm("Text Field", CvId.VARIABLES.getId());
+		final CVTerm choice1 = CVTermTestDataInitializer.createTerm("Option 1", 2030);
+		this.cvTermDao.save(categoricalScale);
+		this.cvTermDao.save(textScale);
+		this.cvTermDao.save(variable1);
+		this.cvTermDao.save(variable2);
+		this.cvTermDao.save(choice1);
+
+		final CVTermRelationship scaleRelationShip = new CVTermRelationship();
+		scaleRelationShip.setSubjectId(categoricalScale.getCvTermId());
+		scaleRelationShip.setObjectId(TermId.CATEGORICAL_VARIABLE.getId());
+		scaleRelationShip.setTypeId(TermId.HAS_TYPE.getId());
+		this.cvTermRelationshipDao.save(scaleRelationShip);
+
+		final CVTermRelationship variable1Scale = new CVTermRelationship();
+		variable1Scale.setSubjectId(variable1.getCvTermId());
+		variable1Scale.setObjectId(categoricalScale.getCvTermId());
+		variable1Scale.setTypeId(TermId.HAS_SCALE.getId());
+		this.cvTermRelationshipDao.save(variable1Scale);
+
+		final CVTermRelationship textRelationship = new CVTermRelationship();
+		textRelationship.setSubjectId(textScale.getCvTermId());
+		textRelationship.setObjectId(TermId.CHARACTER_VARIABLE.getId());
+		textRelationship.setTypeId(TermId.HAS_TYPE.getId());
+		this.cvTermRelationshipDao.save(textRelationship);
+
+		final CVTermRelationship variable2Scale = new CVTermRelationship();
+		variable2Scale.setSubjectId(variable2.getCvTermId());
+		variable2Scale.setObjectId(textScale.getCvTermId());
+		variable2Scale.setTypeId(TermId.HAS_SCALE.getId());
+		this.cvTermRelationshipDao.save(variable2Scale);
+
+		this.saveProjectVariableWithValue(this.study, variable1, 1, VariableType.STUDY_DETAIL, choice1.getCvTermId().toString());
+		this.saveProjectVariableWithValue(this.study, variable2, 2, VariableType.STUDY_DETAIL, "Mock Input Field");
+		final Integer projectId = this.study.getProjectId();
+		final Map<String, String> map = this.projectPropDao.getProjectPropsAndValuesByStudy(projectId, new ArrayList<>());
+		Assert.assertEquals(2, this.projectPropDao.getByProjectId(projectId).size());
+		Assert.assertNotNull("Study has properties ",map);
+ 		Assert.assertEquals(map.get(variable1.getDefinition()),choice1.getDefinition());
+		Assert.assertEquals(map.get(variable2.getDefinition()),"Mock Input Field");
+
+	}
+
+	private ProjectProperty saveProjectVariableWithValue(final DmsProject project, final CVTerm variable, final int rank, final VariableType variableType, final String value) {
+		final ProjectProperty property1 = new ProjectProperty();
+		property1.setAlias(RandomStringUtils.randomAlphabetic(20));
+		property1.setRank(rank);
+		property1.setTypeId(variableType.getId());
+		property1.setProject(project);
+		property1.setVariableId(variable.getCvTermId());
+		property1.setValue(value);
+		return this.projectPropDao.save(property1);
 	}
 
 }

--- a/src/test/java/org/generationcp/middleware/dao/dms/ProjectPropertyDaoTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/dms/ProjectPropertyDaoTest.java
@@ -369,12 +369,14 @@ public class ProjectPropertyDaoTest extends IntegrationTestBase {
 		final CVTerm textScale = CVTermTestDataInitializer.createTerm("Text Scale", CvId.VARIABLES.getId());
 		final CVTerm variable1 = CVTermTestDataInitializer.createTerm("Categorical Option", CvId.SCALES.getId());
 		final CVTerm variable2 = CVTermTestDataInitializer.createTerm("Text Field", CvId.VARIABLES.getId());
+		final CVTerm personId = CVTermTestDataInitializer.createTerm("PersonId", CvId.VARIABLES.getId());
 		final CVTerm choice1 = CVTermTestDataInitializer.createTerm("Option 1", 2030);
 		this.cvTermDao.save(categoricalScale);
 		this.cvTermDao.save(textScale);
 		this.cvTermDao.save(variable1);
 		this.cvTermDao.save(variable2);
 		this.cvTermDao.save(choice1);
+		this.cvTermDao.save(personId);
 
 		final CVTermRelationship scaleRelationShip = new CVTermRelationship();
 		scaleRelationShip.setSubjectId(categoricalScale.getCvTermId());
@@ -400,15 +402,90 @@ public class ProjectPropertyDaoTest extends IntegrationTestBase {
 		variable2Scale.setTypeId(TermId.HAS_SCALE.getId());
 		this.cvTermRelationshipDao.save(variable2Scale);
 
+		final CVTermRelationship personIdRelationship = new CVTermRelationship();
+		personIdRelationship.setSubjectId(personId.getCvTermId());
+		personIdRelationship.setObjectId(1901);
+		personIdRelationship.setTypeId(TermId.HAS_SCALE.getId());
+		this.cvTermRelationshipDao.save(personIdRelationship);
+
 		this.saveProjectVariableWithValue(this.study, variable1, 1, VariableType.STUDY_DETAIL, choice1.getCvTermId().toString());
 		this.saveProjectVariableWithValue(this.study, variable2, 2, VariableType.STUDY_DETAIL, "Mock Input Field");
+		this.saveProjectVariableWithValue(this.study, personId, 3, VariableType.STUDY_DETAIL, "1");
+
 		final Integer projectId = this.study.getProjectId();
 		final Map<String, String> map = this.projectPropDao.getProjectPropsAndValuesByStudy(projectId, new ArrayList<>());
-		Assert.assertEquals(2, this.projectPropDao.getByProjectId(projectId).size());
+		Assert.assertEquals(2, map.size());
 		Assert.assertNotNull("Study has properties ",map);
  		Assert.assertEquals(map.get(variable1.getDefinition()),choice1.getDefinition());
 		Assert.assertEquals(map.get(variable2.getDefinition()),"Mock Input Field");
+		Assert.assertNull("Variable PersonId excluded from the result",map.get(personId.getDefinition()));
+	}
 
+	@Test
+	public void testGetProjectPropsAndValuesByStudyWithPiName() {
+		final CVTerm categoricalScale = CVTermTestDataInitializer.createTerm("Categorical Scale", CvId.SCALES.getId());
+		final CVTerm textScale = CVTermTestDataInitializer.createTerm("Text Scale", CvId.VARIABLES.getId());
+		final CVTerm variable1 = CVTermTestDataInitializer.createTerm("Categorical Option", CvId.SCALES.getId());
+		final CVTerm variable2 = CVTermTestDataInitializer.createTerm("Text Field", CvId.VARIABLES.getId());
+		final CVTerm personId = CVTermTestDataInitializer.createTerm("PersonId", CvId.VARIABLES.getId());
+		final CVTerm personName = CVTermTestDataInitializer.createTerm("PersonName", CvId.VARIABLES.getId());
+		final CVTerm choice1 = CVTermTestDataInitializer.createTerm("Option 1", 2030);
+		this.cvTermDao.save(categoricalScale);
+		this.cvTermDao.save(textScale);
+		this.cvTermDao.save(variable1);
+		this.cvTermDao.save(variable2);
+		this.cvTermDao.save(choice1);
+		this.cvTermDao.save(personId);
+		this.cvTermDao.save(personName);
+
+		final CVTermRelationship scaleRelationShip = new CVTermRelationship();
+		scaleRelationShip.setSubjectId(categoricalScale.getCvTermId());
+		scaleRelationShip.setObjectId(TermId.CATEGORICAL_VARIABLE.getId());
+		scaleRelationShip.setTypeId(TermId.HAS_TYPE.getId());
+		this.cvTermRelationshipDao.save(scaleRelationShip);
+
+		final CVTermRelationship variable1Scale = new CVTermRelationship();
+		variable1Scale.setSubjectId(variable1.getCvTermId());
+		variable1Scale.setObjectId(categoricalScale.getCvTermId());
+		variable1Scale.setTypeId(TermId.HAS_SCALE.getId());
+		this.cvTermRelationshipDao.save(variable1Scale);
+
+		final CVTermRelationship textRelationship = new CVTermRelationship();
+		textRelationship.setSubjectId(textScale.getCvTermId());
+		textRelationship.setObjectId(TermId.CHARACTER_VARIABLE.getId());
+		textRelationship.setTypeId(TermId.HAS_TYPE.getId());
+		this.cvTermRelationshipDao.save(textRelationship);
+
+		final CVTermRelationship variable2Scale = new CVTermRelationship();
+		variable2Scale.setSubjectId(variable2.getCvTermId());
+		variable2Scale.setObjectId(textScale.getCvTermId());
+		variable2Scale.setTypeId(TermId.HAS_SCALE.getId());
+		this.cvTermRelationshipDao.save(variable2Scale);
+
+		final CVTermRelationship personIdRelationship = new CVTermRelationship();
+		personIdRelationship.setSubjectId(personId.getCvTermId());
+		personIdRelationship.setObjectId(1901);
+		personIdRelationship.setTypeId(TermId.HAS_SCALE.getId());
+		this.cvTermRelationshipDao.save(personIdRelationship);
+
+		final CVTermRelationship personNameRelationship = new CVTermRelationship();
+		personNameRelationship.setSubjectId(personName.getCvTermId());
+		personNameRelationship.setObjectId(1902);
+		personNameRelationship.setTypeId(TermId.HAS_SCALE.getId());
+		this.cvTermRelationshipDao.save(personNameRelationship);
+
+		this.saveProjectVariableWithValue(this.study, variable1, 1, VariableType.STUDY_DETAIL, choice1.getCvTermId().toString());
+		this.saveProjectVariableWithValue(this.study, variable2, 2, VariableType.STUDY_DETAIL, "Mock Input Field");
+		this.saveProjectVariableWithValue(this.study, personId, 3, VariableType.STUDY_DETAIL, "1");
+		this.saveProjectVariableWithValue(this.study, personName, 4, VariableType.STUDY_DETAIL, "Person Name 1");
+		final Integer projectId = this.study.getProjectId();
+		final Map<String, String> map = this.projectPropDao.getProjectPropsAndValuesByStudy(projectId, new ArrayList<>());
+		Assert.assertEquals(3, map.size());
+		Assert.assertNotNull("Study has properties ",map);
+		Assert.assertEquals(map.get(variable1.getDefinition()),choice1.getDefinition());
+		Assert.assertEquals(map.get(variable2.getDefinition()),"Mock Input Field");
+		Assert.assertEquals(map.get(personName.getDefinition()),"Person Name 1");
+		Assert.assertNull("Variable PersonId excluded from the result",map.get(personId.getDefinition()));
 	}
 
 	private ProjectProperty saveProjectVariableWithValue(final DmsProject project, final CVTerm variable, final int rank, final VariableType variableType, final String value) {

--- a/src/test/java/org/generationcp/middleware/dao/dms/ProjectPropertyDaoTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/dms/ProjectPropertyDaoTest.java
@@ -243,7 +243,7 @@ public class ProjectPropertyDaoTest extends IntegrationTestBase {
 		final CVTerm variable1 = CVTermTestDataInitializer.createTerm(RandomStringUtils.randomAlphanumeric(50), CvId.VARIABLES.getId());
 		this.cvTermDao.save(variable1);
 		final ProjectProperty projectProperty = this.saveProjectVariable(plotDataset, variable1, 1, VariableType.TRAIT);
-		final List<ProjectProperty> projectProperties = this.projectPropDao.getByStudyAndStandardVariableIds(study.getProjectId(), Arrays.asList(variable1.getCvTermId()));
+		final List<ProjectProperty> projectProperties = this.projectPropDao.getByStudyAndStandardVariableIds(this.study.getProjectId(), Arrays.asList(variable1.getCvTermId()));
 		Assert.assertTrue(projectProperties.contains(projectProperty));
 	}
 


### PR DESCRIPTION
Modify script when retrieving property name and value when using the api
/{crop}​/brapi​/v1​/studies​/{studyDbId}
/{crop}/brapi/v2/studies/{studyDbId}
When creating study, the cvterm_id of the selected possible value of categorical variable is being saved as value projectproperty table, to retrieve the actual value (definition), added a join for the cvterm_relationship
Added unit test for categorical variable