### PR TITLE
IBP-3985 germplasm search showing deleted names

### DIFF
--- a/src/main/java/org/generationcp/middleware/dao/GermplasmSearchDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/GermplasmSearchDAO.java
@@ -407,7 +407,7 @@ public class GermplasmSearchDAO extends GenericDAO<Germplasm, Integer> {
                 + "       LEFT JOIN ims_transaction gt \n" + "              ON gt.lotid = gl.lotid AND gt.trnstat <> 9 \n"
                 + "       LEFT JOIN methods m \n" + "              ON m.mid = g.methn \n" + "       LEFT JOIN location l \n"
                 + "              ON l.locid = g.glocn \n" + "       LEFT JOIN `names` allNames  \n"
-                + "              ON g.gid = allNames.gid \n");
+                + "              ON g.gid = allNames.gid and allNames.nstat != 9 \n");
 
         for (final String propertyId : addedColumnsPropertyIds) {
             if (GermplasmSearchDAO.fromClauseColumnsMap.containsKey(propertyId)) {

--- a/src/main/java/org/generationcp/middleware/pojos/Germplasm.java
+++ b/src/main/java/org/generationcp/middleware/pojos/Germplasm.java
@@ -180,7 +180,7 @@ public class Germplasm implements Serializable {
 					+ "( nval = :name OR nval = :noSpaceName OR nval = :standardizedName )";
 
 	public static final String COUNT_BY_NAME_ALL_MODES_USING_EQUAL =
-			"SELECT COUNT(DISTINCT g.gid) FROM germplsm g JOIN names n ON g.gid = n.gid WHERE  g.deleted = 0  AND g.grplce = 0 AND "
+			"SELECT COUNT(DISTINCT g.gid) FROM germplsm g JOIN names n ON g.gid = n.gid and n.nstat != 9 WHERE  g.deleted = 0  AND g.grplce = 0 AND "
 					+ "( nval = :name OR nval = :noSpaceName OR nval = :standardizedName )";
 
 	public static final String GET_BY_NAME_ALL_MODES_USING_LIKE =
@@ -188,7 +188,7 @@ public class Germplasm implements Serializable {
 					+ "( nval LIKE :name OR nval LIKE :noSpaceName OR nval LIKE :standardizedName )";
 
 	public static final String COUNT_BY_NAME_ALL_MODES_USING_LIKE =
-			"SELECT COUNT(DISTINCT g.gid) FROM germplsm g JOIN names n ON g.gid = n.gid WHERE  g.deleted = 0  AND g.grplce = 0 AND "
+			"SELECT COUNT(DISTINCT g.gid) FROM germplsm g JOIN names n ON g.gid = n.gid and n.nstat != 9 WHERE  g.deleted = 0  AND g.grplce = 0 AND "
 					+ "( nval LIKE :name OR nval LIKE :noSpaceName OR nval LIKE :standardizedName )";
 
 	public static final String GET_BY_GID_WITH_METHOD_TYPE =


### PR DESCRIPTION
This PR is to avoid using the deleted name during the importing germplasm and also fix doesn't show the deleted name in View Germpalsm in Manage Germplasm.

Please, review