### PR TITLE
IBP-4349-BrapiUseGermplsmGUID

### DIFF
--- a/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmService.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmService.java
@@ -1,5 +1,6 @@
 package org.generationcp.middleware.api.germplasm;
 
+import org.generationcp.middleware.api.brapi.v1.attribute.AttributeDTO;
 import org.generationcp.middleware.api.brapi.v1.germplasm.GermplasmDTO;
 import org.generationcp.middleware.api.brapi.v2.germplasm.GermplasmImportRequest;
 import org.generationcp.middleware.domain.germplasm.GermplasmDto;
@@ -102,5 +103,10 @@ public interface GermplasmService {
 	PedigreeDTO getPedigree(final Integer gid, final String notation, final Boolean includeSiblings);
 
 	ProgenyDTO getProgeny(final Integer gid);
+
+	List<AttributeDTO> getAttributesByGid(
+			String gid, List<String> attributeDbIds, Integer pageSize, Integer pageNumber);
+
+	long countAttributesByGid(String gid, List<String> attributeDbIds);
 
 }

--- a/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmService.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmService.java
@@ -4,6 +4,8 @@ import org.generationcp.middleware.api.brapi.v1.germplasm.GermplasmDTO;
 import org.generationcp.middleware.api.brapi.v2.germplasm.GermplasmImportRequest;
 import org.generationcp.middleware.domain.germplasm.GermplasmDto;
 import org.generationcp.middleware.domain.germplasm.GermplasmUpdateDTO;
+import org.generationcp.middleware.domain.germplasm.PedigreeDTO;
+import org.generationcp.middleware.domain.germplasm.ProgenyDTO;
 import org.generationcp.middleware.domain.germplasm.importation.GermplasmImportRequestDto;
 import org.generationcp.middleware.domain.germplasm.importation.GermplasmImportResponseDto;
 import org.generationcp.middleware.domain.germplasm.importation.GermplasmMatchRequestDto;
