### PR TITLE
IBP-3806 inventory manager study filter

### DIFF
--- a/src/main/java/org/generationcp/middleware/dao/dms/DmsProjectDao.java
+++ b/src/main/java/org/generationcp/middleware/dao/dms/DmsProjectDao.java
@@ -129,7 +129,7 @@ public class DmsProjectDao extends GenericDAO<DmsProject, Integer> {
 			+ " WHERE subject.parent_project_id = :folderId "
 			+ "   AND parent.study_type_id IS NULL "
 			+ "   AND subject.deleted != " + DELETED_STUDY
-			+ "   AND (subject.program_uuid = :program_uuid OR subject.program_uuid IS NULL) "
+			+ "   AND (:program_uuid IS NULL OR subject.program_uuid = :program_uuid OR subject.program_uuid IS NULL) "
 			+ "   AND (:studyTypeId is null or subject.study_type_id = :studyTypeId or subject.study_type_id is null)"
 			// the OR here for value = null is required for folders.
 			+ "	ORDER BY name";

--- a/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
@@ -680,6 +680,19 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 					+ " AND transaction.trnqty < 0 THEN transaction.trndate ELSE null END)) <= :lastWithdrawalDateTo");
 				paramBuilder.setParameter("lastWithdrawalDateTo", DATE_FORMAT.format(lastWithdrawalDateTo));
 			}
+
+			final List<Integer> plantingStudyIds = lotsSearchDto.getPlantingStudyIds();
+			if (plantingStudyIds != null && !plantingStudyIds.isEmpty()) {
+				paramBuilder.append(" and exists(select 1 \n" //
+					+ " from project study_filter_p \n" //
+					+ "	    inner join project study_filter_plotdata on study_filter_p.project_id = study_filter_plotdata.study_id \n" //
+					+ "     inner join nd_experiment study_filter_nde on study_filter_plotdata.project_id = study_filter_nde.project_id \n"
+					+ "     inner join ims_experiment_transaction study_filter_iet on study_filter_nde.nd_experiment_id = study_filter_iet.nd_experiment_id \n"
+					+ "     inner join ims_transaction study_filter_transaction on study_filter_iet.trnid = study_filter_transaction.trnid \n"
+					+ "     inner join ims_lot study_filter_lot on study_filter_transaction.lotid = study_filter_lot.lotid \n" //
+					+ " where study_filter_p.project_id in (:plantingStudyIds) and study_filter_lot.lotid = lot.lotid)"); //
+				paramBuilder.setParameterList("plantingStudyIds", plantingStudyIds);
+			}
 		}
 	}
 

--- a/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
@@ -643,6 +643,17 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 					+ " and lot.etype = 'GERMPLSM' ");
 				paramBuilder.setParameterList("germplasmListIds", germplasmListIds);
 			}
