### PR TITLE
IBP-4945: Validate file overwrite

### DIFF
--- a/src/main/java/org/generationcp/middleware/api/file/FileMetadataServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/file/FileMetadataServiceImpl.java
@@ -137,10 +137,19 @@ public class FileMetadataServiceImpl implements FileMetadataService {
 	public String getFilePath(final String observationUnitId, final String fileName) {
 		final ExperimentModel experimentModel = this.daoFactory.getExperimentDao().getByObsUnitId(observationUnitId);
 		final DmsProject study = experimentModel.getProject().getStudy();
-		return FILE_PATH_PREFIX_PROGRAMUUID + study.getProgramUUID()
+		final String path = FILE_PATH_PREFIX_PROGRAMUUID + study.getProgramUUID()
 			+ FILE_PATH_SLASH + FILE_PATH_PREFIX_STUDYID + study.getProjectId()
 			+ FILE_PATH_SLASH + FILE_PATH_PREFIX_OBSUNITUUID + observationUnitId
 			+ FILE_PATH_SLASH + fileName;
+		this.validatePathNotExists(path);
+		return path;
+	}
+
+	private void validatePathNotExists(final String path) {
+		final FileMetadata fileMetadata = this.daoFactory.getFileMetadataDAO().getByPath(path);
+		if (fileMetadata != null) {
+			throw new MiddlewareRequestException("", "filemetadata.path.overwrite");
+		}
 	}
 
 	@Override

--- a/src/main/java/org/generationcp/middleware/dao/FileMetadataDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/FileMetadataDAO.java
@@ -71,4 +71,10 @@ public class FileMetadataDAO extends GenericDAO<FileMetadata, Integer> {
 			paramBuilder.setParameter("observationUnitUUID", observationUnitUUID);
 		}
 	}
+
+	public FileMetadata getByPath(final String path) {
+		return (FileMetadata) this.getSession().createCriteria(this.getPersistentClass())
+			.add(Restrictions.eq("path", path))
+			.uniqueResult();
+	}
 }

--- a/src/main/resources/mw_messages_en.properties
+++ b/src/main/resources/mw_messages_en.properties
@@ -60,5 +60,6 @@ measurement.variable.invalid.categorical.value=Invalid categorical value found f
 filemetadata.record.not.found=The file metadata record for imageDbId={0} was not found in the database
 filemetadata.observationunit.not.found=The observation unit ({0}) was not found in the database
 filemetadata.variable.not.found=There are no file type variables associated to observationUnitDbId={0}
+filemetadata.path.overwrite=The file name already exists, if you want to replace it, please delete the existing one
 filemetadata.brapi.multiple.file.variables=File/Image upload using BrAPI is not possible if the study has more than one trait of type "file" 
 filemetadata.brapi.location.parse.error=There was an error while parsing imageLocation


### PR DESCRIPTION
Amends https://github.com/IntegratedBreedingPlatform/Workbench/pull/544

- Move validation from frontend to here
- Same file name is allowed if it belongs to a different path
- We don't add complex locking mechanism, the UI is in charge of locking
 while the request is in progress, and other scenarios are
 considered edge cases (concurrent request with the same file name and
 path)
- No constraints at the table level given that path > 255 bytes
  - current length (varchar 2000) is to allow longer file names and also for consistency with URL
  - also no constraint might be useful in a future germplasm merge
 scenario, where multiple multiple (merged) germplasm have a
 corresponding row in file_metadata pointing to the same file path,
 which in turns makes possible the merging mechanism without having to
 copy elements in the file storage, only keeping the same reference