### PR TITLE
IBP-3977-CrossExpansionExcludeLevelWithNullParent

### DIFF
--- a/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/DoubleCrossProcessor.java
+++ b/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/DoubleCrossProcessor.java
@@ -63,7 +63,8 @@ public class DoubleCrossProcessor implements BreedingMethodProcessor {
 
 	private PedigreeString constructPedigreeString(final GermplasmNode node, final Integer level,
 			final FixedLineNameResolver fixedLineNameResolver, final boolean originatesFromComplexCross) {
-		final PedigreeString femalePedigreeString = getPedigreeString(node.getFemaleParent(), level, fixedLineNameResolver, originatesFromComplexCross);
+		final PedigreeString femalePedigreeString =
+			this.getPedigreeString(node.getFemaleParent(), level, fixedLineNameResolver, originatesFromComplexCross);
 		final PedigreeString malePedigreeString = getPedigreeString(node.getMaleParent(), level, fixedLineNameResolver, originatesFromComplexCross);
 		final PedigreeString femaleCrossPedigreeString = new PedigreeString();
 		femaleCrossPedigreeString.setNumberOfCrosses(femalePedigreeString.getNumberOfCrosses() + malePedigreeString.getNumberOfCrosses()
@@ -76,8 +77,10 @@ public class DoubleCrossProcessor implements BreedingMethodProcessor {
 	private PedigreeString getPedigreeString(final GermplasmNode node, final Integer level, final FixedLineNameResolver fixedLineNameResolver,
 			final boolean originatesFromComplexCross) {
 		if(node != null) {
-			return this.pedigreeStringBuilder.buildPedigreeString(node, level - 1, fixedLineNameResolver, originatesFromComplexCross);
-		} 
+			if(node.getMaleParent()!=null && node.getFemaleParent()!=null) {
+				return this.pedigreeStringBuilder.buildPedigreeString(node, level - 1, fixedLineNameResolver, originatesFromComplexCross);
+			}
+		}
 		return this.inbredProcessor.processGermplasmNode(node, level - 1, fixedLineNameResolver, originatesFromComplexCross);
 
 	}

--- a/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/DoubleCrossProcessor.java
+++ b/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/DoubleCrossProcessor.java
@@ -55,7 +55,7 @@ public class DoubleCrossProcessor implements BreedingMethodProcessor {
 
 	private PedigreeString constructPedigreeStringForSingleCrossHybrids(final GermplasmNode singleCrossHybrids, final Integer level,
 			final FixedLineNameResolver fixedLineNameResolver, final boolean originatesFromComplexCross) {
-		if (singleCrossHybrids != null) {
+		if (singleCrossHybrids != null && singleCrossHybrids.getFemaleParent() != null && singleCrossHybrids.getMaleParent() != null) {
 			return this.constructPedigreeString(singleCrossHybrids, level, fixedLineNameResolver, originatesFromComplexCross);
 		}
 		return this.inbredProcessor.processGermplasmNode(singleCrossHybrids, level - 1, fixedLineNameResolver, originatesFromComplexCross);

--- a/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/DoubleCrossProcessor.java
+++ b/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/DoubleCrossProcessor.java
@@ -76,10 +76,8 @@ public class DoubleCrossProcessor implements BreedingMethodProcessor {
 
 	private PedigreeString getPedigreeString(final GermplasmNode node, final Integer level, final FixedLineNameResolver fixedLineNameResolver,
 			final boolean originatesFromComplexCross) {
-		if(node != null) {
-			if(node.getMaleParent()!=null && node.getFemaleParent()!=null) {
-				return this.pedigreeStringBuilder.buildPedigreeString(node, level - 1, fixedLineNameResolver, originatesFromComplexCross);
-			}
+		if(node != null && node.getMaleParent() != null && node.getFemaleParent() != null) {
+			return this.pedigreeStringBuilder.buildPedigreeString(node, level - 1, fixedLineNameResolver, originatesFromComplexCross);
 		}
 		return this.inbredProcessor.processGermplasmNode(node, level - 1, fixedLineNameResolver, originatesFromComplexCross);
 

--- a/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/SingleCrossHybridProcessor.java
+++ b/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/SingleCrossHybridProcessor.java
@@ -55,7 +55,7 @@ public class SingleCrossHybridProcessor implements BreedingMethodProcessor {
 			LOG.debug("Germplasm with GID '{}' is being processed by an single cross processor. "
 					, germplasmNode.getGermplasm().getGid());
 		}
-		
+
 		final PedigreeString femalePedigreeString = this.getPedigreeString(level, fixedLineNameResolver, germplasmNode.getFemaleParent(), originatesFromComplexCross);
 
 		final PedigreeString malePedigreeString = this.getPedigreeString(level, fixedLineNameResolver, germplasmNode.getMaleParent(), originatesFromComplexCross);
@@ -70,7 +70,9 @@ public class SingleCrossHybridProcessor implements BreedingMethodProcessor {
 			final GermplasmNode germplasmNode, final boolean originatesFromComplexCross) {
 		boolean complexCross = levelSubtractor == 0 ? true : originatesFromComplexCross;
 		if (germplasmNode != null) {
-			return this.pedigreeStringBuilder.buildPedigreeString(germplasmNode, level - this.levelSubtractor, fixedLineNameResolver, complexCross);
+			if( germplasmNode.getFemaleParent() !=null && germplasmNode.getMaleParent() !=null) {
+				return this.pedigreeStringBuilder.buildPedigreeString(germplasmNode, level - this.levelSubtractor, fixedLineNameResolver, complexCross);
+			}
 		}
 		return this.inbredProcessor.processGermplasmNode(germplasmNode, level - this.levelSubtractor, fixedLineNameResolver, complexCross);
 	}

--- a/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/SingleCrossHybridProcessor.java
+++ b/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/SingleCrossHybridProcessor.java
@@ -68,7 +68,7 @@ public class SingleCrossHybridProcessor implements BreedingMethodProcessor {
 
 	private PedigreeString getPedigreeString(final Integer level, final FixedLineNameResolver fixedLineNameResolver,
 			final GermplasmNode germplasmNode, final boolean originatesFromComplexCross) {
-		boolean complexCross = levelSubtractor == 0 ? true : originatesFromComplexCross;
+		final boolean complexCross = this.levelSubtractor == 0 ? true : originatesFromComplexCross;
 		if (germplasmNode != null) {
 			if( germplasmNode.getFemaleParent() !=null && germplasmNode.getMaleParent() !=null) {
 				return this.pedigreeStringBuilder.buildPedigreeString(germplasmNode, level - this.levelSubtractor, fixedLineNameResolver, complexCross);

--- a/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/SingleCrossHybridProcessor.java
+++ b/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/SingleCrossHybridProcessor.java
@@ -69,10 +69,8 @@ public class SingleCrossHybridProcessor implements BreedingMethodProcessor {
 	private PedigreeString getPedigreeString(final Integer level, final FixedLineNameResolver fixedLineNameResolver,
 			final GermplasmNode germplasmNode, final boolean originatesFromComplexCross) {
 		final boolean complexCross = this.levelSubtractor == 0 ? true : originatesFromComplexCross;
-		if (germplasmNode != null) {
-			if( germplasmNode.getFemaleParent() !=null && germplasmNode.getMaleParent() !=null) {
-				return this.pedigreeStringBuilder.buildPedigreeString(germplasmNode, level - this.levelSubtractor, fixedLineNameResolver, complexCross);
-			}
+		if (germplasmNode != null && germplasmNode.getFemaleParent() != null && germplasmNode.getMaleParent() != null) {
+			return this.pedigreeStringBuilder.buildPedigreeString(germplasmNode, level - this.levelSubtractor, fixedLineNameResolver, complexCross);
 		}
 		return this.inbredProcessor.processGermplasmNode(germplasmNode, level - this.levelSubtractor, fixedLineNameResolver, complexCross);
 	}

--- a/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/ThreeWayHybridProcessor.java
+++ b/src/main/java/org/generationcp/middleware/service/pedigree/string/processors/ThreeWayHybridProcessor.java
@@ -86,7 +86,7 @@ public class ThreeWayHybridProcessor implements BreedingMethodProcessor {
 
 	private PedigreeString getPedigreeString(final Integer level, final FixedLineNameResolver fixedLineNameResolver,
 			final GermplasmNode singleCrossHybridFemaleParent, final boolean originatesFromComplexCross) {
-		if(singleCrossHybridFemaleParent != null) {
+		if(singleCrossHybridFemaleParent != null && singleCrossHybridFemaleParent.getFemaleParent() != null && singleCrossHybridFemaleParent.getMaleParent() != null) {
 			return this.pedigreeStringBuilder.buildPedigreeString(singleCrossHybridFemaleParent, level - 1, fixedLineNameResolver, originatesFromComplexCross);
 		}
 		return this.inbredProcessor.processGermplasmNode(singleCrossHybridFemaleParent, level - 1, fixedLineNameResolver, originatesFromComplexCross);

--- a/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/DoubleCrossProcessorTest.java
+++ b/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/DoubleCrossProcessorTest.java
@@ -22,11 +22,11 @@ public class DoubleCrossProcessorTest {
 
 	@Before
 	public void setUp() {
-		fixedLineNameResolver = Mockito.mock(FixedLineNameResolver.class);
+		this.fixedLineNameResolver = Mockito.mock(FixedLineNameResolver.class);
 		// We use any and null value because in the test be do not want any fixed line based name resolution
-		Mockito.when(fixedLineNameResolver.nameTypeBasedResolution(Mockito.any(GermplasmNode.class))).thenReturn(
+		Mockito.when(this.fixedLineNameResolver.nameTypeBasedResolution(Mockito.any(GermplasmNode.class))).thenReturn(
 				Optional.<String>fromNullable(null));
-		Mockito.when(fixedLineNameResolver.nameTypeBasedResolution(null)).thenReturn(
+		Mockito.when(this.fixedLineNameResolver.nameTypeBasedResolution(null)).thenReturn(
 				Optional.<String>fromNullable(null));
 	}
 
@@ -36,7 +36,7 @@ public class DoubleCrossProcessorTest {
 		final GermplasmNode parentGermplasmNode = PedigreeStringTestUtil.createDoubleCrossTestGermplasmTree();
 
 		final PedigreeString resultantPedigreeString =
-				doubleCrossProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3), fixedLineNameResolver, false);
+			this.doubleCrossProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3), this.fixedLineNameResolver, false);
 		assertEquals("Incorrect double cross generation", "B/C//E/F", resultantPedigreeString.getPedigree());
 		assertEquals("We have crated one cross.", 2, resultantPedigreeString.getNumberOfCrosses());
 
@@ -57,7 +57,7 @@ public class DoubleCrossProcessorTest {
 		parentGermplasmNode.setFemaleParent(femaleGermplasmNode);
 		parentGermplasmNode.setMaleParent(null);
 		final PedigreeString resultantPedigreeString =
-				doubleCrossProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3), fixedLineNameResolver, false);
+			this.doubleCrossProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3), this.fixedLineNameResolver, false);
 		assertEquals("Incorrect double cross generation with missing male parent", "B/C//Unknown", resultantPedigreeString.getPedigree());
 		assertEquals("We have crated one cross.", 2, resultantPedigreeString.getNumberOfCrosses());
 
@@ -72,7 +72,7 @@ public class DoubleCrossProcessorTest {
 		parentGermplasmNode.setFemaleParent(null);
 		parentGermplasmNode.setMaleParent(null);
 		final PedigreeString resultantPedigreeString =
-				doubleCrossProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3), fixedLineNameResolver, false);
+			this.doubleCrossProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3), this.fixedLineNameResolver, false);
 		assertEquals("Incorret double cross generationw with missing parents.", "Unknown/Unknown", resultantPedigreeString.getPedigree());
 		assertEquals("We have created 1 cross", 1, resultantPedigreeString.getNumberOfCrosses());
 
@@ -84,14 +84,14 @@ public class DoubleCrossProcessorTest {
 		final GermplasmNode femaleGermplasmNode =
 			PedigreeStringTestUtil.createGermplasmNode(6, "FemaleParent", PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
 				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
-		femaleGermplasmNode.setFemaleParent(getGrandParents("gpFFemale"));
-		femaleGermplasmNode.setMaleParent(getGrandParents("gpFMale"));
+		femaleGermplasmNode.setFemaleParent(this.getGrandParents("gpFFemale"));
+		femaleGermplasmNode.setMaleParent(this.getGrandParents("gpFMale"));
 
 		final GermplasmNode maleGermplasmNode =
 			PedigreeStringTestUtil.createGermplasmNode(6, "MaleParent", PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
 				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
-		maleGermplasmNode.setFemaleParent(getGrandParents("gpMFemale"));
-		maleGermplasmNode.setMaleParent(getGrandParents("gpMMale"));
+		maleGermplasmNode.setFemaleParent(this.getGrandParents("gpMFemale"));
+		maleGermplasmNode.setMaleParent(this.getGrandParents("gpMMale"));
 
 
 		final GermplasmNode germplasmNode =
@@ -101,7 +101,7 @@ public class DoubleCrossProcessorTest {
 		germplasmNode.setMaleParent(maleGermplasmNode);
 
 		final PedigreeString resultantPedigreeString =
-			doubleCrossProcessor.processGermplasmNode(germplasmNode,2, fixedLineNameResolver, false);
+			this.doubleCrossProcessor.processGermplasmNode(germplasmNode,2, this.fixedLineNameResolver, false);
 		assertEquals("Incorret double cross generationw with missing parents.", "gpFFemale/gpFMale//gpMFemale/gpMMale", resultantPedigreeString.getPedigree());
 		assertEquals("We have created 1 cross", 2, resultantPedigreeString.getNumberOfCrosses());
 

--- a/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/DoubleCrossProcessorTest.java
+++ b/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/DoubleCrossProcessorTest.java
@@ -77,4 +77,44 @@ public class DoubleCrossProcessorTest {
 		assertEquals("We have created 1 cross", 1, resultantPedigreeString.getNumberOfCrosses());
 
 	}
+
+	@Test
+	public void testCreationOfDoubleCrossWithNullGrandParents() throws Exception {
+
+		final GermplasmNode femaleGermplasmNode =
+			PedigreeStringTestUtil.createGermplasmNode(6, "FemaleParent", PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
+				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
+		femaleGermplasmNode.setFemaleParent(getGrandParents("gpFFemale"));
+		femaleGermplasmNode.setMaleParent(getGrandParents("gpFMale"));
+
+		final GermplasmNode maleGermplasmNode =
+			PedigreeStringTestUtil.createGermplasmNode(6, "MaleParent", PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
+				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
+		maleGermplasmNode.setFemaleParent(getGrandParents("gpMFemale"));
+		maleGermplasmNode.setMaleParent(getGrandParents("gpMMale"));
+
+
+		final GermplasmNode germplasmNode =
+			PedigreeStringTestUtil.createGermplasmNode(6, "G", PedigreeStringTestUtil.DOUBLE_CROSS_METHOD_ID,
+				PedigreeStringTestUtil.DOUBLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.DOUBLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
+		germplasmNode.setFemaleParent(femaleGermplasmNode);
+		germplasmNode.setMaleParent(maleGermplasmNode);
+
+		final PedigreeString resultantPedigreeString =
+			doubleCrossProcessor.processGermplasmNode(germplasmNode,2, fixedLineNameResolver, false);
+		assertEquals("Incorret double cross generationw with missing parents.", "gpFFemale/gpFMale//gpMFemale/gpMMale", resultantPedigreeString.getPedigree());
+		assertEquals("We have created 1 cross", 2, resultantPedigreeString.getNumberOfCrosses());
+
+	}
+
+	public GermplasmNode getGrandParents(final String name) {
+		final GermplasmNode germplasm =
+			PedigreeStringTestUtil.createGermplasmNode(6, name, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
+				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
+
+		return germplasm;
+	}
+
+
+
 }

--- a/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/DoubleCrossProcessorTest.java
+++ b/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/DoubleCrossProcessorTest.java
@@ -115,6 +115,4 @@ public class DoubleCrossProcessorTest {
 		return germplasm;
 	}
 
-
-
 }

--- a/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/SingleCrossHybridProcessorTest.java
+++ b/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/SingleCrossHybridProcessorTest.java
@@ -21,11 +21,11 @@ public class SingleCrossHybridProcessorTest {
 
 	@Before
 	public void setUp() {
-		fixedLineNameResolver = Mockito.mock(FixedLineNameResolver.class);
+		this.fixedLineNameResolver = Mockito.mock(FixedLineNameResolver.class);
 		// We use any and null value because in the test be do not want any fixed line based name resolution
-		Mockito.when(fixedLineNameResolver.nameTypeBasedResolution(Mockito.any(GermplasmNode.class))).thenReturn(
+		Mockito.when(this.fixedLineNameResolver.nameTypeBasedResolution(Mockito.any(GermplasmNode.class))).thenReturn(
 				Optional.<String>fromNullable(null));
-		Mockito.when(fixedLineNameResolver.nameTypeBasedResolution(null)).thenReturn(
+		Mockito.when(this.fixedLineNameResolver.nameTypeBasedResolution(null)).thenReturn(
 				Optional.<String>fromNullable(null));
 	}
 
@@ -34,7 +34,8 @@ public class SingleCrossHybridProcessorTest {
 		final SingleCrossHybridProcessor singleCrossHybridProcessor = new SingleCrossHybridProcessor();
 		final GermplasmNode parentGermplasmNode = PedigreeStringTestUtil.createSingleCrossTestGermplasmTree();
 
-		final PedigreeString resultantPedigreeString = singleCrossHybridProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3), fixedLineNameResolver, false);
+		final PedigreeString resultantPedigreeString = singleCrossHybridProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3),
+			this.fixedLineNameResolver, false);
 		assertEquals("Pedigree string is a cross of the female and male children ", "B/C", resultantPedigreeString.getPedigree());
 		assertEquals("We have crated one cross.", 1, resultantPedigreeString.getNumberOfCrosses());
 
@@ -56,7 +57,8 @@ public class SingleCrossHybridProcessorTest {
 				PedigreeStringTestUtil.BULK_OR_POPULATION_SAMPLE_METHOD_ID, PedigreeStringTestUtil.BULK_OR_POPULATION_SAMPLE_METHOD_NAME,
 				PedigreeStringTestUtil.BULK_OR_POPULATION_SAMPLE_METHOD_NUMBER_OF_PROGENITOR));
 
-		final PedigreeString resultantPedigreeString = singleCrossHybridProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3), fixedLineNameResolver, false);
+		final PedigreeString resultantPedigreeString = singleCrossHybridProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3),
+			this.fixedLineNameResolver, false);
 		assertEquals("Pedigree string is 2/3 since we do not have a preferred name.", "2/3", resultantPedigreeString.getPedigree());
 		assertEquals("We have crated one cross.", 1, resultantPedigreeString.getNumberOfCrosses());
 
@@ -69,7 +71,8 @@ public class SingleCrossHybridProcessorTest {
 				PedigreeStringTestUtil.createGermplasmNode(1, "A", PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
 						PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
 
-		final PedigreeString resultantPedigreeString = singleCrossHybridProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3), fixedLineNameResolver, false);
+		final PedigreeString resultantPedigreeString = singleCrossHybridProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3),
+			this.fixedLineNameResolver, false);
 		assertEquals("Pedigree string is Unknown/Unknow since we cannot " + "determine the name or the GID", "Unknown/Unknown",
 				resultantPedigreeString.getPedigree());
 		assertEquals("We have crated one cross.", 1, resultantPedigreeString.getNumberOfCrosses());
@@ -85,7 +88,8 @@ public class SingleCrossHybridProcessorTest {
 		parentGermplasmNode.setFemaleParent(new GermplasmNode(null));
 		parentGermplasmNode.setMaleParent(new GermplasmNode(null));
 
-		final PedigreeString resultantPedigreeString = singleCrossHybridProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3), fixedLineNameResolver, false);
+		final PedigreeString resultantPedigreeString = singleCrossHybridProcessor.processGermplasmNode(parentGermplasmNode, new Integer(3),
+			this.fixedLineNameResolver, false);
 		assertEquals("Pedigree string is Unknown/Unknow since we cannot " + "determine the name or the GID", "Unknown/Unknown",
 				resultantPedigreeString.getPedigree());
 		assertEquals("We have crated one cross.", 1, resultantPedigreeString.getNumberOfCrosses());
@@ -114,7 +118,8 @@ public class SingleCrossHybridProcessorTest {
 		germplasmNode.setFemaleParent(femaleParent);
 		germplasmNode.setMaleParent(maleParent);
 
-		final PedigreeString resultantPedigreeString = singleCrossHybridProcessor.processGermplasmNode(germplasmNode, 2, fixedLineNameResolver, false);
+		final PedigreeString resultantPedigreeString = singleCrossHybridProcessor.processGermplasmNode(germplasmNode, 2,
+			this.fixedLineNameResolver, false);
 		assertEquals("Pedigree string is Unknown/Unknow since we cannot " + "determine the name or the GID", "FemaleParent1/MaleParent1",
 			resultantPedigreeString.getPedigree());
 		assertEquals("We have crated one cross.", 1, resultantPedigreeString.getNumberOfCrosses());

--- a/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/SingleCrossHybridProcessorTest.java
+++ b/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/SingleCrossHybridProcessorTest.java
@@ -92,4 +92,33 @@ public class SingleCrossHybridProcessorTest {
 
 	}
 
+	@Test
+	public void testUnknownParentLevel2() {
+		final SingleCrossHybridProcessor singleCrossHybridProcessor = new SingleCrossHybridProcessor();
+
+		final GermplasmNode femaleParent =
+			PedigreeStringTestUtil.createGermplasmNode(1, "FemaleParent1", PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
+				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
+		femaleParent.setFemaleParent(null);
+		femaleParent.setMaleParent(null);
+
+		final GermplasmNode maleParent =
+			PedigreeStringTestUtil.createGermplasmNode(1, "MaleParent1", PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
+				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
+		maleParent.setFemaleParent(null);
+		maleParent.setMaleParent(null);
+
+		final GermplasmNode germplasmNode =
+			PedigreeStringTestUtil.createGermplasmNode(1, "A", PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
+				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
+		germplasmNode.setFemaleParent(femaleParent);
+		germplasmNode.setMaleParent(maleParent);
+
+		final PedigreeString resultantPedigreeString = singleCrossHybridProcessor.processGermplasmNode(germplasmNode, 2, fixedLineNameResolver, false);
+		assertEquals("Pedigree string is Unknown/Unknow since we cannot " + "determine the name or the GID", "FemaleParent1/MaleParent1",
+			resultantPedigreeString.getPedigree());
+		assertEquals("We have crated one cross.", 1, resultantPedigreeString.getNumberOfCrosses());
+
+	}
+
 }

--- a/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/SingleCrossHybridProcessorTest.java
+++ b/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/SingleCrossHybridProcessorTest.java
@@ -97,7 +97,7 @@ public class SingleCrossHybridProcessorTest {
 	}
 
 	@Test
-	public void testUnknownParentLevel2() {
+	public void testUnknownGrandParents() {
 		final SingleCrossHybridProcessor singleCrossHybridProcessor = new SingleCrossHybridProcessor();
 
 		final GermplasmNode femaleParent =

--- a/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/ThreeWayHybridProcessorTest.java
+++ b/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/ThreeWayHybridProcessorTest.java
@@ -141,4 +141,52 @@ public class ThreeWayHybridProcessorTest {
 		assertEquals("We have crated one cross.", 1, resultantPedigreeString.getNumberOfCrosses());
 
 	}
+
+	@Test
+	public void testCreationOfThreeWayCrossWhereBothGrandParentsAreMissing() {
+
+		final GermplasmNode femaleParent =
+			PedigreeStringTestUtil.createGermplasmNode(1, "FemaleParent1", PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
+				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
+		femaleParent.setFemaleParent(getGrandParents("gFFemale", false));
+		femaleParent.setMaleParent(getGrandParents("gFMale", false));
+
+		final GermplasmNode maleParent =
+			PedigreeStringTestUtil.createGermplasmNode(1, "MaleParent1", PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
+				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
+		maleParent.setFemaleParent(getGrandParents("gMFemale", false));
+		maleParent.setMaleParent(getGrandParents("gMMale", false));
+
+		final GermplasmNode threeWayCrossParentNode =
+			PedigreeStringTestUtil.createGermplasmNode(5, "E", PedigreeStringTestUtil.THREE_WAY_CROSS_METHOD_ID,
+				PedigreeStringTestUtil.THREE_WAY_CROSS_METHOD_ID_METHOD_NAME,
+				PedigreeStringTestUtil.THREE_WAY_CROSS_METHOD_NUMBER_OF_PROGENITOR);
+		threeWayCrossParentNode.setFemaleParent(femaleParent);
+		threeWayCrossParentNode.setMaleParent(maleParent);
+
+		final ThreeWayHybridProcessor threeWayHybridProcessor = new ThreeWayHybridProcessor();
+
+		final PedigreeString resultantPedigreeString =
+			threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, 4, fixedLineNameResolver, false);
+		assertEquals("Incorrect three way cross generation where both parent is null ", "gFFemale/gFMale//MaleParent1",
+			resultantPedigreeString.getPedigree());
+		assertEquals("We have crated one cross.", 2, resultantPedigreeString.getNumberOfCrosses());
+
+	}
+
+	public GermplasmNode getGrandParents(final String name, boolean withParent) {
+		final GermplasmNode germplasm =
+			PedigreeStringTestUtil.createGermplasmNode(6, name, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
+				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
+		if(withParent) {
+			germplasm.setMaleParent(this.getGrandParents("GGParent1", false));
+			germplasm.setFemaleParent(this.getGrandParents("GGParent2", false));
+
+		} else {
+			germplasm.setMaleParent(null);
+			germplasm.setFemaleParent(null);
+		}
+
+		return germplasm;
+	}
 }

--- a/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/ThreeWayHybridProcessorTest.java
+++ b/src/test/java/org/generationcp/middleware/service/pedigree/string/processors/ThreeWayHybridProcessorTest.java
@@ -19,11 +19,11 @@ public class ThreeWayHybridProcessorTest {
 
 	@Before
 	public void setUp() {
-		fixedLineNameResolver = Mockito.mock(FixedLineNameResolver.class);
+		this.fixedLineNameResolver = Mockito.mock(FixedLineNameResolver.class);
 		// We use any and null value because in the test be do not want any fixed line based name resolution
-		Mockito.when(fixedLineNameResolver.nameTypeBasedResolution(Mockito.any(GermplasmNode.class))).thenReturn(
+		Mockito.when(this.fixedLineNameResolver.nameTypeBasedResolution(Mockito.any(GermplasmNode.class))).thenReturn(
 				Optional.<String>fromNullable(null));
-		Mockito.when(fixedLineNameResolver.nameTypeBasedResolution(null)).thenReturn(
+		Mockito.when(this.fixedLineNameResolver.nameTypeBasedResolution(null)).thenReturn(
 				Optional.<String>fromNullable(null));
 	}
 
@@ -45,7 +45,7 @@ public class ThreeWayHybridProcessorTest {
 		final ThreeWayHybridProcessor threeWayHybridProcessor = new ThreeWayHybridProcessor();
 
 		final PedigreeString resultantPedigreeString =
-				threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, new Integer(3), fixedLineNameResolver, false);
+				threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, new Integer(3), this.fixedLineNameResolver, false);
 		assertEquals("Incorrect three way cross generation where female parent has the single cross", "B/C//D",
 				resultantPedigreeString.getPedigree());
 		assertEquals("We have crated one cross.", 2, resultantPedigreeString.getNumberOfCrosses());
@@ -71,7 +71,7 @@ public class ThreeWayHybridProcessorTest {
 		final ThreeWayHybridProcessor threeWayHybridProcessor = new ThreeWayHybridProcessor();
 
 		final PedigreeString resultantPedigreeString =
-				threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, new Integer(3), fixedLineNameResolver, false);
+				threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, new Integer(3), this.fixedLineNameResolver, false);
 		assertEquals("Incorrect three way cross generation where male parent has the single cross", "D//B/C",
 				resultantPedigreeString.getPedigree());
 		assertEquals("We have created one cross.", 2, resultantPedigreeString.getNumberOfCrosses());
@@ -93,7 +93,7 @@ public class ThreeWayHybridProcessorTest {
 		final ThreeWayHybridProcessor threeWayHybridProcessor = new ThreeWayHybridProcessor();
 
 		final PedigreeString resultantPedigreeString =
-				threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, new Integer(3), fixedLineNameResolver, false);
+				threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, new Integer(3), this.fixedLineNameResolver, false);
 		assertEquals("Incorrect three way cross generation where male parent is null ", "B/C//Unknown",
 				resultantPedigreeString.getPedigree());
 		assertEquals("We have crated one cross.", 2, resultantPedigreeString.getNumberOfCrosses());
@@ -114,7 +114,7 @@ public class ThreeWayHybridProcessorTest {
 		final ThreeWayHybridProcessor threeWayHybridProcessor = new ThreeWayHybridProcessor();
 
 		final PedigreeString resultantPedigreeString =
-				threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, new Integer(3), fixedLineNameResolver, false);
+				threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, new Integer(3), this.fixedLineNameResolver, false);
 		assertEquals("Incorrect three way cross generation where female parent is null ", "Unknown//B/C",
 				resultantPedigreeString.getPedigree());
 		assertEquals("We have crated one cross.", 2, resultantPedigreeString.getNumberOfCrosses());
@@ -135,7 +135,7 @@ public class ThreeWayHybridProcessorTest {
 		final ThreeWayHybridProcessor threeWayHybridProcessor = new ThreeWayHybridProcessor();
 
 		final PedigreeString resultantPedigreeString =
-				threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, new Integer(3), fixedLineNameResolver, false);
+				threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, new Integer(3), this.fixedLineNameResolver, false);
 		assertEquals("Incorrect three way cross generation where both parent is null ", "Unknown/Unknown",
 				resultantPedigreeString.getPedigree());
 		assertEquals("We have crated one cross.", 1, resultantPedigreeString.getNumberOfCrosses());
@@ -148,14 +148,14 @@ public class ThreeWayHybridProcessorTest {
 		final GermplasmNode femaleParent =
 			PedigreeStringTestUtil.createGermplasmNode(1, "FemaleParent1", PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
 				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
-		femaleParent.setFemaleParent(getGrandParents("gFFemale", false));
-		femaleParent.setMaleParent(getGrandParents("gFMale", false));
+		femaleParent.setFemaleParent(this.getGrandParents("gFFemale", false));
+		femaleParent.setMaleParent(this.getGrandParents("gFMale", false));
 
 		final GermplasmNode maleParent =
 			PedigreeStringTestUtil.createGermplasmNode(1, "MaleParent1", PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
 				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);
-		maleParent.setFemaleParent(getGrandParents("gMFemale", false));
-		maleParent.setMaleParent(getGrandParents("gMMale", false));
+		maleParent.setFemaleParent(this.getGrandParents("gMFemale", false));
+		maleParent.setMaleParent(this.getGrandParents("gMMale", false));
 
 		final GermplasmNode threeWayCrossParentNode =
 			PedigreeStringTestUtil.createGermplasmNode(5, "E", PedigreeStringTestUtil.THREE_WAY_CROSS_METHOD_ID,
@@ -167,14 +167,14 @@ public class ThreeWayHybridProcessorTest {
 		final ThreeWayHybridProcessor threeWayHybridProcessor = new ThreeWayHybridProcessor();
 
 		final PedigreeString resultantPedigreeString =
-			threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, 4, fixedLineNameResolver, false);
+			threeWayHybridProcessor.processGermplasmNode(threeWayCrossParentNode, 4, this.fixedLineNameResolver, false);
 		assertEquals("Incorrect three way cross generation where both parent is null ", "gFFemale/gFMale//MaleParent1",
 			resultantPedigreeString.getPedigree());
 		assertEquals("We have crated one cross.", 2, resultantPedigreeString.getNumberOfCrosses());
 
 	}
 
-	public GermplasmNode getGrandParents(final String name, boolean withParent) {
+	public GermplasmNode getGrandParents(final String name, final boolean withParent) {
 		final GermplasmNode germplasm =
 			PedigreeStringTestUtil.createGermplasmNode(6, name, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_ID,
 				PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NAME, PedigreeStringTestUtil.SINGLE_CROSS_METHOD_NUMBER_OF_PROGENITOR);


### PR DESCRIPTION
If null crossing value retain existing value