### PR TITLE
IBP-3907 Fix "ouf of bound" filter for decimal numbers

### DIFF
--- a/src/main/java/org/generationcp/middleware/dao/dms/ObservationUnitsSearchDao.java
+++ b/src/main/java/org/generationcp/middleware/dao/dms/ObservationUnitsSearchDao.java
@@ -776,11 +776,11 @@ public class ObservationUnitsSearchDao extends GenericDAO<ExperimentModel, Integ
 			+ "          ) " //
 			+ "        when dataType.cvterm_id = " + TermId.NUMERIC_VARIABLE.getId() //
 			// get the numericals whose value is not within bounds
-			+ "          then cast(ph2." + filterByDraftOrValue + " as unsigned) < scaleMinRange.value or cast(ph2." + filterByDraftOrValue
-			+ " as unsigned) > scaleMaxRange.value " //
-			+ "            or cast(ph2." + filterByDraftOrValue + " as unsigned) < vo.expected_min or cast(ph2." + filterByDraftOrValue
-			+ " as unsigned) > vo.expected_max "
-			//
+			// cast strings to decimal (+ 0) to compare
+			+ "          then ph2." + filterByDraftOrValue + " + 0 < scaleMinRange.value "  //
+			+ "            or ph2." + filterByDraftOrValue + " + 0 > scaleMaxRange.value " //
+			+ "            or ph2." + filterByDraftOrValue + " + 0 < vo.expected_min "  //
+			+ "            or ph2." + filterByDraftOrValue + " + 0 > vo.expected_max " //
 			+ "        else false " //
 			+ "        end " //
 			+ "    )"); //

--- a/src/test/java/org/generationcp/middleware/dao/dms/ObservationUnitsSearchDaoTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/dms/ObservationUnitsSearchDaoTest.java
@@ -440,15 +440,16 @@ public class ObservationUnitsSearchDaoTest extends IntegrationTestBase {
 		final String traitName = "MyTrait";
 
 		final Geolocation geolocation = this.testDataInitializer.createTestGeolocation("1", 101);
-		final List<ExperimentModel> instance1Units = this.testDataInitializer.createTestExperimentsWithStock(this.study, this.plot, null, geolocation, 3);
+		final List<ExperimentModel> instance1Units = this.testDataInitializer.createTestExperimentsWithStock(this.study, this.plot, null, geolocation, 4);
 		final Integer traitId = this.createTrait(traitName);
 		final List<ExperimentModel> unitsWithObservations = Collections.singletonList(instance1Units.get(0));
 		final List<ExperimentModel> unitsWithObservations2 = Collections.singletonList(instance1Units.get(1));
 		final List<ExperimentModel> unitsWithObservations3 = Collections.singletonList(instance1Units.get(2));
+		final List<ExperimentModel> unitsWithObservations4 = Collections.singletonList(instance1Units.get(3));
 		this.testDataInitializer.addPhenotypes(unitsWithObservations, traitId, "1000");
 		this.testDataInitializer.addPhenotypes(unitsWithObservations2, traitId, "3000");
 		this.testDataInitializer.addPhenotypes(unitsWithObservations3, traitId, "5");
-
+		this.testDataInitializer.addPhenotypes(unitsWithObservations4, traitId, "100.1");
 		final MeasurementVariableDto measurementVariableDto = new MeasurementVariableDto(traitId, traitName);
 		final ObservationUnitsSearchDTO observationUnitsSearchDTO = this.testDataInitializer.createTestObservationUnitsDTO();
 		final Integer datasetId = this.plot.getProjectId();
@@ -465,7 +466,7 @@ public class ObservationUnitsSearchDaoTest extends IntegrationTestBase {
 		this.sessionProvder.getSession().flush();
 
 		final List<ObservationUnitRow> measurementRows = this.obsUnitSearchDao.getObservationUnitsByVariable(observationUnitsSearchDTO);
-		assertEquals(3, measurementRows.size());
+		assertEquals(4, measurementRows.size());
 	}
 
 	@Test


### PR DESCRIPTION
Previously numeric values were cast to unsigned, so values were truncated to integers and some decimal values at the boundaries were incorrectly label as within-bounds.
Cast them using the +0 trick to avoid having to specify a "precision" parameter with other methods (e.g cast to float)

cc @IntegratedBreedingPlatform/developers 