### PR TITLE
IBP-4241 Remove obsolete index germplsm_idx13, changeset and total count

### DIFF
--- a/src/main/java/org/generationcp/middleware/dao/GermplasmSearchDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/GermplasmSearchDAO.java
@@ -953,7 +953,8 @@ public class GermplasmSearchDAO extends GenericDAO<Germplasm, Integer> {
 	public long countSearchGermplasm(final GermplasmSearchRequest germplasmSearchRequest, final String programUUID) {
 
 		try {
-			// Reusing the same query without filters is expensive. We create a simpler one for count all
+			// Reusing the same query without filters is expensive. We create a simpler one for count all.
+			// Even then, count takes ~ 15s in large db, so it's not executed by default
 			if (germplasmSearchRequest == null) {
 				final SQLQuery sqlQuery =
 					this.getSession().createSQLQuery(" select count(gid) from germplsm g where 1 = 1 " + GERMPLASM_NOT_DELETED_CLAUSE);

--- a/src/main/resources/liquibase/crop_changelog/16_4_1.xml
+++ b/src/main/resources/liquibase/crop_changelog/16_4_1.xml
@@ -4,16 +4,15 @@
 				   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
 		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
-	<changeSet author="nahuel" id="v16.2.0-1">
+	<changeSet author="nahuel" id="v16.4.1-1">
 		<preConditions onFail="MARK_RAN">
-			<not>
+			<and>
 				<indexExists tableName="germplsm" indexName="germplsm_idx13"></indexExists>
-			</not>
+				<changeSetExecuted id="v16.2.0-1" author="nahuel" changeLogFile="liquibase/crop_changelog/16_2_0.xml"></changeSetExecuted>
+			</and>
 		</preConditions>
-		<comment>Add index for germplsm "deleted" column</comment>
-		<createIndex indexName="germplsm_idx13" tableName="germplsm" unique="false">
-			<column name="deleted"></column>
-		</createIndex>
+		<comment>Removes obsolete index germplsm_idx13 created by 16_2_0.xml</comment>
+		<dropIndex tableName="germplsm" indexName="germplsm_idx13"></dropIndex>
 	</changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/liquibase/crop_master.xml
+++ b/src/main/resources/liquibase/crop_master.xml
@@ -64,7 +64,7 @@
 	<include file="crop_changelog/15_4_1.xml" relativeToChangelogFile="true"/>
 	<include file="crop_changelog/15_4_2.xml" relativeToChangelogFile="true"/>
 	<include file="crop_changelog/16_1_0.xml" relativeToChangelogFile="true"/>
-	<include file="crop_changelog/16_2_0.xml" relativeToChangelogFile="true"/>
 	<include file="crop_changelog/16_3_0.xml" relativeToChangelogFile="true"/>
 	<include file="crop_changelog/16_4_0.xml" relativeToChangelogFile="true"/>
+	<include file="crop_changelog/16_4_1.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
It has been detected that germplsm_idx13 affected the performance of
germplasm search filtered count in the uat server.
This index was introduced mainly for the total count, but we saw
omitting this count will greatly improve the overall performance of the
search, and since this count is not of much value for the user, we
remove it altogether.

Middleware
- Remove changeset so that we avoid running the expensive (now
obsolete) index creation for each migration.
- Remove created index wherever the old changeset has run.
BMSAPI / Workbench:
- Remove total count.

Issue: IBP-4241