@@ -74,7 +76,7 @@ public interface GermplasmService {
 
 	List<GermplasmDTO> searchFilteredGermplasm(GermplasmSearchRequestDto germplasmSearchRequestDTO, Pageable pageable);
 
-	Optional<GermplasmDTO> getGermplasmDTOByGUID(String germplasmGUID);
+	Optional<GermplasmDTO> getGermplasmDTOByGUID(String germplasmUUID);
 
 	long countGermplasmByStudy(Integer studyDbId);
 
@@ -96,5 +98,9 @@ public interface GermplasmService {
 	Set<Integer> getGermplasmUsedInOneOrMoreList(List<Integer> gids);
 
 	Set<Integer> getGermplasmUsedInStudies(List<Integer> gids);
+
+	PedigreeDTO getPedigree(final Integer gid, final String notation, final Boolean includeSiblings);
+
+	ProgenyDTO getProgeny(final Integer gid);
 
 }

--- a/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmService.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmService.java
@@ -100,13 +100,13 @@ public interface GermplasmService {
 
 	Set<Integer> getGermplasmUsedInStudies(List<Integer> gids);
 
-	PedigreeDTO getPedigree(final Integer gid, final String notation, final Boolean includeSiblings);
+	PedigreeDTO getPedigree(Integer gid, String notation, Boolean includeSiblings);
 
 	ProgenyDTO getProgeny(final Integer gid);
 
-	List<AttributeDTO> getAttributesByGid(
-			String gid, List<String> attributeDbIds, Integer pageSize, Integer pageNumber);
+	List<AttributeDTO> getAttributesByGUID(
+			String germplasmUUID, List<String> attributeDbIds, Pageable pageable);
 
-	long countAttributesByGid(String gid, List<String> attributeDbIds);
+	long countAttributesByGUID(String gemrplasmUUID, List<String> attributeDbIds);
 
 }

--- a/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmService.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmService.java
@@ -74,7 +74,7 @@ public interface GermplasmService {
 
 	List<GermplasmDTO> searchFilteredGermplasm(GermplasmSearchRequestDto germplasmSearchRequestDTO, Pageable pageable);
 
-	Optional<GermplasmDTO> getGermplasmDTOByGID(Integer gid);
+	Optional<GermplasmDTO> getGermplasmDTOByGUID(String germplasmGUID);
 
 	long countGermplasmByStudy(Integer studyDbId);
 

--- a/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmServiceImpl.java
@@ -14,6 +14,8 @@ import org.generationcp.middleware.dao.ims.LotDAO;
 import org.generationcp.middleware.domain.germplasm.GermplasmDto;
 import org.generationcp.middleware.domain.germplasm.GermplasmNameDto;
 import org.generationcp.middleware.domain.germplasm.GermplasmUpdateDTO;
+import org.generationcp.middleware.domain.germplasm.PedigreeDTO;
+import org.generationcp.middleware.domain.germplasm.ProgenyDTO;
 import org.generationcp.middleware.domain.germplasm.importation.GermplasmImportDTO;
 import org.generationcp.middleware.domain.germplasm.importation.GermplasmImportResponseDto;
 import org.generationcp.middleware.domain.germplasm.importation.GermplasmMatchRequestDto;
@@ -343,6 +345,16 @@ public class GermplasmServiceImpl implements GermplasmService {
 	@Override
 	public Set<Integer> getGermplasmUsedInStudies(final List<Integer> gids) {
 		return new HashSet<>(this.daoFactory.getStockDao().getGermplasmUsedInStudies(gids));
+	}
+
+	@Override
+	public PedigreeDTO getPedigree(final Integer gid, final String notation, final Boolean includeSiblings) {
+		return this.daoFactory.getGermplasmDao().getPedigree(gid, notation, includeSiblings);
+	}
+
+	@Override
+	public ProgenyDTO getProgeny(final Integer gid) {
+		return this.daoFactory.getGermplasmDao().getProgeny(gid);
 	}
 
 	private void saveGermplasmUpdateDTO(final Integer userId, final Map<String, Integer> attributeCodes,
@@ -1009,9 +1021,9 @@ public class GermplasmServiceImpl implements GermplasmService {
 	}
 
 	@Override
-	public Optional<GermplasmDTO> getGermplasmDTOByGUID(final String germplasmGUID) {
+	public Optional<GermplasmDTO> getGermplasmDTOByGUID(final String germplasmUUID) {
 		final GermplasmSearchRequestDto searchDto = new GermplasmSearchRequestDto();
-		searchDto.setGermplasmDbIds(Collections.singletonList(germplasmGUID));
+		searchDto.setGermplasmDbIds(Collections.singletonList(germplasmUUID));
 		final List<GermplasmDTO> germplasmDTOS = this.searchFilteredGermplasm(searchDto,  new PageRequest(0, 1));
 		if (!CollectionUtils.isEmpty(germplasmDTOS)) {
 			return Optional.of(germplasmDTOS.get(0));

--- a/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmServiceImpl.java
@@ -1009,9 +1009,9 @@ public class GermplasmServiceImpl implements GermplasmService {
 	}
 
 	@Override
-	public Optional<GermplasmDTO> getGermplasmDTOByGID(final Integer gid) {
+	public Optional<GermplasmDTO> getGermplasmDTOByGUID(final String germplasmGUID) {
 		final GermplasmSearchRequestDto searchDto = new GermplasmSearchRequestDto();
-		searchDto.setGermplasmDbIds(Collections.singletonList(String.valueOf(gid)));
+		searchDto.setGermplasmDbIds(Collections.singletonList(germplasmGUID));
 		final List<GermplasmDTO> germplasmDTOS = this.searchFilteredGermplasm(searchDto,  new PageRequest(0, 1));
 		if (!CollectionUtils.isEmpty(germplasmDTOS)) {
 			return Optional.of(germplasmDTOS.get(0));

--- a/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmServiceImpl.java
@@ -359,14 +359,14 @@ public class GermplasmServiceImpl implements GermplasmService {
 	}
 
 	@Override
-	public List<AttributeDTO> getAttributesByGid(
-			final String gid, final List<String> attributeDbIds, final Integer pageSize, final Integer pageNumber) {
-		return this.daoFactory.getAttributeDAO().getAttributesByGidAndAttributeIds(gid, attributeDbIds, pageSize, pageNumber);
+	public List<AttributeDTO> getAttributesByGUID(
+			final String germplasmUUID, final List<String> attributeDbIds, final Pageable pageable) {
+		return this.daoFactory.getAttributeDAO().getAttributesByGUIDAndAttributeIds(germplasmUUID, attributeDbIds, pageable);
 	}
 
 	@Override
-	public long countAttributesByGid(final String gid, final List<String> attributeDbIds) {
-		return this.daoFactory.getAttributeDAO().countAttributesByGid(gid, attributeDbIds);
+	public long countAttributesByGUID(final String gemrplasmUUID, final List<String> attributeDbIds) {
+		return this.daoFactory.getAttributeDAO().countAttributesByGUID(gemrplasmUUID, attributeDbIds);
 	}
 
 	private void saveGermplasmUpdateDTO(final Integer userId, final Map<String, Integer> attributeCodes,

--- a/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasm/GermplasmServiceImpl.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
+import org.generationcp.middleware.api.brapi.v1.attribute.AttributeDTO;
 import org.generationcp.middleware.api.brapi.v1.germplasm.GermplasmDTO;
 import org.generationcp.middleware.api.brapi.v2.germplasm.GermplasmImportRequest;
 import org.generationcp.middleware.api.brapi.v2.germplasm.Synonym;
@@ -355,6 +356,17 @@ public class GermplasmServiceImpl implements GermplasmService {
 	@Override
 	public ProgenyDTO getProgeny(final Integer gid) {
 		return this.daoFactory.getGermplasmDao().getProgeny(gid);
+	}
+
+	@Override
+	public List<AttributeDTO> getAttributesByGid(
+			final String gid, final List<String> attributeDbIds, final Integer pageSize, final Integer pageNumber) {
+		return this.daoFactory.getAttributeDAO().getAttributesByGidAndAttributeIds(gid, attributeDbIds, pageSize, pageNumber);
+	}
+
+	@Override
+	public long countAttributesByGid(final String gid, final List<String> attributeDbIds) {
+		return this.daoFactory.getAttributeDAO().countAttributesByGid(gid, attributeDbIds);
 	}
 
 	private void saveGermplasmUpdateDTO(final Integer userId, final Map<String, Integer> attributeCodes,

--- a/src/main/java/org/generationcp/middleware/api/inventory/study/StudyTransactionsDto.java
+++ b/src/main/java/org/generationcp/middleware/api/inventory/study/StudyTransactionsDto.java
@@ -15,10 +15,10 @@ public class StudyTransactionsDto extends TransactionDto {
 		final Double amount, final Double lotAvailableBalance, final String notes, final Date createdDate, final Integer lotId, final String lotUUID,
 		final Integer gid, final String designation, final String stockId, final Integer scaleId, final String scaleName,
 		final String lotStatus, final String transactionStatus, final Integer locationId, final String locationName,
-		final String locationAbbr, final String comments) {
+		final String locationAbbr, final String comments, final String germplasmUUID) {
 
 		super(transactionId, createdByUsername, transactionType, amount, lotAvailableBalance, notes, createdDate, lotId, lotUUID, gid, designation, stockId,
-			scaleId, scaleName, lotStatus, transactionStatus, locationId, locationName, locationAbbr, comments);
+			scaleId, scaleName, lotStatus, transactionStatus, locationId, locationName, locationAbbr, comments, germplasmUUID);
 		this.observationUnits = new ArrayList<>();
 	}
 

--- a/src/main/java/org/generationcp/middleware/dao/AttributeDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/AttributeDAO.java
@@ -151,7 +151,7 @@ public class AttributeDAO extends GenericDAO<Attribute, Integer> {
 			final SQLQuery query = this.getSession().createSQLQuery(sql);
 			query.addScalar("attributeCode").addScalar("attributeDbId").addScalar("attributeName").addScalar("determinedDate")
 				.addScalar("value");
-			query.setParameter("gid", germplasmUUID);
+			query.setParameter("germplasmUUID", germplasmUUID);
 
 			if (attributeIds != null && !attributeIds.isEmpty()) {
 				query.setParameterList("attributs", attributeIds);
@@ -218,8 +218,8 @@ public class AttributeDAO extends GenericDAO<Attribute, Integer> {
 			+ "    atributs a"
 			+ "        INNER JOIN"
 			+ "    udflds u ON a.atype = u.fldno "
-			+ "        IINER JOIN"
-			+ "    gemrplsm g ON a.gid = g.gid "
+			+ "        INNER JOIN"
+			+ "    germplsm g ON a.gid = g.gid "
 			+ " WHERE"
 			+ "    g.germplsm_uuid = :germplasmUUID AND u.ftable = 'ATRIBUTS'";
 

--- a/src/main/java/org/generationcp/middleware/dao/AttributeDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/AttributeDAO.java
@@ -144,9 +144,9 @@ public class AttributeDAO extends GenericDAO<Attribute, Integer> {
 	public List<AttributeDTO> getAttributesByGUIDAndAttributeIds(
 			final String germplasmUUID, final List<String> attributeIds, final Pageable pageable) {
 
-		List<AttributeDTO> attributes;
+		final List<AttributeDTO> attributes;
 		try {
-			String sql = this.buildQueryForAttributes(attributeIds);
+			final String sql = this.buildQueryForAttributes(attributeIds);
 
 			final SQLQuery query = this.getSession().createSQLQuery(sql);
 			query.addScalar("attributeCode").addScalar("attributeDbId").addScalar("attributeName").addScalar("determinedDate")

--- a/src/main/java/org/generationcp/middleware/dao/AttributeDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/AttributeDAO.java
@@ -157,10 +157,7 @@ public class AttributeDAO extends GenericDAO<Attribute, Integer> {
 				query.setParameterList("attributs", attributeIds);
 			}
 
-			if (pageable != null) {
-				query.setFirstResult(pageable.getPageSize() * (pageable.getPageNumber() - 1));
-				query.setMaxResults(pageable.getPageSize());
-			}
+			addPaginationToSQLQuery(query, pageable);
 
 			query.setResultTransformer(Transformers.aliasToBean(AttributeDTO.class));
 

--- a/src/main/java/org/generationcp/middleware/dao/GermplasmDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/GermplasmDAO.java
@@ -757,7 +757,7 @@ public class GermplasmDAO extends GenericDAO<Germplasm, Integer> {
 	public PedigreeDTO getPedigree(final Integer germplasmDbId, final String notation, final Boolean includeSiblings) {
 		try {
 			final String query = "SELECT "
-				+ "   g.gid as germplasmDbId," //
+				+ "   g.germplsm_uuid as germplasmDbId," // use gid as germplasmDbId
 				+ "   (select n.nval from names n where n.gid = g.gid AND n.nstat = 1) as defaultDisplayName," //
 				+ "   CONCAT(m.mcode, '|', m.mname, '|', m.mtype) AS crossingPlan," //
 				+ "   year(str_to_date(g.gdate, '%Y%m%d')) as crossingYear," //
@@ -794,7 +794,7 @@ public class GermplasmDAO extends GenericDAO<Germplasm, Integer> {
 			}
 
 			final String siblingsQuery = "SELECT" //
-				+ "   sibling.gid AS germplasmDbId," //
+				+ "   sibling.germplsm_uuid AS germplasmDbId," //
 				+ "   n.nval AS defaultDisplayName" //
 				+ " FROM germplsm g" //
 				+ "   INNER JOIN germplsm sibling ON sibling.gpid1 = g.gpid1"//
@@ -859,7 +859,7 @@ public class GermplasmDAO extends GenericDAO<Germplasm, Integer> {
 				.list();
 
 			final ProgenyDTO progenyDTO = new ProgenyDTO();
-			progenyDTO.setGermplasmDbId(germplasm.getGid());
+			progenyDTO.setGermplasmDbId(germplasm.getGermplasmUUID());
 			progenyDTO.setDefaultDisplayName(germplasm.getPreferredName().getNval());
 
 			progenyDTO.setProgeny(progeny);

--- a/src/main/java/org/generationcp/middleware/dao/GermplasmDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/GermplasmDAO.java
@@ -706,7 +706,7 @@ public class GermplasmDAO extends GenericDAO<Germplasm, Integer> {
 			// = Record is not deleted or replaced.
 			generativeChildrenCriteria.add(Restrictions.eq(GermplasmDAO.DELETED, Boolean.FALSE));
 
-			final List<Germplasm> children = new ArrayList<>(generativeChildrenCriteria.getExecutableCriteria(this.getSession()).list());
+			final List<Germplasm> children = new ArrayList<Germplasm>(generativeChildrenCriteria.getExecutableCriteria(this.getSession()).list());
 
 			// Find additional children via progenitor linkage
 			final DetachedCriteria otherChildrenCriteria = DetachedCriteria.forClass(Progenitor.class);
@@ -827,7 +827,7 @@ public class GermplasmDAO extends GenericDAO<Germplasm, Integer> {
 			}
 
 			final String query = "SELECT" //
-				+ "   progeny.gid as germplasmDbId," //
+				+ "   progeny.germplsm_uuid as germplasmDbId," //
 				+ "   name.nval as defaultDisplayName," //
 				+ "   CASE" //
 				+ "   WHEN progeny.gnpgs = -1" //

--- a/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.util.CollectionUtils;
 
 import java.math.BigInteger;
 import java.text.SimpleDateFormat;
@@ -519,6 +520,10 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 				paramBuilder.setParameter("stockId", stockId + '%');
 			}
 
+			if (!CollectionUtils.isEmpty(lotsSearchDto.getGermplasmGUIDs())) {
+				paramBuilder.append(" and g.germplsm_uuid IN (:germplasmGuids)");
+				paramBuilder.setParameterList("germplasmGuids", lotsSearchDto.getGermplasmGUIDs());
+			}
 		}
 		paramBuilder.append(" GROUP BY lot.lotid ");
 

--- a/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
@@ -521,9 +521,9 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 				paramBuilder.setParameter("stockId", stockId + '%');
 			}
 
-			if (!CollectionUtils.isEmpty(lotsSearchDto.getGermplasmGUIDs())) {
+			if (!CollectionUtils.isEmpty(lotsSearchDto.getGermplasmUUIDs())) {
 				paramBuilder.append(" and g.germplsm_uuid IN (:germplasmGuids)");
-				paramBuilder.setParameterList("germplasmGuids", lotsSearchDto.getGermplasmGUIDs());
+				paramBuilder.setParameterList("germplasmGuids", lotsSearchDto.getGermplasmUUIDs());
 			}
 		}
 		paramBuilder.append(" GROUP BY lot.lotid ");

--- a/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
@@ -412,7 +412,8 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 		+ "  users.uname as createdByUsername, " //
 		+ "  lot.created_date as createdDate, " //
 		+ "  MAX(CASE WHEN transaction.trnstat = " + TransactionStatus.CONFIRMED.getIntValue() + " AND transaction.trnqty >= 0 THEN transaction.trndate ELSE null END) AS lastDepositDate, " //
-		+ "  MAX(CASE WHEN transaction.trnstat = " + TransactionStatus.CONFIRMED.getIntValue() + " AND transaction.trnqty < 0 THEN transaction.trndate ELSE null END) AS lastWithdrawalDate " //
+		+ "  MAX(CASE WHEN transaction.trnstat = " + TransactionStatus.CONFIRMED.getIntValue() + " AND transaction.trnqty < 0 THEN transaction.trndate ELSE null END) AS lastWithdrawalDate, " //
+		+ "  g.germplsm_uuid as germplasmUUID " //
 		+ "FROM ims_lot lot " //
 		+ "       LEFT JOIN ims_transaction transaction ON transaction.lotid = lot.lotid AND transaction.trnstat <> " + TransactionStatus.CANCELLED.getIntValue()  //
 		+ "       INNER JOIN germplsm g on g.gid = lot.eid " //
@@ -715,6 +716,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 			query.addScalar("createdDate", DateType.INSTANCE);
 			query.addScalar("lastDepositDate", DateType.INSTANCE);
 			query.addScalar("lastWithdrawalDate",DateType.INSTANCE);
+			query.addScalar("germplasmUUID");
 
 			query.setResultTransformer(Transformers.aliasToBean(ExtendedLotDto.class));
 

--- a/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
@@ -95,40 +95,40 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 			+ " where lot.eid in (:gids) AND lot.etype = 'GERMPLSM' AND lot.status <> 9 ORDER BY lot.eid";
 
 	@SuppressWarnings("unchecked")
-	public List<Lot> getByEntityType(String type, int start, int numOfRows) throws MiddlewareQueryException {
+	public List<Lot> getByEntityType(final String type, final int start, final int numOfRows) throws MiddlewareQueryException {
 		try {
-			Criteria criteria = this.getSession().createCriteria(Lot.class);
+			final Criteria criteria = this.getSession().createCriteria(Lot.class);
 			criteria.add(Restrictions.eq(ENTITY_TYPE, type));
 			criteria.setFirstResult(start);
 			criteria.setMaxResults(numOfRows);
 			return criteria.list();
-		} catch (HibernateException e) {
+		} catch (final HibernateException e) {
 			this.logAndThrowException("Error with getByEntityType(type=" + type + QUERY_FROM_LOT + e.getMessage(), e);
 		}
 		return new ArrayList<Lot>();
 	}
 
 	@SuppressWarnings("unchecked")
-	public Map<Integer, BigInteger> countLotsWithAvailableBalance(List<Integer> gids) throws MiddlewareQueryException {
-		Map<Integer, BigInteger> lotCounts = new HashMap<Integer, BigInteger>();
+	public Map<Integer, BigInteger> countLotsWithAvailableBalance(final List<Integer> gids) throws MiddlewareQueryException {
+		final Map<Integer, BigInteger> lotCounts = new HashMap<Integer, BigInteger>();
 
 		try {
-			String sql = "SELECT entity_id, CAST(SUM(CASE WHEN avail_bal = 0 THEN 0 ELSE 1 END) AS UNSIGNED) FROM ( "
+			final String sql = "SELECT entity_id, CAST(SUM(CASE WHEN avail_bal = 0 THEN 0 ELSE 1 END) AS UNSIGNED) FROM ( "
 					+ "SELECT i.lotid, i.eid AS entity_id, " + "   SUM(trnqty) AS avail_bal " + "  FROM ims_lot i "
 					+ "  LEFT JOIN ims_transaction act ON act.lotid = i.lotid AND act.trnstat <> 9 "
 					+ " WHERE i.status = 0 AND i.etype = 'GERMPLSM' AND i.eid  in (:gids) " + " GROUP BY i.lotid ) inv "
 					+ "WHERE avail_bal > -1 " + "GROUP BY entity_id;";
 
-			Query query = this.getSession().createSQLQuery(sql).setParameterList("gids", gids);
-			List<Object[]> result = query.list();
-			for (Object[] row : result) {
-				Integer gid = (Integer) row[0];
-				BigInteger count = (BigInteger) row[1];
+			final Query query = this.getSession().createSQLQuery(sql).setParameterList("gids", gids);
+			final List<Object[]> result = query.list();
+			for (final Object[] row : result) {
+				final Integer gid = (Integer) row[0];
+				final BigInteger count = (BigInteger) row[1];
 
 				lotCounts.put(gid, count);
 			}
 
-		} catch (Exception e) {
+		} catch (final Exception e) {
 			this.logAndThrowException("Error at countLotsWithAvailableBalance=" + gids + AT_LOT_DAO + e.getMessage(), e);
 		}
 
@@ -136,11 +136,11 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 	}
 
 	@SuppressWarnings("unchecked")
-	public Map<Integer, Object[]> getAvailableBalanceCountAndTotalLotsCount(List<Integer> gids) throws MiddlewareQueryException {
-		Map<Integer, Object[]> lotCounts = new HashMap<Integer, Object[]>();
+	public Map<Integer, Object[]> getAvailableBalanceCountAndTotalLotsCount(final List<Integer> gids) throws MiddlewareQueryException {
+		final Map<Integer, Object[]> lotCounts = new HashMap<Integer, Object[]>();
 
 		try {
-			String sql = "SELECT entity_id, CAST(SUM(CASE WHEN avail_bal = 0 THEN 0 ELSE 1 END) AS UNSIGNED), Count(DISTINCT lotid) "
+			final String sql = "SELECT entity_id, CAST(SUM(CASE WHEN avail_bal = 0 THEN 0 ELSE 1 END) AS UNSIGNED), Count(DISTINCT lotid) "
 					+ ",sum(avail_bal), count(distinct scaleid), scaleid " + " FROM ( " + "SELECT i.lotid, i.eid AS entity_id, "
 					+ "  SUM(CASE WHEN trnstat = " + TransactionStatus.CONFIRMED.getIntValue() + " OR (trnstat = " + TransactionStatus.PENDING.getIntValue() + " AND trntype = " + TransactionType.WITHDRAWAL.getId()
 					+ ") THEN trnqty ELSE 0 END) AS avail_bal, "
@@ -149,14 +149,14 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 					+ " WHERE i.status = 0 AND i.etype = 'GERMPLSM' AND i.eid  in (:gids) " + " GROUP BY i.lotid ) inv "
 					+ "WHERE avail_bal > -1 " + "GROUP BY entity_id;";
 
-			Query query = this.getSession().createSQLQuery(sql).setParameterList("gids", gids);
-			List<Object[]> result = query.list();
-			for (Object[] row : result) {
-				Integer gid = (Integer) row[0];
-				BigInteger lotsWithAvailableBalance = (BigInteger) row[1];
-				BigInteger lotCount = (BigInteger) row[2];
-				Double availableBalance = (Double) row[3];
-				BigInteger distinctScaleIdCount = (BigInteger) row[4];
+			final Query query = this.getSession().createSQLQuery(sql).setParameterList("gids", gids);
+			final List<Object[]> result = query.list();
+			for (final Object[] row : result) {
+				final Integer gid = (Integer) row[0];
+				final BigInteger lotsWithAvailableBalance = (BigInteger) row[1];
+				final BigInteger lotCount = (BigInteger) row[2];
+				final Double availableBalance = (Double) row[3];
+				final BigInteger distinctScaleIdCount = (BigInteger) row[4];
 				Integer allLotsScaleId = null;
 				if (row[5] != null) {
 					allLotsScaleId = (Integer) row[5];
@@ -166,32 +166,32 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 						new Object[] {lotsWithAvailableBalance, lotCount, availableBalance, distinctScaleIdCount, allLotsScaleId});
 			}
 
-		} catch (Exception e) {
+		} catch (final Exception e) {
 			this.logAndThrowException("Error at countLotsWithAvailableBalanceAndTotalLots=" + gids + AT_LOT_DAO + e.getMessage(), e);
 		}
 
 		return lotCounts;
 	}
 
-	public List<Lot> getLotAggregateDataForListEntry(Integer listId, Integer gid) throws MiddlewareQueryException {
-		List<Lot> lots = new ArrayList<Lot>();
+	public List<Lot> getLotAggregateDataForListEntry(final Integer listId, final Integer gid) throws MiddlewareQueryException {
+		final List<Lot> lots = new ArrayList<Lot>();
 
 		try {
-			String sql = LotDAO.GET_LOTS_FOR_LIST_ENTRIES + " ORDER by lot.lotid ";
+			final String sql = LotDAO.GET_LOTS_FOR_LIST_ENTRIES + " ORDER by lot.lotid ";
 
-			Query query = this.getSession().createSQLQuery(sql);
+			final Query query = this.getSession().createSQLQuery(sql);
 			query.setParameterList("gids", Collections.singletonList(gid));
 			query.setParameter("listId", listId);
 			query.setParameter("includeCloseLots", 1);
 
-			List<Integer> statusList = Lists.newArrayList();
+			final List<Integer> statusList = Lists.newArrayList();
 			statusList.add(0);
 			statusList.add(1);
 			query.setParameterList("statusList", statusList);
 
 			this.createLotRows(lots, query, true);
 
-		} catch (Exception e) {
+		} catch (final Exception e) {
 			this.logAndThrowException(
 					"Error at getLotAggregateDataForListEntry for list ID = " + listId + " and GID = " + gid + AT_LOT_DAO + e.getMessage(),
 					e);
@@ -199,42 +199,42 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 		return lots;
 	}
 
-	public List<Lot> getLotAggregateDataForGermplasm(Integer gid) throws MiddlewareQueryException {
-		List<Lot> lots = new ArrayList<Lot>();
+	public List<Lot> getLotAggregateDataForGermplasm(final Integer gid) throws MiddlewareQueryException {
+		final List<Lot> lots = new ArrayList<Lot>();
 
 		try {
-			String sql = LotDAO.GET_LOTS_FOR_GERMPLASM + "ORDER by lotid ";
+			final String sql = LotDAO.GET_LOTS_FOR_GERMPLASM + "ORDER by lotid ";
 
-			Query query = this.getSession().createSQLQuery(sql);
+			final Query query = this.getSession().createSQLQuery(sql);
 			query.setParameterList("gids", Collections.singleton(gid));
 			query.setParameter("includeCloseLots", 1);
 
 			this.createLotRows(lots, query, false);
 
-		} catch (Exception e) {
+		} catch (final Exception e) {
 			this.logAndThrowException("Error at getLotAggregateDataForGermplasm for GID = " + gid + AT_LOT_DAO + e.getMessage(), e);
 		}
 
 		return lots;
 	}
 
-	public Map<Integer, Object[]> getLotStatusDataForGermplasm(Integer gid) throws MiddlewareQueryException {
-		Map<Integer, Object[]> lotStatusCounts = new HashMap<Integer, Object[]>();
+	public Map<Integer, Object[]> getLotStatusDataForGermplasm(final Integer gid) throws MiddlewareQueryException {
+		final Map<Integer, Object[]> lotStatusCounts = new HashMap<Integer, Object[]>();
 
 		try {
-			String sql = LotDAO.GET_LOTS_STATUS_FOR_GERMPLASM;
+			final String sql = LotDAO.GET_LOTS_STATUS_FOR_GERMPLASM;
 
-			Query query = this.getSession().createSQLQuery(sql).setParameterList("gids", Collections.singletonList(gid));
-			List<Object[]> result = query.list();
-			for (Object[] row : result) {
-				Integer lotId = (Integer) row[0];
-				BigInteger lotDistinctStatusCount = (BigInteger) row[1];
-				Integer distinctStatus = (Integer) row[2];
+			final Query query = this.getSession().createSQLQuery(sql).setParameterList("gids", Collections.singletonList(gid));
+			final List<Object[]> result = query.list();
+			for (final Object[] row : result) {
+				final Integer lotId = (Integer) row[0];
+				final BigInteger lotDistinctStatusCount = (BigInteger) row[1];
+				final Integer distinctStatus = (Integer) row[2];
 
 				lotStatusCounts.put(lotId, new Object[] {lotDistinctStatusCount, distinctStatus});
 			}
 
-		} catch (Exception e) {
+		} catch (final Exception e) {
 			this.logAndThrowException("Error at getLotStatusDataForGermplasm for GID = " + gid + AT_LOT_DAO + e.getMessage(), e);
 		}
 
@@ -242,21 +242,21 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 	}
 
 	public List<Object[]> retrieveLotScalesForGermplasms(final List<Integer> gids) throws MiddlewareQueryException {
-		List<Object[]> lotScalesForGermplasm = new ArrayList<>();
+		final List<Object[]> lotScalesForGermplasm = new ArrayList<>();
 
 		try {
-			String sql = LotDAO.GET_LOT_SCALE_FOR_GERMPLSMS;
+			final String sql = LotDAO.GET_LOT_SCALE_FOR_GERMPLSMS;
 
-			Query query = this.getSession().createSQLQuery(sql).setParameterList("gids", gids);
-			List<Object[]> result = query.list();
-			for (Object[] row : result) {
-				Integer gid = (Integer) row[0];
-				Integer scaleId = (Integer) row[1];
-				String scaleName = (String) row[2];
+			final Query query = this.getSession().createSQLQuery(sql).setParameterList("gids", gids);
+			final List<Object[]> result = query.list();
+			for (final Object[] row : result) {
+				final Integer gid = (Integer) row[0];
+				final Integer scaleId = (Integer) row[1];
+				final String scaleName = (String) row[2];
 				lotScalesForGermplasm.add(new Object[] {gid, scaleId, scaleName});
 			}
 
-		} catch (Exception e) {
+		} catch (final Exception e) {
 			this.logAndThrowException("Error at retrieveLotScalesForGermplasms for GIDss = " + gids + AT_LOT_DAO + e.getMessage(), e);
 		}
 
@@ -265,7 +265,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 
 	public Set<Integer> getGermplasmsWithOpenLots(final List<Integer> gids) {
 		try {
-			Query query = this.getSession().createSQLQuery("select distinct (i.eid) FROM ims_lot i "
+			final Query query = this.getSession().createSQLQuery("select distinct (i.eid) FROM ims_lot i "
 				+ "WHERE i.status = 0 AND i.etype = 'GERMPLSM' AND i.eid  IN (:gids) GROUP BY i.lotid ")
 				.setParameterList("gids", gids);
 			return Sets.newHashSet(query.list());
@@ -276,33 +276,33 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 	}
 
 	@SuppressWarnings("unchecked")
-	private void createLotRows(List<Lot> lots, Query query, boolean withReservationMap) {
-		List<Object[]> result = query.list();
+	private void createLotRows(final List<Lot> lots, final Query query, final boolean withReservationMap) {
+		final List<Object[]> result = query.list();
 
 		Map<Integer, Double> reservationMap = null;
 		Map<Integer, Double> committedMap = null;
 		Map<Integer, Set<String>> reservationStatusMap = null;
 		Lot lot = null;
 
-		for (Object[] row : result) {
-			Integer lotId = (Integer) row[0];
+		for (final Object[] row : result) {
+			final Integer lotId = (Integer) row[0];
 			if (lot == null || !lot.getId().equals(lotId)) {
 				if (lot != null && reservationMap != null && committedMap != null) {
 					lot.getAggregateData().setReservationMap(reservationMap);
 					lot.getAggregateData().setReservationStatusMap(reservationStatusMap);
 					lot.getAggregateData().setCommittedMap(committedMap);
 				}
-				Integer entityId = (Integer) row[1];
-				Integer locationId = (Integer) row[2];
-				Integer scaleId = (Integer) row[3];
-				String comments = (String) row[4];
-				Integer lotStatus = (Integer) row[5];
-				Double actualBalance = (Double) row[6];
-				Double availableBalance = (Double) row[7];
-				Double reservedTotal = (Double) row[8];
-				Double committedTotal = (Double) row[9];
-				String stockIds = (String) row[10];
-				Date createdDate = (Date) row[11];
+				final Integer entityId = (Integer) row[1];
+				final Integer locationId = (Integer) row[2];
+				final Integer scaleId = (Integer) row[3];
+				final String comments = (String) row[4];
+				final Integer lotStatus = (Integer) row[5];
+				final Double actualBalance = (Double) row[6];
+				final Double availableBalance = (Double) row[7];
+				final Double reservedTotal = (Double) row[8];
+				final Double committedTotal = (Double) row[9];
+				final String stockIds = (String) row[10];
+				final Date createdDate = (Date) row[11];
 
 				lot = new Lot(lotId);
 				lot.setEntityId(entityId);
@@ -312,7 +312,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 				lot.setStatus(lotStatus);
 				lot.setCreatedDate(createdDate);
 
-				LotAggregateData aggregateData = new LotAggregateData(lotId);
+				final LotAggregateData aggregateData = new LotAggregateData(lotId);
 				aggregateData.setActualBalance(actualBalance);
 				aggregateData.setAvailableBalance(availableBalance);
 				aggregateData.setReservedTotal(reservedTotal);
@@ -334,9 +334,9 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 			}
 
 			if (withReservationMap) {
-				Integer recordId = (Integer) row[12];
-				Double qty = (Double) row[13];
-				Integer transactionState = (Integer) row[14];
+				final Integer recordId = (Integer) row[12];
+				final Double qty = (Double) row[13];
+				final Integer transactionState = (Integer) row[14];
 
 				// compute total reserved and committed for entry
 				if (recordId != null && qty != null && transactionState != null) {
@@ -366,7 +366,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 				}
 
 				if (row[15] != null) {
-					Integer transactionId = (Integer) row[15];
+					final Integer transactionId = (Integer) row[15];
 					lot.getAggregateData().setTransactionId(transactionId);
 				}
 
@@ -685,7 +685,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 
 	public List<ExtendedLotDto> searchLots(final LotsSearchDto lotsSearchDto, final Pageable pageable) {
 		try {
-			final StringBuilder searchLotQuerySql = new StringBuilder(SEARCH_LOT_QUERY);
+			final StringBuilder searchLotQuerySql = new StringBuilder(this.SEARCH_LOT_QUERY);
 			addSearchLotsQueryFiltersAndGroupBy(new SqlQueryParamBuilder(searchLotQuerySql), lotsSearchDto);
 			addSortToSearchLotsQuery(searchLotQuerySql, pageable);
 
@@ -731,7 +731,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 
 	public long countSearchLots(final LotsSearchDto lotsSearchDto) {
 		try {
-			final StringBuilder filteredLotsQuery = new StringBuilder(SEARCH_LOT_QUERY);
+			final StringBuilder filteredLotsQuery = new StringBuilder(this.SEARCH_LOT_QUERY);
 			addSearchLotsQueryFiltersAndGroupBy(new SqlQueryParamBuilder(filteredLotsQuery), lotsSearchDto);
 			final String countLotsQuery = "Select count(1) from (" + filteredLotsQuery + ") as filteredLots";
 			final SQLQuery query = this.getSession().createSQLQuery(countLotsQuery.toString());
@@ -745,7 +745,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 
 	public List<UserDefinedField> getGermplasmAttributeTypes(final LotsSearchDto searchDto) {
 		try {
-			final StringBuilder lotsQuery = new StringBuilder(SEARCH_LOT_QUERY);
+			final StringBuilder lotsQuery = new StringBuilder(this.SEARCH_LOT_QUERY);
 			addSearchLotsQueryFiltersAndGroupBy(new SqlQueryParamBuilder(lotsQuery), searchDto);
 
 			final String sql = "select distinct {u.*} from atributs a inner join udflds u "
@@ -764,7 +764,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 
 	public Map<Integer, Map<Integer, String>> getGermplasmAttributeValues(final LotsSearchDto searchDto) {
 		try {
-			final StringBuilder lotsQuery = new StringBuilder(SEARCH_LOT_QUERY);
+			final StringBuilder lotsQuery = new StringBuilder(this.SEARCH_LOT_QUERY);
 			addSearchLotsQueryFiltersAndGroupBy(new SqlQueryParamBuilder(lotsQuery), searchDto);
 
 			final String sql = "select distinct {a.*} from atributs a inner join (" + lotsQuery + ") lots on lots.gid = a.gid";
@@ -798,7 +798,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 		try {
 			final Map<String, BigInteger> lotsCountPerScaleName = new HashMap<>();
 
-			final StringBuilder filterLotsQuery = new StringBuilder(SEARCH_LOT_QUERY);
+			final StringBuilder filterLotsQuery = new StringBuilder(this.SEARCH_LOT_QUERY);
 			addSearchLotsQueryFiltersAndGroupBy(new SqlQueryParamBuilder(filterLotsQuery), lotsSearchDto);
 
 			final String countQuery = "SELECT scale.name, count(*) from ("  //
@@ -808,8 +808,8 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 			final SQLQuery query = this.getSession().createSQLQuery(countQuery);
 			addSearchLotsQueryFiltersAndGroupBy(new SqlQueryParamBuilder(query), lotsSearchDto);
 
-			List<Object[]> result = query.list();
-			for (Object[] row : result) {
+			final List<Object[]> result = query.list();
+			for (final Object[] row : result) {
 				final String scaleName = (String) row[0];
 
 				final BigInteger count = (BigInteger) row[1];
@@ -878,7 +878,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 
 	public void closeLots(final List<Integer> lotIds) {
 		try {
-			String hqlUpdate = "update Lot l set l.status= :status where l.id in (:idList)";
+			final String hqlUpdate = "update Lot l set l.status= :status where l.id in (:idList)";
 			this.getSession().createQuery(hqlUpdate)
 				.setParameter("status", LotStatus.CLOSED.getIntValue())
 				.setParameterList("idList", lotIds)

--- a/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/LotDAO.java
@@ -386,7 +386,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 	}
 
 	//New inventory functions, please locate them below this line to help cleaning in the near future.
-	private final String SEARCH_LOT_QUERY = "SELECT lot.lotid as lotId, " //
+	private static final String SEARCH_LOT_QUERY = "SELECT lot.lotid as lotId, " //
 		+ "  lot.lot_uuid AS lotUUID, " //
 		+ "  lot.stock_id AS stockId, " //
 		+ "  lot.eid as gid, " //
@@ -686,7 +686,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 
 	public List<ExtendedLotDto> searchLots(final LotsSearchDto lotsSearchDto, final Pageable pageable) {
 		try {
-			final StringBuilder searchLotQuerySql = new StringBuilder(this.SEARCH_LOT_QUERY);
+			final StringBuilder searchLotQuerySql = new StringBuilder(SEARCH_LOT_QUERY);
 			addSearchLotsQueryFiltersAndGroupBy(new SqlQueryParamBuilder(searchLotQuerySql), lotsSearchDto);
 			addSortToSearchLotsQuery(searchLotQuerySql, pageable);
 
@@ -733,7 +733,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 
 	public long countSearchLots(final LotsSearchDto lotsSearchDto) {
 		try {
-			final StringBuilder filteredLotsQuery = new StringBuilder(this.SEARCH_LOT_QUERY);
+			final StringBuilder filteredLotsQuery = new StringBuilder(SEARCH_LOT_QUERY);
 			addSearchLotsQueryFiltersAndGroupBy(new SqlQueryParamBuilder(filteredLotsQuery), lotsSearchDto);
 			final String countLotsQuery = "Select count(1) from (" + filteredLotsQuery + ") as filteredLots";
 			final SQLQuery query = this.getSession().createSQLQuery(countLotsQuery.toString());
@@ -747,7 +747,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 
 	public List<UserDefinedField> getGermplasmAttributeTypes(final LotsSearchDto searchDto) {
 		try {
-			final StringBuilder lotsQuery = new StringBuilder(this.SEARCH_LOT_QUERY);
+			final StringBuilder lotsQuery = new StringBuilder(SEARCH_LOT_QUERY);
 			addSearchLotsQueryFiltersAndGroupBy(new SqlQueryParamBuilder(lotsQuery), searchDto);
 
 			final String sql = "select distinct {u.*} from atributs a inner join udflds u "
@@ -766,7 +766,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 
 	public Map<Integer, Map<Integer, String>> getGermplasmAttributeValues(final LotsSearchDto searchDto) {
 		try {
-			final StringBuilder lotsQuery = new StringBuilder(this.SEARCH_LOT_QUERY);
+			final StringBuilder lotsQuery = new StringBuilder(SEARCH_LOT_QUERY);
 			addSearchLotsQueryFiltersAndGroupBy(new SqlQueryParamBuilder(lotsQuery), searchDto);
 
 			final String sql = "select distinct {a.*} from atributs a inner join (" + lotsQuery + ") lots on lots.gid = a.gid";
@@ -800,7 +800,7 @@ public class LotDAO extends GenericDAO<Lot, Integer> {
 		try {
 			final Map<String, BigInteger> lotsCountPerScaleName = new HashMap<>();
 
-			final StringBuilder filterLotsQuery = new StringBuilder(this.SEARCH_LOT_QUERY);
+			final StringBuilder filterLotsQuery = new StringBuilder(SEARCH_LOT_QUERY);
 			addSearchLotsQueryFiltersAndGroupBy(new SqlQueryParamBuilder(filterLotsQuery), lotsSearchDto);
 
 			final String countQuery = "SELECT scale.name, count(*) from ("  //

--- a/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
@@ -475,7 +475,7 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 
 	public List<TransactionDto> searchTransactions(final TransactionsSearchDto transactionsSearchDto, final Pageable pageable) {
 		try {
-			final StringBuilder filterTransactionsQuery = new StringBuilder(SEARCH_TRANSACTIONS_QUERY);
+			final StringBuilder filterTransactionsQuery = new StringBuilder(this.SEARCH_TRANSACTIONS_QUERY);
 			addSearchTransactionsFilters(new SqlQueryParamBuilder(filterTransactionsQuery), transactionsSearchDto);
 			addSortToSearchTransactionsQuery(filterTransactionsQuery, pageable);
 
@@ -498,7 +498,7 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 
 	public long countSearchTransactions(final TransactionsSearchDto transactionsSearchDto) {
 		try {
-			final StringBuilder filterTransactionsQuery = new StringBuilder(SEARCH_TRANSACTIONS_QUERY);
+			final StringBuilder filterTransactionsQuery = new StringBuilder(this.SEARCH_TRANSACTIONS_QUERY);
 			addSearchTransactionsFilters(new SqlQueryParamBuilder(filterTransactionsQuery), transactionsSearchDto);
 			final String countTransactionsQuery =
 				"Select count(1) from (" + filterTransactionsQuery.toString() + ") as filteredTransactions";
@@ -515,7 +515,7 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 		try {
 
 			if (lotId != null) {
-				final StringBuilder sql = new StringBuilder(SEARCH_TRANSACTIONS_QUERY);
+				final StringBuilder sql = new StringBuilder(this.SEARCH_TRANSACTIONS_QUERY);
 				sql.append(" and (tr.trnstat =").append(TransactionStatus.CONFIRMED.getIntValue()).append(" or (tr.trnstat = ")
 					.append(TransactionStatus.PENDING.getIntValue()).
 					append(" and tr.trntype = ").append(TransactionType.WITHDRAWAL.getId()).append(")) ");
@@ -724,7 +724,7 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 		final TransactionsSearchDto transactionsSearchDto,
 		final StringBuilder obsUnitsQuerySql) {
 
-		final StringBuilder searchTransactionsQuery = new StringBuilder(SEARCH_TRANSACTIONS_QUERY);
+		final StringBuilder searchTransactionsQuery = new StringBuilder(this.SEARCH_TRANSACTIONS_QUERY);
 		final SqlQueryParamBuilder paramBuilder = new SqlQueryParamBuilder(searchTransactionsQuery);
 		addSearchTransactionsFilters(paramBuilder, transactionsSearchDto);
 		this.excludeCancelledTransactions(paramBuilder);

--- a/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
@@ -29,7 +29,6 @@ import org.generationcp.middleware.pojos.report.TransactionReportRow;
 import org.generationcp.middleware.util.SqlQueryParamBuilder;
 import org.generationcp.middleware.util.Util;
 import org.hibernate.Criteria;
-import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.SQLQuery;
@@ -451,9 +450,9 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 				paramBuilder.setParameterList("harvestingStudyIds", harvestingStudyIds);
 			}
 
-			if (!CollectionUtils.isEmpty(transactionsSearchDto.getGermplasmGuids())) {
+			if (!CollectionUtils.isEmpty(transactionsSearchDto.getGermplasmUUIDs())) {
 				paramBuilder.append(" and g.germplsm_uuid IN (:guids)");
-				paramBuilder.setParameterList("guids", transactionsSearchDto.getGermplasmGuids());
+				paramBuilder.setParameterList("guids", transactionsSearchDto.getGermplasmUUIDs());
 			}
 		}
 	}

--- a/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
@@ -288,7 +288,8 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 		+ " lot.locid as lotLocationId, "
 		+ " loc.lname as lotLocationName, "//
 		+ " loc.labbr as lotLocationAbbr, "//
-		+ " lot.comments as lotComments "
+		+ " lot.comments as lotComments, "//
+		+ " g.germplsm_uuid as gerplsmUUID "
 		+ " FROM"//
 		+ "   ims_transaction tr "//
 		+ "        INNER JOIN"//
@@ -579,7 +580,8 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 				Integer.class,   // locationId
 				String.class,    // locationName
 				String.class,    // locationAbbr
-				String.class     // comments
+				String.class,    // comments
+				String.class     // gerplsmUUID
 			);
 		} catch (final NoSuchMethodException ex) {
 			throw new RuntimeException(ex);
@@ -608,7 +610,8 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 				Integer.class,   // locationId
 				String.class,    // locationName
 				String.class,    // locationAbbr
-				String.class     // comments
+				String.class,    // comments
+				String.class	 // gerplsmUUID
 			);
 		} catch (final NoSuchMethodException ex) {
 			throw new RuntimeException(ex);
@@ -636,6 +639,7 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 		query.addScalar("lotLocationName");
 		query.addScalar("lotLocationAbbr");
 		query.addScalar("lotComments");
+		query.addScalar("gerplsmUUID");
 	}
 
 

--- a/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
@@ -258,7 +258,7 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 	}
 
 	//New inventory functions, please locate them below this line to help cleaning in the near future.
-	private final String SEARCH_TRANSACTIONS_QUERY = "SELECT " //
+	private static final String SEARCH_TRANSACTIONS_QUERY = "SELECT " //
 		+ "    tr.trnid AS transactionId,"//
 		+ "    users.uname AS createdByUsername,"//
 		+ "(CASE WHEN trntype = " + TransactionType.DEPOSIT.getId() + " THEN '" + TransactionType.DEPOSIT.getValue()
@@ -475,7 +475,7 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 
 	public List<TransactionDto> searchTransactions(final TransactionsSearchDto transactionsSearchDto, final Pageable pageable) {
 		try {
-			final StringBuilder filterTransactionsQuery = new StringBuilder(this.SEARCH_TRANSACTIONS_QUERY);
+			final StringBuilder filterTransactionsQuery = new StringBuilder(SEARCH_TRANSACTIONS_QUERY);
 			addSearchTransactionsFilters(new SqlQueryParamBuilder(filterTransactionsQuery), transactionsSearchDto);
 			addSortToSearchTransactionsQuery(filterTransactionsQuery, pageable);
 
@@ -498,7 +498,7 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 
 	public long countSearchTransactions(final TransactionsSearchDto transactionsSearchDto) {
 		try {
-			final StringBuilder filterTransactionsQuery = new StringBuilder(this.SEARCH_TRANSACTIONS_QUERY);
+			final StringBuilder filterTransactionsQuery = new StringBuilder(SEARCH_TRANSACTIONS_QUERY);
 			addSearchTransactionsFilters(new SqlQueryParamBuilder(filterTransactionsQuery), transactionsSearchDto);
 			final String countTransactionsQuery =
 				"Select count(1) from (" + filterTransactionsQuery.toString() + ") as filteredTransactions";
@@ -515,7 +515,7 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 		try {
 
 			if (lotId != null) {
-				final StringBuilder sql = new StringBuilder(this.SEARCH_TRANSACTIONS_QUERY);
+				final StringBuilder sql = new StringBuilder(SEARCH_TRANSACTIONS_QUERY);
 				sql.append(" and (tr.trnstat =").append(TransactionStatus.CONFIRMED.getIntValue()).append(" or (tr.trnstat = ")
 					.append(TransactionStatus.PENDING.getIntValue()).
 					append(" and tr.trntype = ").append(TransactionType.WITHDRAWAL.getId()).append(")) ");
@@ -580,7 +580,7 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 				String.class,    // locationName
 				String.class,    // locationAbbr
 				String.class,    // comments
-				String.class     // gerplsmUUID
+				String.class     // germplsmUUID
 			);
 		} catch (final NoSuchMethodException ex) {
 			throw new RuntimeException(ex);
@@ -610,7 +610,7 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 				String.class,    // locationName
 				String.class,    // locationAbbr
 				String.class,    // comments
-				String.class	 // gerplsmUUID
+				String.class	 // germplsmUUID
 			);
 		} catch (final NoSuchMethodException ex) {
 			throw new RuntimeException(ex);
@@ -727,7 +727,7 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 		final TransactionsSearchDto transactionsSearchDto,
 		final StringBuilder obsUnitsQuerySql) {
 
-		final StringBuilder searchTransactionsQuery = new StringBuilder(this.SEARCH_TRANSACTIONS_QUERY);
+		final StringBuilder searchTransactionsQuery = new StringBuilder(SEARCH_TRANSACTIONS_QUERY);
 		final SqlQueryParamBuilder paramBuilder = new SqlQueryParamBuilder(searchTransactionsQuery);
 		addSearchTransactionsFilters(paramBuilder, transactionsSearchDto);
 		this.excludeCancelledTransactions(paramBuilder);

--- a/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/ims/TransactionDAO.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.util.CollectionUtils;
 
 import java.lang.reflect.Constructor;
 import java.math.BigInteger;
@@ -447,6 +448,11 @@ public class TransactionDAO extends GenericDAO<Transaction, Integer> {
 					+ "                and study_filter_iet.type = " + ExperimentTransactionType.HARVESTING.getId()
 					+ " where study_filter_p.project_id in (:harvestingStudyIds) and study_filter_iet.trnid = tr.trnid)"); //
 				paramBuilder.setParameterList("harvestingStudyIds", harvestingStudyIds);
+			}
+
+			if (!CollectionUtils.isEmpty(transactionsSearchDto.getGermplasmGuids())) {
+				paramBuilder.append(" and g.germplsm_uuid IN (:guids)");
+				paramBuilder.setParameterList("guids", transactionsSearchDto.getGermplasmGuids());
 			}
 		}
 	}

--- a/src/main/java/org/generationcp/middleware/domain/germplasm/PedigreeDTO.java
+++ b/src/main/java/org/generationcp/middleware/domain/germplasm/PedigreeDTO.java
@@ -9,14 +9,14 @@ import java.util.List;
 public class PedigreeDTO {
 
 	public static class Sibling {
-		private Integer germplasmDbId;
+		private String germplasmDbId;
 		private String defaultDisplayName;
 
-		public Integer getGermplasmDbId() {
+		public String getGermplasmDbId() {
 			return germplasmDbId;
 		}
 
-		public void setGermplasmDbId(final Integer germplasmDbId) {
+		public void setGermplasmDbId(final String germplasmDbId) {
 			this.germplasmDbId = germplasmDbId;
 		}
 
@@ -30,7 +30,7 @@ public class PedigreeDTO {
 
 	}
 
-	private Integer germplasmDbId;
+	private String germplasmDbId;
 	private String defaultDisplayName;
 	private String pedigree;
 	private String crossingPlan;
@@ -44,11 +44,11 @@ public class PedigreeDTO {
 	private String parent2Type;
 	private List<Sibling> siblings;
 
-	public int getGermplasmDbId() {
+	public String getGermplasmDbId() {
 		return germplasmDbId;
 	}
 
-	public void setGermplasmDbId(final Integer germplasmDbId) {
+	public void setGermplasmDbId(final String germplasmDbId) {
 		this.germplasmDbId = germplasmDbId;
 	}
 

--- a/src/main/java/org/generationcp/middleware/domain/germplasm/ProgenyDTO.java
+++ b/src/main/java/org/generationcp/middleware/domain/germplasm/ProgenyDTO.java
@@ -10,15 +10,15 @@ public class ProgenyDTO {
 
 	public static class Progeny {
 
-		private int germplasmDbId;
+		private String germplasmDbId;
 		private String defaultDisplayName;
 		private String parentType;
 
-		public int getGermplasmDbId() {
+		public String getGermplasmDbId() {
 			return germplasmDbId;
 		}
 
-		public void setGermplasmDbId(final int germplasmDbId) {
+		public void setGermplasmDbId(final String germplasmDbId) {
 			this.germplasmDbId = germplasmDbId;
 		}
 
@@ -40,16 +40,16 @@ public class ProgenyDTO {
 	}
 
 
-	private int germplasmDbId;
+	private String germplasmDbId;
 	private String defaultDisplayName;
 	// defined as singular in BrAPI. See also https://github.com/plantbreeding/API/issues/275
 	private List<Progeny> progeny;
 
-	public int getGermplasmDbId() {
+	public String getGermplasmDbId() {
 		return germplasmDbId;
 	}
 
-	public void setGermplasmDbId(final int germplasmDbId) {
+	public void setGermplasmDbId(final String germplasmDbId) {
 		this.germplasmDbId = germplasmDbId;
 	}
 

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/ExtendedLotDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/ExtendedLotDto.java
@@ -60,7 +60,7 @@ public class ExtendedLotDto extends LotDto {
 	private String germplasmUUID;
 
 	public Date getCreatedDate() {
-		return createdDate;
+		return this.createdDate;
 	}
 
 	public void setCreatedDate(final Date createdDate) {
@@ -68,7 +68,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public String getDesignation() {
-		return designation;
+		return this.designation;
 	}
 
 	public void setDesignation(final String designation) {
@@ -76,7 +76,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public Double getActualBalance() {
-		return actualBalance;
+		return this.actualBalance;
 	}
 
 	public void setActualBalance(final Double actualBalance) {
@@ -84,7 +84,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public Double getAvailableBalance() {
-		return availableBalance;
+		return this.availableBalance;
 	}
 
 	public void setAvailableBalance(final Double availableBalance) {
@@ -92,7 +92,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public Double getReservedTotal() {
-		return reservedTotal;
+		return this.reservedTotal;
 	}
 
 	public void setReservedTotal(final Double reservedTotal) {
@@ -100,7 +100,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public Double getWithdrawalTotal() {
-		return withdrawalTotal;
+		return this.withdrawalTotal;
 	}
 
 	public void setWithdrawalTotal(final Double withdrawalTotal) {
@@ -108,7 +108,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public Date getLastDepositDate() {
-		return lastDepositDate;
+		return this.lastDepositDate;
 	}
 
 	public void setLastDepositDate(final Date lastDepositDate) {
@@ -116,7 +116,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public Date getLastWithdrawalDate() {
-		return lastWithdrawalDate;
+		return this.lastWithdrawalDate;
 	}
 
 	public void setLastWithdrawalDate(final Date lastWithdrawalDate) {
@@ -124,7 +124,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public Integer getMgid() {
-		return mgid;
+		return this.mgid;
 	}
 
 	public void setMgid(final Integer mgid) {
@@ -148,7 +148,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public String getLocationName() {
-		return locationName;
+		return this.locationName;
 	}
 
 	public void setLocationName(final String locationName) {
@@ -156,7 +156,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public String getLocationAbbr() {
-		return locationAbbr;
+		return this.locationAbbr;
 	}
 
 	public void setLocationAbbr(final String locationAbbr) {
@@ -164,7 +164,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public String getUnitName() {
-		return unitName;
+		return this.unitName;
 	}
 
 	public void setUnitName(final String unitName) {
@@ -172,7 +172,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public String getCreatedByUsername() {
-		return createdByUsername;
+		return this.createdByUsername;
 	}
 
 	public void setCreatedByUsername(final String createdByUsername) {
@@ -180,7 +180,7 @@ public class ExtendedLotDto extends LotDto {
 	}
 
 	public Double getPendingDepositsTotal() {
-		return pendingDepositsTotal;
+		return this.pendingDepositsTotal;
 	}
 
 	public void setPendingDepositsTotal(final Double pendingDepositsTotal) {

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/ExtendedLotDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/ExtendedLotDto.java
@@ -1,7 +1,7 @@
 package org.generationcp.middleware.domain.inventory.manager;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
 import org.pojomatic.Pojomatic;
 import org.pojomatic.annotations.AutoProperty;
@@ -55,6 +55,9 @@ public class ExtendedLotDto extends LotDto {
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMdd")
 	@JsonView({InventoryView.LotView.class})
 	private Date lastWithdrawalDate;
+
+	@JsonIgnore
+	private String germplasmUUID;
 
 	public Date getCreatedDate() {
 		return createdDate;
@@ -182,6 +185,14 @@ public class ExtendedLotDto extends LotDto {
 
 	public void setPendingDepositsTotal(final Double pendingDepositsTotal) {
 		this.pendingDepositsTotal = pendingDepositsTotal;
+	}
+
+	public String getGermplasmUUID() {
+		return this.germplasmUUID;
+	}
+
+	public void setGermplasmUUID(final String germplasmUUID) {
+		this.germplasmUUID = germplasmUUID;
 	}
 
 	@Override

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotsSearchDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotsSearchDto.java
@@ -84,7 +84,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	private String locationNameContainsString;
 
 	public Integer getStatus() {
-		return status;
+		return this.status;
 	}
 
 	public void setStatus(final Integer status) {
@@ -92,7 +92,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public List<Integer> getLotIds() {
-		return lotIds;
+		return this.lotIds;
 	}
 
 	public void setLotIds(final List<Integer> lotIds) {
@@ -100,7 +100,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public List<String> getLotUUIDs() {
-		return lotUUIDs;
+		return this.lotUUIDs;
 	}
 
 	public void setLotUUIDs(final List<String> lotUUIDs) {
@@ -108,7 +108,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public String getStockId() {
-		return stockId;
+		return this.stockId;
 	}
 
 	public void setStockId(final String stockId) {
@@ -116,7 +116,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public List<Integer> getGids() {
-		return gids;
+		return this.gids;
 	}
 
 	public void setGids(final List<Integer> gids) {
@@ -124,7 +124,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public List<Integer> getMgids() {
-		return mgids;
+		return this.mgids;
 	}
 
 	public void setMgids(final List<Integer> mgids) {
@@ -132,7 +132,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public String getDesignation() {
-		return designation;
+		return this.designation;
 	}
 
 	public void setDesignation(final String designation) {
@@ -140,7 +140,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public List<Integer> getLocationIds() {
-		return locationIds;
+		return this.locationIds;
 	}
 
 	public void setLocationIds(final List<Integer> locationIds) {
@@ -148,7 +148,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public List<Integer> getUnitIds() {
-		return unitIds;
+		return this.unitIds;
 	}
 
 	public void setUnitIds(final List<Integer> unitIds) {
@@ -156,7 +156,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Double getMinActualBalance() {
-		return minActualBalance;
+		return this.minActualBalance;
 	}
 
 	public void setMinActualBalance(final Double minActualBalance) {
@@ -164,7 +164,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Double getMaxActualBalance() {
-		return maxActualBalance;
+		return this.maxActualBalance;
 	}
 
 	public void setMaxActualBalance(final Double maxActualBalance) {
@@ -172,7 +172,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Double getMinAvailableBalance() {
-		return minAvailableBalance;
+		return this.minAvailableBalance;
 	}
 
 	public void setMinAvailableBalance(final Double minAvailableBalance) {
@@ -180,7 +180,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Double getMaxAvailableBalance() {
-		return maxAvailableBalance;
+		return this.maxAvailableBalance;
 	}
 
 	public void setMaxAvailableBalance(final Double maxAvailableBalance) {
@@ -188,7 +188,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Double getMinReservedTotal() {
-		return minReservedTotal;
+		return this.minReservedTotal;
 	}
 
 	public void setMinReservedTotal(final Double minReservedTotal) {
@@ -196,7 +196,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Double getMaxReservedTotal() {
-		return maxReservedTotal;
+		return this.maxReservedTotal;
 	}
 
 	public void setMaxReservedTotal(final Double maxReservedTotal) {
@@ -204,7 +204,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Double getMinWithdrawalTotal() {
-		return minWithdrawalTotal;
+		return this.minWithdrawalTotal;
 	}
 
 	public void setMinWithdrawalTotal(final Double minWithdrawalTotal) {
@@ -212,7 +212,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Double getMaxWithdrawalTotal() {
-		return maxWithdrawalTotal;
+		return this.maxWithdrawalTotal;
 	}
 
 	public void setMaxWithdrawalTotal(final Double maxWithdrawalTotal) {
@@ -220,7 +220,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public String getCreatedByUsername() {
-		return createdByUsername;
+		return this.createdByUsername;
 	}
 
 	public void setCreatedByUsername(final String createdByUsername) {
@@ -228,7 +228,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Date getCreatedDateFrom() {
-		return createdDateFrom;
+		return this.createdDateFrom;
 	}
 
 	public void setCreatedDateFrom(final Date createdDateFrom) {
@@ -236,7 +236,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Date getCreatedDateTo() {
-		return createdDateTo;
+		return this.createdDateTo;
 	}
 
 	public void setCreatedDateTo(final Date createdDateTo) {
@@ -244,7 +244,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Date getLastDepositDateFrom() {
-		return lastDepositDateFrom;
+		return this.lastDepositDateFrom;
 	}
 
 	public void setLastDepositDateFrom(final Date lastDepositDateFrom) {
@@ -252,7 +252,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Date getLastDepositDateTo() {
-		return lastDepositDateTo;
+		return this.lastDepositDateTo;
 	}
 
 	public void setLastDepositDateTo(final Date lastDepositDateTo) {
@@ -260,7 +260,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Date getLastWithdrawalDateFrom() {
-		return lastWithdrawalDateFrom;
+		return this.lastWithdrawalDateFrom;
 	}
 
 	public void setLastWithdrawalDateFrom(final Date lastWithdrawalDateFrom) {
@@ -268,7 +268,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Date getLastWithdrawalDateTo() {
-		return lastWithdrawalDateTo;
+		return this.lastWithdrawalDateTo;
 	}
 
 	public void setLastWithdrawalDateTo(final Date lastWithdrawalDateTo) {
@@ -276,7 +276,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public String getNotesContainsString() {
-		return notesContainsString;
+		return this.notesContainsString;
 	}
 
 	public void setNotesContainsString(final String notesContainsString) {
@@ -284,7 +284,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public List<Integer> getGermplasmListIds() {
-		return germplasmListIds;
+		return this.germplasmListIds;
 	}
 
 	public void setGermplasmListIds(final List<Integer> germplasmListIds) {
@@ -308,7 +308,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public String getLocationNameContainsString() {
-		return locationNameContainsString;
+		return this.locationNameContainsString;
 	}
 
 	public void setLocationNameContainsString(final String locationNameContainsString) {
@@ -316,7 +316,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Double getMinPendingDepositsTotal() {
-		return minPendingDepositsTotal;
+		return this.minPendingDepositsTotal;
 	}
 
 	public void setMinPendingDepositsTotal(final Double minPendingDepositTotal) {
@@ -324,7 +324,7 @@ public class LotsSearchDto extends SearchRequestDto {
 	}
 
 	public Double getMaxPendingDepositsTotal() {
-		return maxPendingDepositsTotal;
+		return this.maxPendingDepositsTotal;
 	}
 
 	public void setMaxPendingDepositsTotal(final Double maxPendingDepositTotal) {

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotsSearchDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotsSearchDto.java
@@ -59,7 +59,7 @@ public class LotsSearchDto extends SearchRequestDto {
 
 	private List<Integer> harvestingStudyIds;
 
-	private List<String> germplasmGUIDs;
+	private List<String> germplasmUUIDs;
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
 	private Date createdDateFrom;
@@ -331,12 +331,12 @@ public class LotsSearchDto extends SearchRequestDto {
 		this.maxPendingDepositsTotal = maxPendingDepositTotal;
 	}
 
-	public List<String> getGermplasmGUIDs() {
-		return this.germplasmGUIDs;
+	public List<String> getGermplasmUUIDs() {
+		return this.germplasmUUIDs;
 	}
 
-	public void setGermplasmGUIDs(final List<String> germplasmGUIDs) {
-		this.germplasmGUIDs = germplasmGUIDs;
+	public void setGermplasmUUIDs(final List<String> germplasmUUIDs) {
+		this.germplasmUUIDs = germplasmUUIDs;
 	}
 
 	@Override

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotsSearchDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/LotsSearchDto.java
@@ -59,6 +59,8 @@ public class LotsSearchDto extends SearchRequestDto {
 
 	private List<Integer> harvestingStudyIds;
 
+	private List<String> germplasmGUIDs;
+
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
 	private Date createdDateFrom;
 
@@ -327,6 +329,14 @@ public class LotsSearchDto extends SearchRequestDto {
 
 	public void setMaxPendingDepositsTotal(final Double maxPendingDepositTotal) {
 		this.maxPendingDepositsTotal = maxPendingDepositTotal;
+	}
+
+	public List<String> getGermplasmGUIDs() {
+		return this.germplasmGUIDs;
+	}
+
+	public void setGermplasmGUIDs(final List<String> germplasmGUIDs) {
+		this.germplasmGUIDs = germplasmGUIDs;
 	}
 
 	@Override

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/TransactionDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/TransactionDto.java
@@ -33,7 +33,7 @@ public class TransactionDto {
 		final Date createdDate, final Integer lotId, final String lotUUID, final Integer gid, final String designation,
 		final String stockId,
 		final Integer scaleId, final String scaleName, final String lotStatus, final String transactionStatus, final Integer locationId,
-		final String locationName, final String locationAbbr, final String comments) {
+		final String locationName, final String locationAbbr, final String comments, final String germplasmUUID) {
 
 		this.transactionId = transactionId;
 		this.createdByUsername = createdByUsername;
@@ -56,6 +56,7 @@ public class TransactionDto {
 		this.lot.setUnitName(scaleName);
 		this.lot.setDesignation(designation);
 		this.lot.setAvailableBalance(lotAvailableBalance);
+		this.lot.setGermplasmUUID(germplasmUUID);
 	}
 
 	public Integer getTransactionId() {

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/TransactionsSearchDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/TransactionsSearchDto.java
@@ -42,7 +42,7 @@ public class TransactionsSearchDto extends SearchRequestDto {
 	private List<Integer> harvestingStudyIds;
 
 	public List<Integer> getGermplasmListIds() {
-		return germplasmListIds;
+		return this.germplasmListIds;
 	}
 
 	public void setGermplasmListIds(final List<Integer> germplasmListIds) {
@@ -170,7 +170,7 @@ public class TransactionsSearchDto extends SearchRequestDto {
 	}
 
 	public List<Integer> getStatusIds() {
-		return statusIds;
+		return this.statusIds;
 	}
 
 	public void setStatusIds(final List<Integer> statusIds) {
@@ -178,7 +178,7 @@ public class TransactionsSearchDto extends SearchRequestDto {
 	}
 
 	public Integer getLotStatus() {
-		return lotStatus;
+		return this.lotStatus;
 	}
 
 	public void setLotStatus(final Integer lotStatus) {
@@ -202,7 +202,7 @@ public class TransactionsSearchDto extends SearchRequestDto {
 	}
 
 	public List<String> getLotUUIDs() {
-		return lotUUIDs;
+		return this.lotUUIDs;
 	}
 
 	public void setLotUUIDs(final List<String> lotUUIDs) {

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/TransactionsSearchDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/TransactionsSearchDto.java
@@ -27,7 +27,7 @@ public class TransactionsSearchDto extends SearchRequestDto {
 	private List<Integer> unitIds;
 	private Double minAmount;
 	private Double maxAmount;
-	private List<String> germplasmGuids;
+	private List<String> germplasmUUIDs;
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
 	private Date createdDateFrom;
@@ -209,12 +209,12 @@ public class TransactionsSearchDto extends SearchRequestDto {
 		this.lotUUIDs = lotUUIDs;
 	}
 
-	public List<String> getGermplasmGuids() {
-		return this.germplasmGuids;
+	public List<String> getGermplasmUUIDs() {
+		return this.germplasmUUIDs;
 	}
 
-	public void setGermplasmGuids(final List<String> germplasmGuids) {
-		this.germplasmGuids = germplasmGuids;
+	public void setGermplasmUUIDs(final List<String> germplasmUUIDs) {
+		this.germplasmUUIDs = germplasmUUIDs;
 	}
 
 	@Override

--- a/src/main/java/org/generationcp/middleware/domain/inventory/manager/TransactionsSearchDto.java
+++ b/src/main/java/org/generationcp/middleware/domain/inventory/manager/TransactionsSearchDto.java
@@ -27,6 +27,7 @@ public class TransactionsSearchDto extends SearchRequestDto {
 	private List<Integer> unitIds;
 	private Double minAmount;
 	private Double maxAmount;
+	private List<String> germplasmGuids;
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
 	private Date createdDateFrom;
@@ -206,6 +207,14 @@ public class TransactionsSearchDto extends SearchRequestDto {
 
 	public void setLotUUIDs(final List<String> lotUUIDs) {
 		this.lotUUIDs = lotUUIDs;
+	}
+
+	public List<String> getGermplasmGuids() {
+		return this.germplasmGuids;
+	}
+
+	public void setGermplasmGuids(final List<String> germplasmGuids) {
+		this.germplasmGuids = germplasmGuids;
 	}
 
 	@Override

--- a/src/main/java/org/generationcp/middleware/manager/GermplasmDataManagerImpl.java
+++ b/src/main/java/org/generationcp/middleware/manager/GermplasmDataManagerImpl.java
@@ -1490,17 +1490,6 @@ public class GermplasmDataManagerImpl extends DataManager implements GermplasmDa
 	}
 
 	@Override
-	public List<AttributeDTO> getAttributesByGid(
-		final String gid, final List<String> attributeDbIds, final Integer pageSize, final Integer pageNumber) {
-		return this.daoFactory.getAttributeDAO().getAttributesByGidAndAttributeIds(gid, attributeDbIds, pageSize, pageNumber);
-	}
-
-	@Override
-	public long countAttributesByGid(final String gid, final List<String> attributeDbIds) {
-		return this.daoFactory.getAttributeDAO().countAttributesByGid(gid, attributeDbIds);
-	}
-
-	@Override
 	public List<Attribute> getAttributeByIds(final List<Integer> ids) {
 		return this.daoFactory.getAttributeDAO().getByIDs(ids);
 	}

--- a/src/main/java/org/generationcp/middleware/manager/GermplasmDataManagerImpl.java
+++ b/src/main/java/org/generationcp/middleware/manager/GermplasmDataManagerImpl.java
@@ -1274,16 +1274,6 @@ public class GermplasmDataManagerImpl extends DataManager implements GermplasmDa
 		return treeNode;
 	}
 
-	@Override
-	public PedigreeDTO getPedigree(final Integer germplasmDbId, final String notation, final Boolean includeSiblings) {
-		return this.daoFactory.getGermplasmDao().getPedigree(germplasmDbId, notation, includeSiblings);
-	}
-
-	@Override
-	public ProgenyDTO getProgeny(final Integer germplasmDbId) {
-		return this.daoFactory.getGermplasmDao().getProgeny(germplasmDbId);
-	}
-
 	/**
 	 * Local method for getting a particular germplasm's Name.
 	 *

--- a/src/main/java/org/generationcp/middleware/manager/api/GermplasmDataManager.java
+++ b/src/main/java/org/generationcp/middleware/manager/api/GermplasmDataManager.java
@@ -990,10 +990,6 @@ public interface GermplasmDataManager {
 	 */
 	Map<Integer, GermplasmPedigreeTreeNode> getDirectParentsForStudy(int studyId);
 
-	PedigreeDTO getPedigree(Integer germplasmDbId, String notation, final Boolean includeSiblings);
-
-	ProgenyDTO getProgeny(Integer germplasmDbId);
-
 	/*
 	 * get the Germplasm from the crop database based on local gid reference
 	 *

--- a/src/main/java/org/generationcp/middleware/manager/api/GermplasmDataManager.java
+++ b/src/main/java/org/generationcp/middleware/manager/api/GermplasmDataManager.java
@@ -1149,11 +1149,6 @@ public interface GermplasmDataManager {
 
 	List<Integer> addOrUpdateGermplasm(final List<Germplasm> germplasms, final Operation operation);
 
-	List<AttributeDTO> getAttributesByGid(
-		String gid, List<String> attributeDbIds, Integer pageSize, Integer pageNumber);
-
-	long countAttributesByGid(String gid, List<String> attributeDbIds);
-
 	List<Attribute> getAttributeByIds(List<Integer> ids);
 
 	List<String> getNamesByGidsAndPrefixes(List<Integer> gids, List<String> prefixes);

--- a/src/test/java/org/generationcp/middleware/dao/AttributeDAOTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/AttributeDAOTest.java
@@ -12,6 +12,7 @@ import org.hibernate.Session;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.util.CollectionUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -23,6 +24,7 @@ public class AttributeDAOTest extends IntegrationTestBase {
 	private AttributeDAO attributeDao;
 	private GermplasmDAO germplasmDao;
 	private List<Integer> gids;
+	private List<String> guids;
 	private List<UserDefinedField> testAttributeTypes;
 	private Integer previousAttributeTypesCount = 0;
 	private Attribute attribute1;
@@ -48,7 +50,7 @@ public class AttributeDAOTest extends IntegrationTestBase {
 			this.germplasmDao.setSession(session);
 		}
 		
-		if (this.gids == null) {
+		if (CollectionUtils.isEmpty(this.gids) || CollectionUtils.isEmpty(this.guids)) {
 			final List<UserDefinedField> existingAttributeTypes = this.attributeDao.getAttributeTypes();
 			if (existingAttributeTypes != null && !existingAttributeTypes.isEmpty()) {
 				this.previousAttributeTypesCount = existingAttributeTypes.size();
@@ -60,15 +62,19 @@ public class AttributeDAOTest extends IntegrationTestBase {
 	private void setupTestData() {
 		final Germplasm germplasm1 =
 				GermplasmTestDataInitializer.createGermplasm(20180909, 1, 2, 2, 0, 0, 1, 1, 0, 1, 1, "MethodName", "LocationName");
+		germplasm1.setGermplasmUUID(RandomStringUtils.randomAlphanumeric(10));
 		final Germplasm germplasm2 =
 				GermplasmTestDataInitializer.createGermplasm(20180909, 1, 2, 2, 0, 0, 1, 1, 0, 1, 1, "MethodName", "LocationName");
+		germplasm2.setGermplasmUUID(RandomStringUtils.randomAlphanumeric(10));
 		final Germplasm germplasm3 =
 				GermplasmTestDataInitializer.createGermplasm(20180909, 1, 2, 2, 0, 0, 1, 1, 0, 1, 1, "MethodName", "LocationName");
+		germplasm3.setGermplasmUUID(RandomStringUtils.randomAlphanumeric(10));
 		this.germplasmDao.save(germplasm1);
 		this.germplasmDao.save(germplasm2);
 		this.germplasmDao.save(germplasm3);
 		this.gids = Arrays.asList(germplasm1.getGid(), germplasm2.getGid(), germplasm3.getGid());
-		
+		this.guids = Arrays.asList(germplasm1.getGermplasmUUID(), germplasm2.getGermplasmUUID(), germplasm3.getGermplasmUUID());
+
 		final UserDefinedField attributeType1 = new UserDefinedField(null, "ATRIBUTS", RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(20), RandomStringUtils.randomAlphabetic(20), RandomStringUtils.randomAlphabetic(100), RandomStringUtils.randomAlphabetic(100), 1, 1, 20180909, null);
 		final UserDefinedField attributeType2 = new UserDefinedField(null, "ATRIBUTS", RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(20), RandomStringUtils.randomAlphabetic(20), RandomStringUtils.randomAlphabetic(100), RandomStringUtils.randomAlphabetic(100), 1, 1, 20180909, null);
 		final UserDefinedField attributeType3 = new UserDefinedField(null, "ATRIBUTS", RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(20), RandomStringUtils.randomAlphabetic(20), RandomStringUtils.randomAlphabetic(100), RandomStringUtils.randomAlphabetic(100), 1, 1, 20180909, null);
@@ -133,10 +139,10 @@ public class AttributeDAOTest extends IntegrationTestBase {
 	}
 
 	@Test
-	public void testGetAttributesByGidAndAttributeIds() {
+	public void testGetAttributesByGUIDAndAttributeIds() {
 		final List<AttributeDTO> attributes = this.attributeDao
 			.getAttributesByGUIDAndAttributeIds(
-				String.valueOf(this.gids.get(0)), Lists.newArrayList(String.valueOf(this.attribute1.getTypeId())), null);
+				String.valueOf(this.guids.get(0)), Lists.newArrayList(String.valueOf(this.attribute1.getTypeId())), null);
 		Assert.assertNotNull(attributes);
 		Assert.assertEquals(1, attributes.size());
 	}

--- a/src/test/java/org/generationcp/middleware/dao/AttributeDAOTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/AttributeDAOTest.java
@@ -135,8 +135,8 @@ public class AttributeDAOTest extends IntegrationTestBase {
 	@Test
 	public void testGetAttributesByGidAndAttributeIds() {
 		final List<AttributeDTO> attributes = this.attributeDao
-			.getAttributesByGidAndAttributeIds(
-				String.valueOf(this.gids.get(0)), Lists.newArrayList(String.valueOf(this.attribute1.getTypeId())), null, null);
+			.getAttributesByGUIDAndAttributeIds(
+				String.valueOf(this.gids.get(0)), Lists.newArrayList(String.valueOf(this.attribute1.getTypeId())), null);
 		Assert.assertNotNull(attributes);
 		Assert.assertEquals(1, attributes.size());
 	}

--- a/src/test/java/org/generationcp/middleware/dao/GermplasmDAOTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/GermplasmDAOTest.java
@@ -286,7 +286,7 @@ public class GermplasmDAOTest extends IntegrationTestBase {
 	public void testLoadEntityWithNameCollection() {
 		final Germplasm germplasm = this.dao.getById(1);
 		if (germplasm != null) {
-			Assert.assertTrue("If germplasm exists, the name collection can not be empty.", !germplasm.getNames().isEmpty());
+			Assert.assertFalse("If germplasm exists, the name collection can not be empty.", germplasm.getNames().isEmpty());
 		}
 	}
 
@@ -390,6 +390,7 @@ public class GermplasmDAOTest extends IntegrationTestBase {
 		cross.setGpid1(femaleParent.getGid());
 		cross.setGpid2(maleParent.getGid());
 		cross.setGnpgs(2);
+		cross.setGermplasmUUID(RandomStringUtils.randomAlphanumeric(10));
 		this.dao.save(cross);
 
 		final Name crossPreferredName = cross.getPreferredName();
@@ -400,11 +401,13 @@ public class GermplasmDAOTest extends IntegrationTestBase {
 		advance.setGpid1(cross.getGid());
 		advance.setGpid2(cross.getGid());
 		advance.setGnpgs(-1);
+		advance.setGermplasmUUID(RandomStringUtils.randomAlphanumeric(10));
+
 		this.dao.save(advance);
 
 		final ProgenyDTO progeny = this.dao.getProgeny(maleParent.getGid());
 
-		Assert.assertThat(progeny.getGermplasmDbId(), is(maleParent.getGid()));
+		Assert.assertThat(progeny.getGermplasmDbId(), is(maleParent.getGermplasmUUID()));
 		Assert.assertThat(progeny.getDefaultDisplayName(), is(maleParentPreferredName.getNval()));
 		Assert.assertThat(progeny.getProgeny(), hasSize(1));
 		Assert.assertThat(progeny.getProgeny().get(0).getParentType(), is(ParentType.MALE.name()));
@@ -412,10 +415,10 @@ public class GermplasmDAOTest extends IntegrationTestBase {
 
 		final ProgenyDTO crossProgeny = this.dao.getProgeny(cross.getGid());
 
-		Assert.assertThat(crossProgeny.getGermplasmDbId(), is(cross.getGid()));
+		Assert.assertThat(crossProgeny.getGermplasmDbId(), is(cross.getGermplasmUUID()));
 		Assert.assertThat(crossProgeny.getProgeny(), hasSize(1));
 		Assert.assertThat(crossProgeny.getProgeny().get(0).getParentType(), is(ParentType.SELF.name()));
-		Assert.assertThat(crossProgeny.getProgeny().get(0).getGermplasmDbId(), is(advance.getGid()));
+		Assert.assertThat(crossProgeny.getProgeny().get(0).getGermplasmDbId(), is(advance.getGermplasmUUID()));
 	}
 
 	@Test

--- a/src/test/java/org/generationcp/middleware/dao/GermplasmDAOTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/GermplasmDAOTest.java
@@ -319,6 +319,7 @@ public class GermplasmDAOTest extends IntegrationTestBase {
 		cross.setGpid2(maleParent.getGid());
 		cross.setGnpgs(2);
 		cross.setMethodId(generativeMethod.getMid());
+		cross.setGermplasmUUID(RandomStringUtils.randomAlphanumeric(10));
 		this.dao.save(cross);
 
 		final Germplasm advance = GermplasmTestDataInitializer.createGermplasmWithPreferredName();
@@ -326,6 +327,7 @@ public class GermplasmDAOTest extends IntegrationTestBase {
 		advance.setGpid2(cross.getGid());
 		advance.setGnpgs(-1);
 		advance.setMethodId(derivativeMethod.getMid());
+		advance.setGermplasmUUID(RandomStringUtils.randomAlphanumeric(10));
 		this.dao.save(advance);
 
 		final Germplasm advance2 = GermplasmTestDataInitializer.createGermplasmWithPreferredName();
@@ -333,13 +335,14 @@ public class GermplasmDAOTest extends IntegrationTestBase {
 		advance2.setGpid2(cross.getGid());
 		advance2.setGnpgs(-1);
 		advance2.setMethodId(maintenanceMethod.getMid());
+		advance2.setGermplasmUUID(RandomStringUtils.randomAlphanumeric(10));
 		this.dao.save(advance2);
 
 		final PedigreeDTO generativePedigree = this.dao.getPedigree(cross.getGid(), null, false);
 		final PedigreeDTO derivativePedigree = this.dao.getPedigree(advance.getGid(), null, true);
 		final PedigreeDTO maintenancePedigree = this.dao.getPedigree(advance2.getGid(), null, true);
 
-		Assert.assertThat(generativePedigree.getGermplasmDbId(), is(cross.getGid()));
+		Assert.assertThat(generativePedigree.getGermplasmDbId(), is(cross.getGermplasmUUID()));
 		Assert.assertThat(generativePedigree.getParent1DbId(), is(femaleParent.getGid()));
 		Assert.assertThat(generativePedigree.getParent1Type(), is(ParentType.FEMALE.name()));
 		Assert.assertThat(generativePedigree.getParent2DbId(), is(maleParent.getGid()));
@@ -351,7 +354,7 @@ public class GermplasmDAOTest extends IntegrationTestBase {
 		Assert.assertThat(generativePedigree.getCrossingYear(), is(year));
 		Assert.assertThat(generativePedigree.getSiblings(), nullValue());
 
-		Assert.assertThat(derivativePedigree.getGermplasmDbId(), is(advance.getGid()));
+		Assert.assertThat(derivativePedigree.getGermplasmDbId(), is(advance.getGermplasmUUID()));
 		Assert.assertThat(derivativePedigree.getParent1DbId(), is(cross.getGid()));
 		Assert.assertThat(derivativePedigree.getParent1Type(), is(ParentType.POPULATION.name()));
 		Assert.assertThat(derivativePedigree.getParent2DbId(), is(cross.getGid()));
@@ -359,9 +362,9 @@ public class GermplasmDAOTest extends IntegrationTestBase {
 		Assert.assertThat(derivativePedigree.getCrossingPlan(),
 			is(derivativeMethod.getMcode() + "|" + derivativeMethod.getMname() + "|" + derivativeMethod.getMtype()));
 		Assert.assertThat(derivativePedigree.getSiblings(), hasSize(1));
-		Assert.assertThat(derivativePedigree.getSiblings().get(0).getGermplasmDbId(), is(advance2.getGid()));
+		Assert.assertThat(derivativePedigree.getSiblings().get(0).getGermplasmDbId(), is(advance2.getGermplasmUUID()));
 
-		Assert.assertThat(maintenancePedigree.getGermplasmDbId(), is(advance2.getGid()));
+		Assert.assertThat(maintenancePedigree.getGermplasmDbId(), is(advance2.getGermplasmUUID()));
 		Assert.assertThat(maintenancePedigree.getParent1DbId(), is(cross.getGid()));
 		Assert.assertThat(maintenancePedigree.getParent1Type(), is(ParentType.POPULATION.name()));
 		Assert.assertThat(maintenancePedigree.getParent2DbId(), is(cross.getGid()));
@@ -369,7 +372,7 @@ public class GermplasmDAOTest extends IntegrationTestBase {
 		Assert.assertThat(maintenancePedigree.getCrossingPlan(),
 			is(maintenanceMethod.getMcode() + "|" + maintenanceMethod.getMname() + "|" + maintenanceMethod.getMtype()));
 		Assert.assertThat(maintenancePedigree.getSiblings(), hasSize(1));
-		Assert.assertThat(maintenancePedigree.getSiblings().get(0).getGermplasmDbId(), is(advance.getGid()));
+		Assert.assertThat(maintenancePedigree.getSiblings().get(0).getGermplasmDbId(), is(advance.getGermplasmUUID()));
 	}
 
 	@Test


### PR DESCRIPTION
In dao classes, when selecting germplasmDbId value use germplsm_uuid value 
Rename method to *byGUID 
Adding germplasm_guids property to LotsSeachDTO and TransactionsSearchDTO and use when filtering transactions/seedlots