### PR TITLE
IBP-4973 GermplasmGroupingServiceImpl optimization

### DIFF
--- a/src/main/java/org/generationcp/middleware/dao/GermplasmDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/GermplasmDAO.java
@@ -527,9 +527,6 @@ public class GermplasmDAO extends GenericDAO<Germplasm, Integer> {
 			// Get all derivative children
 			children.addAll(this.getDescendants(gid, 'D'));
 
-			// Get all maintenance children
-			children.addAll(this.getDescendants(gid, 'M'));
-
 			// Get all generative childern
 			children.addAll(this.getGenerativeChildren(gid));
 			return children;

--- a/src/main/java/org/generationcp/middleware/service/impl/GermplasmGroupingServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/service/impl/GermplasmGroupingServiceImpl.java
@@ -283,7 +283,8 @@ public class GermplasmGroupingServiceImpl implements GermplasmGroupingService {
 	}
 
 	UserDefinedField getSelectionHistoryNameType(final String nameType) {
-		final UserDefinedField selectionHistoryNameType = this.daoFactory.getUserDefinedFieldDAO().getByTableTypeAndCode("NAMES", "NAME", nameType);
+		final UserDefinedField selectionHistoryNameType =
+			this.daoFactory.getUserDefinedFieldDAO().getByTableTypeAndCode("NAMES", "NAME", nameType);
 		if (selectionHistoryNameType == null) {
 			throw new IllegalStateException(
 				"Missing required reference data: Please ensure User defined field (UDFLD) record for name type '" + nameType
@@ -383,8 +384,9 @@ public class GermplasmGroupingServiceImpl implements GermplasmGroupingService {
 	// have good visualization tools in BMS to verify results of such
 	// complex operations. INFO LOGGing helps.
 	@Override
-	public void processGroupInheritanceForCrosses(final String cropName, final Map<Integer, Integer> germplasmIdMethodIdMap, final boolean applyNewGroupToPreviousCrosses,
-			final Set<Integer> hybridMethods) {
+	public void processGroupInheritanceForCrosses(final String cropName, final Map<Integer, Integer> germplasmIdMethodIdMap,
+		final boolean applyNewGroupToPreviousCrosses,
+		final Set<Integer> hybridMethods) {
 		final GermplasmCache germplasmCache = new GermplasmCache(this.germplasmDataManager, 2);
 		final Set<Integer> gidsOfCrosses = germplasmIdMethodIdMap.keySet();
 		germplasmCache.initialiseCache(cropName, gidsOfCrosses, 2);

--- a/src/main/java/org/generationcp/middleware/service/impl/GermplasmGroupingServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/service/impl/GermplasmGroupingServiceImpl.java
@@ -208,7 +208,7 @@ public class GermplasmGroupingServiceImpl implements GermplasmGroupingService {
 		} else {
 			GermplasmGroupingServiceImpl.LOG.info("Assigning mgid = [{}] for germplasm with gid = [{}]", groupId, germplasm.getGid());
 			germplasm.setMgid(groupId);
-			this.copySelectionHistory(germplasm, this.selHistNameType);
+			this.copySelectionHistory(germplasm);
 			this.daoFactory.getGermplasmDao().save(germplasm);
 		}
 
@@ -332,9 +332,9 @@ public class GermplasmGroupingServiceImpl implements GermplasmGroupingService {
 		germplasm.getNames().add(codedName);
 	}
 
-	private void copySelectionHistory(final Germplasm germplasm, final UserDefinedField nameType) {
+	private void copySelectionHistory(final Germplasm germplasm) {
 
-		final Name mySelectionHistory = this.findNameByType(germplasm, nameType);
+		final Name mySelectionHistory = this.findNameByType(germplasm, this.selHistNameType);
 		if (mySelectionHistory != null) {
 			this.addOrUpdateSelectionHistoryAtFixationName(germplasm, mySelectionHistory, this.selHistAtFixationNameType);
 			GermplasmGroupingServiceImpl.LOG

--- a/src/main/java/org/generationcp/middleware/service/impl/GermplasmGroupingServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/service/impl/GermplasmGroupingServiceImpl.java
@@ -186,7 +186,7 @@ public class GermplasmGroupingServiceImpl implements GermplasmGroupingService {
 					germplasm.getGid(), germplasm.getMgid(), groupId);
 		}
 
-		final Method method = this.daoFactory.getMethodDAO().getById(germplasm.getMethodId());
+		final Method method = germplasm.getMethod();
 		if (method != null && method.isGenerative()) {
 			GermplasmGroupingServiceImpl.LOG
 				.info("Method {} ({}), of the germplasm (gid {}) is generative. MGID assignment for generative germplasm is not supported.",

--- a/src/test/java/org/generationcp/middleware/service/impl/GermplasmGroupingServiceImplTest.java
+++ b/src/test/java/org/generationcp/middleware/service/impl/GermplasmGroupingServiceImplTest.java
@@ -327,7 +327,7 @@ public class GermplasmGroupingServiceImplTest {
 
 		final Method method = new Method(generativeMethodId);
 		method.setMtype("GEN");
-		Mockito.when(this.methodDAO.getById(generativeMethodId)).thenReturn(method);
+		this.germplasmToFix.setMethod(method);
 
 		final Germplasm child1 = new Germplasm();
 		child1.setGid(2);
@@ -351,10 +351,6 @@ public class GermplasmGroupingServiceImplTest {
 	 */
 	@Test
 	public void testMarkFixedCase7() {
-		final Integer generativeMethodId = 123;
-		final Method method = new Method(generativeMethodId);
-		method.setMtype("GEN");
-		Mockito.when(this.methodDAO.getById(generativeMethodId)).thenReturn(method);
 
 		final Germplasm child1 = new Germplasm();
 		child1.setGid(2);
@@ -364,7 +360,12 @@ public class GermplasmGroupingServiceImplTest {
 		child2.setGid(3);
 		final Integer expectedChild2MGID = 333;
 		child2.setMgid(expectedChild2MGID);
+
+		final Integer generativeMethodId = 123;
+		final Method method = new Method(generativeMethodId);
+		method.setMtype("GEN");
 		child2.setMethodId(generativeMethodId);
+		child2.setMethod(method);
 
 		Mockito.when(this.germplasmDAO.getAllChildren(this.gidToFix)).thenReturn(Lists.newArrayList(child1, child2));
 


### PR DESCRIPTION
Changes:
- use germplasm.getMethod() instead of getMethodDao
- process selection history name type only once (outside the gid loop)
- store germplasm selection history name per germplasm in a map to avoid multiple retrieval process
- remove maintenance children retrieval in GermplasmDAO#getAllChildren