### PR TITLE
IBP-2770-UseFieldParentValueAsFieldMapLocation

### DIFF
--- a/src/main/java/org/generationcp/middleware/dao/dms/ExperimentPropertyDao.java
+++ b/src/main/java/org/generationcp/middleware/dao/dms/ExperimentPropertyDao.java
@@ -26,6 +26,7 @@ import org.generationcp.middleware.domain.fieldbook.FieldMapTrialInstanceInfo;
 import org.generationcp.middleware.domain.oms.TermId;
 import org.generationcp.middleware.exceptions.MiddlewareQueryException;
 import org.generationcp.middleware.manager.Season;
+import org.generationcp.middleware.pojos.LocdesType;
 import org.generationcp.middleware.pojos.dms.ExperimentProperty;
 import org.generationcp.middleware.util.Debug;
 import org.hibernate.Criteria;
@@ -164,7 +165,7 @@ public class ExperimentPropertyDao extends GenericDAO<ExperimentProperty, Intege
 			final StringBuilder sql =
 					new StringBuilder().append(" SELECT ").append(" p.project_id AS datasetId ").append(" , p.name AS datasetName ")
 							.append(" , st.name AS studyName ").append(" , e.nd_geolocation_id AS instanceId ")
-							.append(" , site.value AS siteName ").append(" , siteId.value AS siteId")
+							.append(" , loc.lname AS siteName ").append(" , loc.locid AS siteId")
 							.append(" , e.nd_experiment_id AS experimentId ").append(" , s.uniqueName AS entryNumber ")
 							.append(" , s.name AS germplasmName ").append(" , epropRep.value AS rep ")
 							.append(" , epropPlot.value AS plotNo ").append(" , row.value AS row ").append(" , col.value AS col ")
@@ -186,16 +187,15 @@ public class ExperimentPropertyDao extends GenericDAO<ExperimentProperty, Intege
 							.append("  INNER JOIN nd_experimentprop epropPlot ON epropPlot.nd_experiment_id = e.nd_experiment_id ")
 							.append("    AND epropPlot.type_id IN (").append(TermId.PLOT_NO.getId()).append(", ")
 							.append(TermId.PLOT_NNO.getId()).append(") ").append(" AND epropPlot.value <> '' ")
-							.append("  LEFT JOIN nd_geolocationprop site ON site.nd_geolocation_id = e.nd_geolocation_id ")
-							.append("    AND site.type_id = ").append(TermId.TRIAL_LOCATION.getId())
-							.append("  LEFT JOIN nd_geolocationprop siteId ON siteId.nd_geolocation_id = e.nd_geolocation_id ")
-							.append("    AND siteId.type_id = ").append(TermId.LOCATION_ID.getId())
 							.append("  LEFT JOIN nd_experimentprop row ON row.nd_experiment_id = e.nd_experiment_id ")
 							.append("    AND row.type_id = ").append(TermId.RANGE_NO.getId())
 							.append("  LEFT JOIN nd_experimentprop col ON col.nd_experiment_id = e.nd_experiment_id ")
 							.append("    AND col.type_id = ").append(TermId.COLUMN_NO.getId())
 							.append("  LEFT JOIN nd_geolocationprop gpSeason ON geo.nd_geolocation_id = gpSeason.nd_geolocation_id ")
 							.append("     AND gpSeason.type_id =  ").append(TermId.SEASON_VAR.getId()).append(" ") // -- 8371 (2452)
