### PR TITLE
IBP-4320 Force ims_lot_idx01 (eid) in germplasm search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.generationcp</groupId>
 	<artifactId>middleware</artifactId>
 	<packaging>jar</packaging>
-        <version>17.0</version>
+        <version>17.0.1</version>
 	<name>Middleware</name>
 
 	<properties>

--- a/src/main/java/org/generationcp/middleware/dao/GermplasmSearchDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/GermplasmSearchDAO.java
@@ -787,7 +787,10 @@ public class GermplasmSearchDAO extends GenericDAO<Germplasm, Integer> {
 
 		final StringBuilder fromClause = new StringBuilder();
 		fromClause.append("FROM germplsm g \n" //
-			+ " LEFT JOIN ims_lot gl ON gl.eid = g.gid AND gl.etype = 'GERMPLSM' AND gl.status = 0 \n" //
+			+ " LEFT JOIN ims_lot gl"  //
+			// FIXME IBP-4320
+			+ "  FORCE INDEX (ims_lot_idx01)"  //
+			+ "  ON gl.eid = g.gid AND gl.etype = 'GERMPLSM' AND gl.status = 0 \n" //
 			+ " LEFT JOIN cvterm scale ON scale.cvterm_id = gl.scaleid \n" //
 			+ " LEFT JOIN methods m ON m.mid = g.methn \n" //
 			+ " LEFT JOIN location l ON l.locid = g.glocn \n" //


### PR DESCRIPTION
Fixes performance issue caused by sub-optimal query plan