### PR TITLE
IBP-4842: Some improvements in brapi v2 observationLevel schema

### DIFF
--- a/src/main/java/org/generationcp/middleware/api/brapi/v2/observationunit/ObservationLevelMapper.java
+++ b/src/main/java/org/generationcp/middleware/api/brapi/v2/observationunit/ObservationLevelMapper.java
@@ -1,0 +1,63 @@
+package org.generationcp.middleware.api.brapi.v2.observationunit;
+
+import org.generationcp.middleware.enumeration.DatasetTypeEnum;
+
+public class ObservationLevelMapper {
+
+	/**
+	 * https://wiki.brapi.org/index.php/Observation_Levels#Accepted_Levels
+	 * Sticking to uppercase for backwards compatibility, although they are lowercase in the standard
+	 * TODO review if there is any client expecting uppercase only
+	 */
+	public enum ObservationLevelEnum {
+		STUDY("STUDY"),
+		FIELD("FIELD"),
+		ENTRY("ENTRY"),
+		REP("REP"),
+		BLOCK("BLOCK"),
+		SUB_BLOCK("SUB-BLOCK"),
+		PLOT("PLOT"),
+		SUB_PLOT("SUB-PLOT"),
+		POT("POT"),
+		SAMPLE("SAMPLE"),
+		PLANT("PLANT");
+
+		private final String name;
+
+		ObservationLevelEnum(final String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	/**
+	 * TODO Continue IBP-4289, it can be used to map from observationlevel to nd_experimentprop
+	 */
+	public enum ObservationLevelProp {
+		REP_NO,
+		BLOCK_NO,
+		PLOT_NO
+	}
+
+	/**
+	 * Map some accepted levels in brapi, otherwise return the dataset name (custom observationlevel as in /observationlevels)
+	 */
+	public static String getObservationLevelNameEnumByDataset(final DatasetTypeEnum datasetTypeEnum) {
+		switch (datasetTypeEnum) {
+			case PLOT_DATA:
+				return ObservationLevelEnum.PLOT.getName();
+			case PLANT_SUBOBSERVATIONS:
+				return ObservationLevelEnum.PLANT.getName();
+			case QUADRAT_SUBOBSERVATIONS:
+			case CUSTOM_SUBOBSERVATIONS:
+			case TIME_SERIES_SUBOBSERVATIONS:
+				return ObservationLevelEnum.SUB_PLOT.getName();
+			default:
+				return datasetTypeEnum.getName();
+		}
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/api/brapi/v2/observationunit/ObservationUnitPosition.java
+++ b/src/main/java/org/generationcp/middleware/api/brapi/v2/observationunit/ObservationUnitPosition.java
@@ -7,7 +7,7 @@ public class ObservationUnitPosition {
 
 	private String entryType;
 	private Map<String, Object> geoCoordinates;
-	private String observationLevel;
+	private ObservationLevelRelationship observationLevel;
 	private List<ObservationLevelRelationship> observationLevelRelationships;
 	private String positionCoordinateX;
 	private String positionCoordinateXType;
@@ -30,11 +30,11 @@ public class ObservationUnitPosition {
 		this.geoCoordinates = geoCoordinates;
 	}
 
-	public String getObservationLevel() {
+	public ObservationLevelRelationship getObservationLevel() {
 		return this.observationLevel;
 	}
 
-	public void setObservationLevel(final String observationLevel) {
+	public void setObservationLevel(final ObservationLevelRelationship observationLevel) {
 		this.observationLevel = observationLevel;
 	}
 

--- a/src/main/java/org/generationcp/middleware/api/brapi/v2/observationunit/ObservationUnitServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/brapi/v2/observationunit/ObservationUnitServiceImpl.java
@@ -401,6 +401,12 @@ public class ObservationUnitServiceImpl implements ObservationUnitService {
 		}
 	}
 
+	/*
+	 * FIXME IBP-4289
+	 *  - ObservationLevelRelationship not consistent with /observationlevels
+	 *  - dto carrying different formats at different points in the call hierarchy (perhaps map directly before saving to ndexpprops?)
+	 *  - See ObservationLevelMapper
+	 */
 	private void renameObservationLevelNamesToBeSaved(final List<ObservationLevelRelationship> relationships) {
 		if (!CollectionUtils.isEmpty(relationships)) {
 			//Convert observation level relationship names to their equivalent in BMS database

--- a/src/main/java/org/generationcp/middleware/enumeration/DatasetTypeEnum.java
+++ b/src/main/java/org/generationcp/middleware/enumeration/DatasetTypeEnum.java
@@ -5,23 +5,25 @@ import java.util.Map;
 
 public enum DatasetTypeEnum {
 
-	STUDY_CONDITIONS(1),
-	MEANS_DATA(2),
-	SUMMARY_DATA(3),
-	PLOT_DATA(4),
-	PLANT_SUBOBSERVATIONS(5),
-	QUADRAT_SUBOBSERVATIONS(6),
-	TIME_SERIES_SUBOBSERVATIONS(7),
-	CUSTOM_SUBOBSERVATIONS(8),
-	SUB_SAMPLE_DATA(9),
-	WEATHER_DATA(10),
-	MEANS_OVER_TRIAL_INSTANCES(11);
+	STUDY_CONDITIONS(1, "STUDY"),
+	MEANS_DATA(2, "MEANS"),
+	SUMMARY_DATA(3, "SUMMARY"),
+	PLOT_DATA(4, "PLOT"),
+	PLANT_SUBOBSERVATIONS(5, "PLANT"),
+	QUADRAT_SUBOBSERVATIONS(6, "QUADRAT"),
+	TIME_SERIES_SUBOBSERVATIONS(7, "TIMESERIES"),
+	CUSTOM_SUBOBSERVATIONS(8, "CUSTOM"),
+	SUB_SAMPLE_DATA(9, "SS"),
+	WEATHER_DATA(10, "WD"),
+	MEANS_OVER_TRIAL_INSTANCES(11, "OM");
 
 	private static final Map<Integer, DatasetTypeEnum> lookup = new HashMap<>();
+	private static final Map<String, DatasetTypeEnum> lookupByName = new HashMap<>();
 
 	static {
 		for (final DatasetTypeEnum datasetTypeEnum : DatasetTypeEnum.values()) {
 			lookup.put(datasetTypeEnum.getId(), datasetTypeEnum);
+			lookupByName.put(datasetTypeEnum.getName(), datasetTypeEnum);
 		}
 	}
 
@@ -29,14 +31,23 @@ public enum DatasetTypeEnum {
 		return lookup.get(id);
 	}
 
-	private final int id;
+	public static DatasetTypeEnum getByName(final String name) {
+		return lookupByName.get(name);
+	}
 
-	DatasetTypeEnum(final int id) {
+	private final int id;
+	private final String name;
+
+	DatasetTypeEnum(final int id, final String name) {
 		this.id = id;
+		this.name = name;
 	}
 
 	public int getId() {
 		return this.id;
 	}
 
+	public String getName() {
+		return name;
+	}
 }

--- a/src/main/java/org/generationcp/middleware/service/impl/study/PhenotypeQuery.java
+++ b/src/main/java/org/generationcp/middleware/service/impl/study/PhenotypeQuery.java
@@ -10,7 +10,7 @@ public class PhenotypeQuery {
 		+ "  nde.obs_unit_id AS observationUnitDbId, " //
 		+ "  nde.json_props AS jsonProps, " //
 		+ "  CONCAT(dataset_type.name, plotNumber.value) AS observationUnitName, " //
-		+ "  dataset_type.name AS observationLevel, " //
+		+ "  dataset_type.name AS datasetName, " //
 		+ "  NULL AS plantNumber, " // Until we have plant level observation
 		+ "  g.germplsm_uuid AS germplasmDbId, " //
 		+ "  s.name AS germplasmName, " //

--- a/src/test/java/org/generationcp/middleware/dao/dms/PhenotypeDaoIntegrationTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/dms/PhenotypeDaoIntegrationTest.java
@@ -375,6 +375,7 @@ public class PhenotypeDaoIntegrationTest extends IntegrationTestBase {
 		Assert.assertEquals(new Long(1), outOfSyncMap.get(plot.getProjectId()));
 	}
 
+	// FIXME this test can be improved to be easier to work with / add assertions
 	@Test
 	public void testSearchObservationUnits() {
 		// Create 2 studies
@@ -405,6 +406,7 @@ public class PhenotypeDaoIntegrationTest extends IntegrationTestBase {
 		this.createEnvironmentData(plot2, 1, traitIds, true);
 		this.sessionProvder.getSession().flush();
 
+		// Search by program
 		final ObservationUnitSearchRequestDTO dto = new ObservationUnitSearchRequestDTO();
 		dto.setProgramDbIds(Collections.singletonList(uniqueID));
 		final List<ObservationUnitDto> results = this.phenotypeDao.searchObservationUnits(1000, 1, dto);
@@ -434,15 +436,24 @@ public class PhenotypeDaoIntegrationTest extends IntegrationTestBase {
 			Assert.assertEquals(experimentModel.getGeoLocation().getLocationId().toString(), result.getStudyDbId());
 		}
 
-		Assert.assertThat(results.get(0).getObservationUnitPosition().getObservationLevel().getLevelName(),
-			is(ObservationLevelMapper.ObservationLevelEnum.PLOT.getName()));
-		Assert.assertThat(results.get(1).getObservationUnitPosition().getObservationLevel().getLevelName(),
-			is(DatasetTypeEnum.MEANS_DATA.getName()));
-
 		// Search by Study ID
 		final ObservationUnitSearchRequestDTO dto2 = new ObservationUnitSearchRequestDTO();
 		dto2.setTrialDbIds(Collections.singletonList(study2.getProjectId().toString()));
 		Assert.assertEquals(NO_OF_GERMPLASM, this.phenotypeDao.countObservationUnits(dto2));
+
+		final List<ObservationUnitDto> study2ObservationUnits = this.phenotypeDao.searchObservationUnits(1000, 1, dto2);
+		study2ObservationUnits.forEach(observationUnitDto -> {
+			Assert.assertThat(observationUnitDto.getObservationUnitPosition().getObservationLevel().getLevelName(),
+				is(DatasetTypeEnum.MEANS_DATA.getName()));
+		});
+
+		final ObservationUnitSearchRequestDTO dto2Study1 = new ObservationUnitSearchRequestDTO();
+		dto2Study1.setTrialDbIds(Collections.singletonList(this.study.getProjectId().toString()));
+		final List<ObservationUnitDto> study1ObservationUnits = this.phenotypeDao.searchObservationUnits(1000, 1, dto2Study1);
+		study1ObservationUnits.forEach(observationUnitDto -> {
+			Assert.assertThat(observationUnitDto.getObservationUnitPosition().getObservationLevel().getLevelName(),
+				is(ObservationLevelMapper.ObservationLevelEnum.PLOT.getName()));
+		});
 
 		// Search by Geolocation ID
 		final ObservationUnitSearchRequestDTO dto3 = new ObservationUnitSearchRequestDTO();

--- a/src/test/java/org/generationcp/middleware/dao/dms/PhenotypeDaoIntegrationTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/dms/PhenotypeDaoIntegrationTest.java
@@ -14,6 +14,7 @@ package org.generationcp.middleware.dao.dms;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.generationcp.middleware.IntegrationTestBase;
+import org.generationcp.middleware.api.brapi.v2.observationunit.ObservationLevelMapper;
 import org.generationcp.middleware.api.germplasm.GermplasmGuidGenerator;
 import org.generationcp.middleware.dao.GermplasmDAO;
 import org.generationcp.middleware.dao.ProjectDAO;
@@ -64,11 +65,11 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.is;
+
 public class PhenotypeDaoIntegrationTest extends IntegrationTestBase {
 
 	private static final int NO_OF_GERMPLASM = 5;
-
-	private static final String PLOT = "PLOT";
 
 	private PhenotypeDao phenotypeDao;
 
@@ -433,6 +434,11 @@ public class PhenotypeDaoIntegrationTest extends IntegrationTestBase {
 			Assert.assertEquals(experimentModel.getGeoLocation().getLocationId().toString(), result.getStudyDbId());
 		}
 
+		Assert.assertThat(results.get(0).getObservationUnitPosition().getObservationLevel().getLevelName(),
+			is(ObservationLevelMapper.ObservationLevelEnum.PLOT.getName()));
+		Assert.assertThat(results.get(1).getObservationUnitPosition().getObservationLevel().getLevelName(),
+			is(DatasetTypeEnum.MEANS_DATA.getName()));
+
 		// Search by Study ID
 		final ObservationUnitSearchRequestDTO dto2 = new ObservationUnitSearchRequestDTO();
 		dto2.setTrialDbIds(Collections.singletonList(study2.getProjectId().toString()));
@@ -457,7 +463,7 @@ public class PhenotypeDaoIntegrationTest extends IntegrationTestBase {
 		// Search by Dataset Type, just for current program
 		final ObservationUnitSearchRequestDTO dto6 = new ObservationUnitSearchRequestDTO();
 		dto6.setProgramDbIds(Collections.singletonList(uniqueID));
-		dto6.setObservationLevel(PLOT);
+		dto6.setObservationLevel(ObservationLevelMapper.ObservationLevelEnum.PLOT.getName());
 		Assert.assertEquals(NO_OF_GERMPLASM, this.phenotypeDao.countObservationUnits(dto6));
 	}
 


### PR DESCRIPTION
- Fix ObservationUnitPosition.observationLevel
- Consolidate mapping and asymmetries in ObservationLevelMapper
  Continues in IBP-4289
- Add name to DatasetTypeEnum and use it to map non-canonical
observation levels