### PR TITLE
Dm changes v18 : crop changesets 17.4.0-4, 17.4.0-5. workbench changeset 17.4.0-4

### DIFF
--- a/src/main/resources/liquibase/crop_changelog/17_4_0.xml
+++ b/src/main/resources/liquibase/crop_changelog/17_4_0.xml
@@ -49,5 +49,21 @@
             10185);
         </sql>
     </changeSet>
+	
+	<changeSet author="corina" id="v17.4.0-3">
+		<preConditions onFail="MARK_RAN">
+			<sqlCheck expectedResult="1">
+					SELECT COUNT(*) > 0
+					FROM methods
+					WHERE mid IN (202,502) and mname LIKE 'Double  haploid%';
+			</sqlCheck>
+		</preConditions>
+		<comment>
+            Remove excess space between "Double" and "haploid" in method names. IBP-4238
+        </comment>
+		<sql dbms="mysql" splitStatements="false">
+			UPDATE methods set mname=REPLACE(mname,'Double  haploid','Double haploid') WHERE `mid` IN (202,502);
+		</sql>
+	</changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/liquibase/crop_changelog/17_4_0.xml
+++ b/src/main/resources/liquibase/crop_changelog/17_4_0.xml
@@ -55,6 +55,7 @@
             10185);
         </sql>
     </changeSet>
+
     <changeSet author="cuenyad" id="v17.4.0-3">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">
@@ -69,4 +70,36 @@
 			VALUES ('23', 'GERMPLASM_LABEL_PRINTING_PRESET', 'Excel template default', '{\"type\":\"LabelPrintingPreset\",\"selectedFields\":[[8240,41,8189,8256,1712,48,1709]],\"barcodeSetting\":{\"barcodeNeeded\":false,\"automaticBarcode\":false,\"barcodeFields\":[]},\"includeHeadings\":true,\"fileConfiguration\":{\"outputType\":\"xls\"}}');
        </sql>
     </changeSet>
+	
+	<changeSet author="corina" id="v17.4.0-4">
+		<preConditions onFail="MARK_RAN">
+			<sqlCheck expectedResult="1">
+					SELECT COUNT(*) > 0
+					FROM methods
+					WHERE `mid` IN (202,502) and mname LIKE 'Double  haploid%';
+			</sqlCheck>
+		</preConditions>
+		<comment>
+            Remove excess space between "Double" and "haploid" in method names. IBP-4238
+        </comment>
+		<sql dbms="mysql" splitStatements="false">
+			UPDATE methods set mname=REPLACE(mname,'Double  haploid','Double haploid') WHERE `mid` IN (202,502);
+		</sql>
+	</changeSet>
+	
+	<changeSet author="corina" id="v17.4.0-5">
+		<preConditions onFail="MARK_RAN">
+			<sqlCheck expectedResult="1">
+					SELECT COUNT(*) > 0 FROM methods WHERE mtype IN ('DER','MAN') AND mprgn != -1;
+			</sqlCheck>
+		</preConditions>
+		<comment>
+            Set methods.mprgn to -1 for derivative and maintenance methods. IBP-4533
+        </comment>
+		<sql dbms="mysql" splitStatements="false">
+			UPDATE methods set mprgn=-1 WHERE mtype IN ('DER','MAN') AND mprgn != -1;
+		</sql>
+	</changeSet>
+		
+        
 </databaseChangeLog>

--- a/src/main/resources/liquibase/crop_changelog/17_4_0.xml
+++ b/src/main/resources/liquibase/crop_changelog/17_4_0.xml
@@ -55,7 +55,7 @@
 			<sqlCheck expectedResult="1">
 					SELECT COUNT(*) > 0
 					FROM methods
-					WHERE mid IN (202,502) and mname LIKE 'Double  haploid%';
+					WHERE `mid` IN (202,502) and mname LIKE 'Double  haploid%';
 			</sqlCheck>
 		</preConditions>
 		<comment>
@@ -65,5 +65,20 @@
 			UPDATE methods set mname=REPLACE(mname,'Double  haploid','Double haploid') WHERE `mid` IN (202,502);
 		</sql>
 	</changeSet>
+	
+	<changeSet author="corina" id="v17.4.0-4">
+		<preConditions onFail="MARK_RAN">
+			<sqlCheck expectedResult="1">
+					SELECT COUNT(*) > 0 FROM methods WHERE mtype IN ('DER','MAN') AND mprgn != -1;
+			</sqlCheck>
+		</preConditions>
+		<comment>
+            Set methods.mprgn to -1 for derivative and maintenance methods. IBP-4533
+        </comment>
+		<sql dbms="mysql" splitStatements="false">
+			UPDATE methods set mprgn=-1 WHERE mtype IN ('DER','MAN') AND mprgn != -1;
+		</sql>
+	</changeSet>
+	
 
 </databaseChangeLog>

--- a/src/main/resources/liquibase/workbench_changelog/17_4_0.xml
+++ b/src/main/resources/liquibase/workbench_changelog/17_4_0.xml
@@ -90,6 +90,18 @@
 															WHERE tool_name = 'germplasm_import');
 		</sql>
 	</changeSet>
+	
+	<changeSet author="corina" id="v17.4.0-4">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT count(*) > 0 FROM workbench_crop WHERE use_uuid=1;
+            </sqlCheck>
+        </preConditions>
+        <comment>Set workbench_crop.use_uuid to 0 in order to use short OBS_UNIT_IDs for barcoding</comment>
+		<sql dbms="mysql" splitStatements="true">
+			UPDATE workbench_crop SET use_uuid=0 where use_uuid=1;
+		</sql>
+	</changeSet>
 
 </databaseChangeLog>
 


### PR DESCRIPTION
crop_changelog:

- added changeset 17.4.0-4 : Remove excess space between "Double" and "haploid" in method names [IBP-4238]
- added changeset 17.4.0-5 : Set methods.mprgn to -1 for derivative and maintenance methods [IBP-4533]

workbench_changelog:

- added changeset 17.4.0-4 to set workbench_crop.use_uuid to 0

Please review and merge. 
cc @mcrimi 

[IBP-4238]: https://ibplatform.atlassian.net/browse/IBP-4238
[IBP-4533]: https://ibplatform.atlassian.net/browse/IBP-4533