### PR TITLE
IBP-5076: optimize germplasm grouping on advance study and crossing

### DIFF
--- a/src/main/java/org/generationcp/middleware/service/impl/GermplasmGroupingServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/service/impl/GermplasmGroupingServiceImpl.java
@@ -66,7 +66,6 @@ public class GermplasmGroupingServiceImpl implements GermplasmGroupingService {
 	private final DaoFactory daoFactory;
 
 	private final Map<Integer, String> germplasmSelHistNameMap = new HashMap<>();
-	private final Map<Integer, Map<String, Name>> germplasmNameTypeMap = new HashMap<>();
 
 	public GermplasmGroupingServiceImpl(final HibernateSessionProvider sessionProvider) {
 		this.daoFactory = new DaoFactory(sessionProvider);
@@ -231,19 +230,11 @@ public class GermplasmGroupingServiceImpl implements GermplasmGroupingService {
 
 	Name findNameByType(final Germplasm germplasm, final UserDefinedField nameType) {
 		if (nameType != null) {
-			final Integer gid = germplasm.getGid();
-			final String type = nameType.getFcode();
-			this.germplasmNameTypeMap.putIfAbsent(gid, new HashMap<>());
-			final Map<String, Name> nameTypeMap = this.germplasmNameTypeMap.get(gid);
-			if (nameTypeMap.containsKey(type)) {
-				return nameTypeMap.get(type);
-			}
-
-			final java.util.Optional<Name> nameOptional = germplasm.getNames().stream().filter(name -> nameType.getFldno().equals(name.getTypeId())).findFirst();
+			final java.util.Optional<Name> nameOptional =
+				germplasm.getNames().stream().filter(name -> nameType.getFldno().equals(name.getTypeId())).findFirst();
 			if (nameOptional.isPresent()) {
-				nameTypeMap.put(type, nameOptional.get());
+				return nameOptional.get();
 			}
-			return nameTypeMap.getOrDefault(type, null);
 		}
 		return null;
 	}


### PR DESCRIPTION
- ensure that processing of UserDefinedField from given name types are only executed once
- [removed] update findNameType to store germplasm-name type-name data in a map to avoid processing the same germplasm-name type pairs multiple times
- copyCodedNames and copyParentalSelectionHistoryAtFixation improvement for advance study (involving germplasms with mgid)
- for crossing, copySelectionHistoryForCross optimization (minor improvement for the ff scenario: hybrid breeding method selected, both parents have mgid and assign mgid from the oldest previous cross -> this is the only scenario that copies selection history and copy coded names)