### PR TITLE
Ibp 4552 fix missing env parameters

### DIFF
--- a/src/main/java/org/generationcp/middleware/api/brapi/StudyServiceBrapiImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/brapi/StudyServiceBrapiImpl.java
@@ -608,7 +608,7 @@ public class StudyServiceBrapiImpl implements StudyServiceBrapi {
 			TermId.LOCATION_ID.getId(),
 			TermId.TRIAL_INSTANCE_FACTOR.getId(),
 			TermId.EXPERIMENT_DESIGN_FACTOR.getId());
-		// filter the already added variables
+		//filter the variables already added
 		filterVariables.addAll(environmentParameterVariables.stream().map(MeasurementVariable::getTermId).collect(Collectors.toList()));
 
 		final List<MeasurementVariable> variables = environmentVariables

--- a/src/test/java/org/generationcp/middleware/brapi/StudyServiceBrapiImplTest.java
+++ b/src/test/java/org/generationcp/middleware/brapi/StudyServiceBrapiImplTest.java
@@ -27,11 +27,13 @@ import org.generationcp.middleware.pojos.workbench.WorkbenchUser;
 import org.generationcp.middleware.service.api.study.EnvironmentParameter;
 import org.generationcp.middleware.service.api.study.StudyDetailsDto;
 import org.generationcp.middleware.service.api.study.StudyInstanceDto;
+import org.generationcp.middleware.service.api.study.StudySearchFilter;
 import org.generationcp.middleware.utils.test.IntegrationTestDataInitializer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.util.CollectionUtils;
 
 import javax.annotation.Resource;
@@ -182,7 +184,11 @@ public class StudyServiceBrapiImplTest extends IntegrationTestBase {
 			.saveStudyInstances(this.cropType.getCropName(), Collections.singletonList(dto), this.testUser.getUserid()).get(0);
 		Assert.assertEquals(dto.getTrialDbId(), savedInstance.getTrialDbId());
 		Assert.assertEquals(dto.getLocationDbId(), savedInstance.getLocationDbId());
-		Assert.assertTrue(CollectionUtils.isEmpty(savedInstance.getEnvironmentParameters()));
+
+		assertThat(savedInstance.getEnvironmentParameters(), hasSize(1));
+		final EnvironmentParameter environmentParameter = savedInstance.getEnvironmentParameters().get(0);
+		assertThat(environmentParameter.getParameterPUI(), is(numericVariable.getCvTermId().toString()));
+		assertThat(environmentParameter.getValue(), is(""));
 	}
 
 	@Test


### PR DESCRIPTION
Environment parameters that have no values have been added to the response.
This change also affects endpoint POST /{crop}/brapi/v2/studies response, and only the response. It doesn't affect the saving process. Please check at: [org.generationcp.middleware.api.brapi.StudyServiceBrapiImpl#saveStudyInstances](https://github.com/IntegratedBreedingPlatform/Middleware/blob/4a7e71fa83961650d1db1adfe3eac9734d5840dc/src/main/java/org/generationcp/middleware/api/brapi/StudyServiceBrapiImpl.java#L315)