### PR TITLE
IBP-4683: fix sub-optimal join between germplsm and transaction

### DIFF
--- a/src/main/java/org/generationcp/middleware/dao/GermplasmSearchDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/GermplasmSearchDAO.java
@@ -811,7 +811,9 @@ public class GermplasmSearchDAO extends GenericDAO<Germplasm, Integer> {
 			// FIXME IBP-4320
 			+ "  FORCE INDEX (ims_lot_idx01)"  //
 			+ "  ON gl.eid = g.gid AND gl.etype = 'GERMPLSM' AND gl.status = 0 \n" //
-			+ " LEFT JOIN ims_transaction gt ON gt.lotid = gl.lotid AND gt.trnstat <> 9 \n" //
+			+ " LEFT JOIN ims_transaction gt"  //
+			+ "  FORCE INDEX (ims_transaction_idx01) " //
+			+ "  ON gt.lotid = gl.lotid AND gt.trnstat <> 9 \n" //
 			+ " LEFT JOIN cvterm scale ON scale.cvterm_id = gl.scaleid \n" //
 			+ " LEFT JOIN methods m ON m.mid = g.methn \n" //
 			+ " LEFT JOIN location l ON l.locid = g.glocn \n" //


### PR DESCRIPTION
The sub-optimal query is triggered when there are no lots/transactions. I’m not sure what recent change may be causing this because last time it worked without this optimization. It is also likely we are hitting mysql micro-performance issues that are probably solved in recent versions.