+
+			final List<Integer> plantingStudyIds = transactionsSearchDto.getPlantingStudyIds();
+			if (plantingStudyIds != null && !plantingStudyIds.isEmpty()) {
+				paramBuilder.append(" and exists(select 1 \n" //
+					+ " from project study_filter_p \n" //
+					+ "	    inner join project study_filter_plotdata on study_filter_p.project_id = study_filter_plotdata.study_id \n" //
+					+ "     inner join nd_experiment study_filter_nde on study_filter_plotdata.project_id = study_filter_nde.project_id \n"
+					+ "     inner join ims_experiment_transaction study_filter_iet on study_filter_nde.nd_experiment_id = study_filter_iet.nd_experiment_id \n"
+					+ " where study_filter_p.project_id in (:plantingStudyIds) and study_filter_iet.trnid = tr.trnid)"); //
+				paramBuilder.setParameterList("plantingStudyIds", plantingStudyIds);
+			}
 		}
 	}
 

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotsSearchDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotsSearchDto.java
@@ -55,6 +55,8 @@ public class LotsSearchDto extends SearchRequestDto {
 
 	private List<Integer> germplasmListIds;
 
+	private List<Integer> plantingStudyIds;
+
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
 	private Date createdDateFrom;
 
@@ -283,6 +285,14 @@ public class LotsSearchDto extends SearchRequestDto {
 
 	public void setGermplasmListIds(final List<Integer> germplasmListIds) {
 		this.germplasmListIds = germplasmListIds;
+	}
+
+	public List<Integer> getPlantingStudyIds() {
+		return this.plantingStudyIds;
+	}
+
+	public void setPlantingStudyIds(final List<Integer> plantingStudyIds) {
+		this.plantingStudyIds = plantingStudyIds;
 	}
 
 	public String getLocationNameContainsString() {

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/TransactionsSearchDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/TransactionsSearchDto.java
@@ -35,10 +35,9 @@ public class TransactionsSearchDto extends SearchRequestDto {
 	private Date createdDateTo;
 
 	private List<Integer> statusIds;
-
 	private Integer lotStatus;
-
 	private List<Integer> germplasmListIds;
+	private List<Integer> plantingStudyIds;
 
 	public List<Integer> getGermplasmListIds() {
 		return germplasmListIds;
@@ -46,6 +45,14 @@ public class TransactionsSearchDto extends SearchRequestDto {
 
 	public void setGermplasmListIds(final List<Integer> germplasmListIds) {
 		this.germplasmListIds = germplasmListIds;
+	}
+
+	public List<Integer> getPlantingStudyIds() {
+		return this.plantingStudyIds;
+	}
+
+	public void setPlantingStudyIds(final List<Integer> plantingStudyIds) {
+		this.plantingStudyIds = plantingStudyIds;
 	}
 
 	public String getDesignation() {

--- a/src/main/java/org/generationcp/middleware/pojos/workbench/PermissionsEnum.java
+++ b/src/main/java/org/generationcp/middleware/pojos/workbench/PermissionsEnum.java
@@ -27,6 +27,14 @@ public enum PermissionsEnum {
 	MANAGE_LOTS,
 	LOT_LABEL_PRINTING;
 
+	public static final String HAS_INVENTORY_VIEW = " or hasAnyAuthority('ADMIN'"
+		+ ",'CROP_MANAGEMENT'"
+		+ ",'MANAGE_INVENTORY'"
+		+ ",'MANAGE_LOTS'"
+		+ ",'MANAGE_TRANSACTIONS'"
+		+ ",'VIEW_LOTS'"
+		+ ",'VIEW_TRANSACTIONS')";
+
 	public static final String HAS_PREPARE_PLANTING = " or hasAnyAuthority('ADMIN'"
 		+ ", 'BREEDING_ACTIVITIES'"
 		+ ", 'MANAGE_STUDIES'"

--- a/src/test/java/org/generationcp/middleware/service/impl/inventory/PlantingServiceImplIntegrationTest.java
+++ b/src/test/java/org/generationcp/middleware/service/impl/inventory/PlantingServiceImplIntegrationTest.java
@@ -5,8 +5,14 @@ import org.generationcp.middleware.DataSetupTest;
 import org.generationcp.middleware.GermplasmTestDataGenerator;
 import org.generationcp.middleware.IntegrationTestBase;
 import org.generationcp.middleware.WorkbenchTestDataUtil;
+import org.generationcp.middleware.api.inventory.study.StudyTransactionsDto;
+import org.generationcp.middleware.api.inventory.study.StudyTransactionsRequest;
+import org.generationcp.middleware.dao.ims.LotDAO;
+import org.generationcp.middleware.dao.ims.TransactionDAO;
 import org.generationcp.middleware.domain.dms.Experiment;
 import org.generationcp.middleware.domain.inventory.common.SearchCompositeDto;
+import org.generationcp.middleware.domain.inventory.manager.TransactionDto;
+import org.generationcp.middleware.domain.inventory.manager.TransactionsSearchDto;
 import org.generationcp.middleware.domain.inventory.planting.PlantingRequestDto;
 import org.generationcp.middleware.domain.oms.TermId;
 import org.generationcp.middleware.enumeration.DatasetTypeEnum;
@@ -289,6 +295,29 @@ public class PlantingServiceImplIntegrationTest extends IntegrationTestBase {
 		assertThat(transactions.size(), equalTo(2));
 		assertThat(transactions.get(0).getQuantity(), equalTo(-50D));
 		assertThat(transactions.get(1).getQuantity(), equalTo(-50D));
+
+		// Verify using other channels
+
+		final TransactionDAO transactionDAO = this.daoFactory.getTransactionDAO();
+
+		// Transaction search
+		final TransactionsSearchDto transactionsSearchDto = new TransactionsSearchDto();
+		transactionsSearchDto.setPlantingStudyIds(Collections.singletonList(studyId));
+		transactionsSearchDto.setTransactionTypes(Collections.singletonList(TransactionType.WITHDRAWAL.getId()));
+		transactionsSearchDto.setTransactionStatus(Collections.singletonList(TransactionStatus.CONFIRMED.getIntValue()));
+		final List<TransactionDto> transactionDtos = transactionDAO.searchTransactions(transactionsSearchDto, null);
+
+		assertThat(transactionDtos.size(), equalTo(transactions.size()));
+		assertThat(transactionDtos.get(0).getTransactionId(), equalTo(transactions.get(0).getId()));
+		assertThat(transactionDtos.get(1).getTransactionId(), equalTo(transactions.get(1).getId()));
+
+		// Study transaction search
+		final StudyTransactionsRequest studyTransactionsRequest = new StudyTransactionsRequest();
+		final List<StudyTransactionsDto> studyTransactionsDtos = transactionDAO.searchStudyTransactions(studyId, studyTransactionsRequest);
+
+		assertThat(studyTransactionsDtos.size(), equalTo(transactions.size()));
+		assertThat(studyTransactionsDtos.get(0).getTransactionId(), equalTo(transactions.get(0).getId()));
+		assertThat(studyTransactionsDtos.get(1).getTransactionId(), equalTo(transactions.get(1).getId()));
 
 	}
 


### PR DESCRIPTION
- Make programUUID optional in `DmsProjectDao.GET_CHILDREN_OF_FOLDER`
query: Inventory manager can be program agnostic
- PermissionsEnum: list who can view lots and transactions and use it
in `/studies/tree`
- Lot/Transaction plantingStudyIds filters: add filtering to queries
- PlantingServiceImplIntegrationTest: add additional verifications: 
   - `transactionDAO.searchTransactions()`
   - `transactionDAO.searchStudyTransactions()`