+							.append(" LEFT JOIN locdes field ON field.dtype = ").append("(SELECT u.fldno FROM udflds u WHERE u.fcode = '" + LocdesType.BLOCK_PARENT.getCode() + "') ").append(" AND field.locid = blk.value")
+							.append(" LEFT JOIN locdes fieldParent ON fieldParent.dtype = ").append("(SELECT u.fldno FROM udflds u WHERE u.fcode = '" + LocdesType.FIELD_PARENT.getCode() + "') ").append(" AND fieldParent.locid = field.dval")
+							.append(" LEFT JOIN location loc ON loc.locid = fieldParent.dval")
 							.append(" WHERE blk.type_id = ").append(TermId.BLOCK_ID.getId());
 
 			if (blockId != null) {
@@ -391,8 +391,8 @@ public class ExperimentPropertyDao extends GenericDAO<ExperimentProperty, Intege
 				trial.setInstanceId((Integer) row[3]);
 				trial.setSiteName((String) row[4]);
 				trial.setLocationName((String) row[4]);
-				if (row[5] != null && NumberUtils.isNumber((String) row[5])) {
-					trial.setLocationId(Integer.valueOf((String) row[5]));
+				if (row[5] != null && NumberUtils.isNumber(row[5].toString())) {
+					trial.setLocationId(Integer.valueOf((row[5].toString())));
 				}
 				if (row[13] != null && NumberUtils.isNumber((String) row[13])) {
 					trial.setBlockId(Integer.valueOf((String) row[13]));

--- a/src/main/java/org/generationcp/middleware/dao/dms/ExperimentPropertyDao.java
+++ b/src/main/java/org/generationcp/middleware/dao/dms/ExperimentPropertyDao.java
@@ -391,8 +391,8 @@ public class ExperimentPropertyDao extends GenericDAO<ExperimentProperty, Intege
 				trial.setInstanceId((Integer) row[3]);
 				trial.setSiteName((String) row[4]);
 				trial.setLocationName((String) row[4]);
-				if (row[5] != null && NumberUtils.isNumber(row[5].toString())) {
-					trial.setLocationId(Integer.valueOf((row[5].toString())));
+				if (row[5] != null && NumberUtils.isNumber((String) row[5])) {
+					trial.setLocationId(Integer.valueOf((String) row[5]));
 				}
 				if (row[13] != null && NumberUtils.isNumber((String) row[13])) {
 					trial.setBlockId(Integer.valueOf((String) row[13]));

--- a/src/main/java/org/generationcp/middleware/operation/saver/GeolocationPropertySaver.java
+++ b/src/main/java/org/generationcp/middleware/operation/saver/GeolocationPropertySaver.java
@@ -26,7 +26,9 @@ public class GeolocationPropertySaver extends Saver {
 					int locationId = trial.getInstanceId();
 					if (trial.getInstanceId() != null && trial.getInstanceId().intValue() == 1) {
 						locationId = this.getExperimentModelSaver().moveStudyToNewGeolocation(info.getFieldbookId());
-						this.saveOrUpdate(locationId, TermId.LOCATION_ID.getId(), trial.getLocationId().toString());
+						if (trial.getLocationId() != null) {
+							this.saveOrUpdate(locationId, TermId.LOCATION_ID.getId(), trial.getLocationId().toString());
+						}
 					}
 
 					if (trial.getBlockId() != null) {

--- a/src/main/java/org/generationcp/middleware/operation/saver/GeolocationPropertySaver.java
+++ b/src/main/java/org/generationcp/middleware/operation/saver/GeolocationPropertySaver.java
@@ -26,9 +26,6 @@ public class GeolocationPropertySaver extends Saver {
 					int locationId = trial.getInstanceId();
 					if (trial.getInstanceId() != null && trial.getInstanceId().intValue() == 1) {
 						locationId = this.getExperimentModelSaver().moveStudyToNewGeolocation(info.getFieldbookId());
-					}
-
-					if (trial.getLocationId() != null) {
 						this.saveOrUpdate(locationId, TermId.LOCATION_ID.getId(), trial.getLocationId().toString());
 					}
 

--- a/src/test/java/org/generationcp/middleware/dao/dms/ExperimentPropertyDaoTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/dms/ExperimentPropertyDaoTest.java
@@ -13,6 +13,7 @@
 package org.generationcp.middleware.dao.dms;
 
 import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.pojos.LocdesType;
 import org.hibernate.SQLQuery;
 import org.hibernate.Session;
 import org.junit.Assert;
@@ -96,7 +97,7 @@ public class ExperimentPropertyDaoTest {
 	private String getFieldmapsInBlockMainQuery() {
 		return " SELECT  p.project_id AS datasetId  , p.name AS datasetName "
 		+ " , st.name AS studyName , e.nd_geolocation_id AS instanceId "
-		+ " , site.value AS siteName , siteId.value AS siteId"
+		+ " , loc.lname AS siteName , loc.locid AS siteId"
 		+ " , e.nd_experiment_id AS experimentId , s.uniqueName AS entryNumber "
 		+ " , s.name AS germplasmName , epropRep.value AS rep "
 		+ " , epropPlot.value AS plotNo , row.value AS row , col.value AS col "
@@ -118,16 +119,15 @@ public class ExperimentPropertyDaoTest {
 		+ "  INNER JOIN nd_experimentprop epropPlot ON epropPlot.nd_experiment_id = e.nd_experiment_id "
 		+ "    AND epropPlot.type_id IN (" + TermId.PLOT_NO.getId()+ ", "
 		+ TermId.PLOT_NNO.getId() + ") AND epropPlot.value <> '' "
-		+ "  LEFT JOIN nd_geolocationprop site ON site.nd_geolocation_id = e.nd_geolocation_id "
-		+ "    AND site.type_id = " + TermId.TRIAL_LOCATION.getId()
-		+ "  LEFT JOIN nd_geolocationprop siteId ON siteId.nd_geolocation_id = e.nd_geolocation_id "
-		+ "    AND siteId.type_id = "+ TermId.LOCATION_ID.getId()
 		+ "  LEFT JOIN nd_experimentprop row ON row.nd_experiment_id = e.nd_experiment_id "
 		+ "    AND row.type_id = "+ TermId.RANGE_NO.getId()
 		+ "  LEFT JOIN nd_experimentprop col ON col.nd_experiment_id = e.nd_experiment_id "
 		+ "    AND col.type_id = "+ TermId.COLUMN_NO.getId()
 		+ "  LEFT JOIN nd_geolocationprop gpSeason ON geo.nd_geolocation_id = gpSeason.nd_geolocation_id "
 		+ "     AND gpSeason.type_id =  "+ TermId.SEASON_VAR.getId() + " "
+		+ " LEFT JOIN locdes field ON field.dtype = (SELECT u.fldno FROM udflds u WHERE u.fcode = '" + LocdesType.BLOCK_PARENT.getCode() + "')  AND field.locid = blk.value"
+		+ " LEFT JOIN locdes fieldParent ON fieldParent.dtype = (SELECT u.fldno FROM udflds u WHERE u.fcode = '" + LocdesType.FIELD_PARENT.getCode() + "')  AND fieldParent.locid = field.dval"
+		+ " LEFT JOIN location loc ON loc.locid = fieldParent.dval"
 		+ " WHERE blk.type_id = "+ TermId.BLOCK_ID.getId();
 	}
 	


### PR DESCRIPTION
Remove override process for location if location is not null || eq. to 1
Modified query in getAllFieldMapsInBlockByTrialInstanceId - return fieldmap parent as sitelocationid 
Fix failing unit test