### PR TITLE
IBP-3888 Rename UPDATE_PENDING_TRANSACTIONS permission name

### DIFF
--- a/src/main/resources/liquibase/workbench_changelog/15_4_0.xml
+++ b/src/main/resources/liquibase/workbench_changelog/15_4_0.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+				   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+	<changeSet author="cuenyad" id="v15.4.0-1">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT count(*) FROM permission
+				where name = 'UPDATE_PENDING_TRANSACTIONS'
+            </sqlCheck>
+        </preConditions>
+        <comment>Rename update pending transactions permission by import transaction updates</comment>
+        <sql dbms="mysql" splitStatements="true">
+			UPDATE permission
+			SET
+				name = 'IMPORT_TRANSACTION_UPDATES',
+				description = 'Import Transaction Updates'
+			WHERE
+				name = 'UPDATE_PENDING_TRANSACTIONS'
+		</sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/workbench_master.xml
+++ b/src/main/resources/liquibase/workbench_master.xml
@@ -45,6 +45,6 @@
 	<include file="workbench_changelog/15_1_0.xml" relativeToChangelogFile="true"/>
 	<include file="workbench_changelog/15_2_0.xml" relativeToChangelogFile="true"/>
 	<include file="workbench_changelog/15_3_0.xml" relativeToChangelogFile="true"/>
-
+	<include file="workbench_changelog/15_4_0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>
 


### PR DESCRIPTION
Hi @clarysabel and @nahuel-soldevilla.
In this PR I change the name of the UPDATE_PENDING_TRANSACTIONS permission.

Include:
https://github.com/IntegratedBreedingPlatform/BMSAPI/pull/369
https://github.com/IntegratedBreedingPlatform/InventoryManager/pull/54

Please, review
Regards, Diego
