### PR TITLE
IBP-5369 fill with cross expansion

### DIFF
--- a/src/main/java/org/generationcp/middleware/api/germplasmlist/GermplasmListDto.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasmlist/GermplasmListDto.java
@@ -22,6 +22,7 @@ public class GermplasmListDto {
 	private String notes;
 	private String parentFolderId;
 	private Integer status;
+	private Integer generationLevel;
 
 	public GermplasmListDto() {
 
@@ -129,6 +130,14 @@ public class GermplasmListDto {
 
 	public void setStatus(final Integer status) {
 		this.status = status;
+	}
+
+	public Integer getGenerationLevel() {
+		return generationLevel;
+	}
+
+	public void setGenerationLevel(final Integer generationLevel) {
+		this.generationLevel = generationLevel;
 	}
 
 	@Override

--- a/src/main/java/org/generationcp/middleware/api/germplasmlist/GermplasmListServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasmlist/GermplasmListServiceImpl.java
@@ -370,8 +370,9 @@ public class GermplasmListServiceImpl implements GermplasmListService {
 			.map(AddGermplasmEntryModel::getGid)
 			.collect(toSet());
 
+		final Integer level = germplasmList.getGenerationLevel();
 		final Map<Integer, String> crossExpansionsBulk =
-			this.pedigreeService.getCrossExpansionsBulk(gids, null, this.crossExpansionProperties);
+			this.pedigreeService.getCrossExpansionsBulk(gids, level, this.crossExpansionProperties);
 
 		final Map<Integer, String> plotCodeValuesIndexedByGids = this.germplasmService.getPlotCodeValues(gids);
 

--- a/src/main/java/org/generationcp/middleware/api/germplasmlist/GermplasmListServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasmlist/GermplasmListServiceImpl.java
@@ -205,7 +205,7 @@ public class GermplasmListServiceImpl implements GermplasmListService {
 		final String description = request.getDescription() != null ? request.getDescription() : StringUtils.EMPTY;
 
 		GermplasmList germplasmList = new GermplasmList(null, request.getListName(), Long.valueOf(this.dateFormat.format(request.getCreationDate())),
-			request.getListType(), currentUserId, description, parent, request.getStatus(), request.getNotes());
+			request.getListType(), currentUserId, description, parent, request.getStatus(), request.getNotes(), null);
 		germplasmList.setProgramUUID(request.getProgramUUID());
 		germplasmList = this.daoFactory.getGermplasmListDAO().saveOrUpdate(germplasmList);
 		request.setListId(germplasmList.getId());
@@ -438,11 +438,18 @@ public class GermplasmListServiceImpl implements GermplasmListService {
 	}
 
 	@Override
-	public GermplasmListDto cloneGermplasmList(final Integer listId, final GermplasmListDto listDto,
-		final Integer loggedInUserId) {
+	public GermplasmListDto cloneGermplasmList(final Integer listId, final GermplasmListDto listDto, final Integer loggedInUserId) {
+
+		// copy info from request
 		final GermplasmList destinationList = this.createGermplasmList(listDto, loggedInUserId);
 		final Integer destinationListId = destinationList.getId();
 
+		// copy other fields not coming in request
+		final GermplasmList originList = this.daoFactory.getGermplasmListDAO().getById(listId);
+		destinationList.setGenerationLevel(originList.getGenerationLevel());
+		this.daoFactory.getGermplasmListDAO().saveOrUpdate(destinationList);
+
+		// copy data
 		this.daoFactory.getGermplasmListDataDAO().copyEntries(listId, destinationListId);
 		this.daoFactory.getGermplasmListDataViewDAO().copyEntries(listId, destinationListId);
 		this.daoFactory.getGermplasmListDataDetailDAO().copyEntries(listId, destinationListId, loggedInUserId);

--- a/src/main/java/org/generationcp/middleware/api/germplasmlist/GermplasmListServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasmlist/GermplasmListServiceImpl.java
@@ -73,8 +73,6 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 public class GermplasmListServiceImpl implements GermplasmListService {
 
 	private final SimpleDateFormat dateFormat = new SimpleDateFormat(Util.DATE_AS_NUMBER_FORMAT);
-	private static final int MAX_CROSS_NAME_SIZE = 240;
-	private static final String TRUNCATED = "(truncated)";
 	public static final String LIST_NOT_FOUND = "list.not.found";
 
 	private final DaoFactory daoFactory;
@@ -288,13 +286,7 @@ public class GermplasmListServiceImpl implements GermplasmListService {
 		try {
 			final List<Integer> deletedListEntryIds = new ArrayList<>();
 			data.forEach(germplasmListData -> {
-				String groupName = germplasmListData.getGroupName();
-				if (groupName.length() > MAX_CROSS_NAME_SIZE) {
-					groupName = groupName.substring(0, MAX_CROSS_NAME_SIZE - 1);
-					groupName = groupName + TRUNCATED;
-					germplasmListData.setGroupName(groupName);
-				}
-
+				germplasmListData.truncateGroupNameIfNeeded();
 				final GermplasmListData recordSaved = this.daoFactory.getGermplasmListDataDAO().saveOrUpdate(germplasmListData);
 				idGermplasmListDataSaved.add(recordSaved);
 				if (!Objects.isNull(germplasmListData.getStatus()) && germplasmListData.getStatus() == 9) {

--- a/src/main/java/org/generationcp/middleware/api/germplasmlist/data/GermplasmListDataService.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasmlist/data/GermplasmListDataService.java
@@ -19,6 +19,8 @@ public interface GermplasmListDataService {
 
 	void updateGermplasmListDataView(Integer listId, List<GermplasmListDataUpdateViewDTO> view);
 
+	void fillWithCrossExpansion(Integer listId, Integer level);
+
 	List<GermplasmListDataDetail> getGermplasmListDataDetailList(Integer listId);
 
 	void reOrderEntries(Integer listId, List<Integer> selectedEntries, Integer entryNumberPosition);

--- a/src/main/java/org/generationcp/middleware/api/germplasmlist/data/GermplasmListDataServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasmlist/data/GermplasmListDataServiceImpl.java
@@ -15,6 +15,7 @@ import org.generationcp.middleware.pojos.Attribute;
 import org.generationcp.middleware.pojos.Germplasm;
 import org.generationcp.middleware.pojos.GermplasmList;
 import org.generationcp.middleware.pojos.GermplasmListColumnCategory;
+import org.generationcp.middleware.pojos.GermplasmListData;
 import org.generationcp.middleware.pojos.GermplasmListDataDefaultView;
 import org.generationcp.middleware.pojos.GermplasmListDataDetail;
 import org.generationcp.middleware.pojos.GermplasmListDataView;
@@ -241,6 +242,20 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 		}
 		germplasmList.setView(updatedView);
 		this.daoFactory.getGermplasmListDAO().save(germplasmList);
+	}
+
+	@Override
+	public void fillWithCrossExpansion(final Integer listId, final Integer level) {
+		final List<GermplasmListData> germplasmListData = this.daoFactory.getGermplasmListDataDAO().getByListId(listId);
+		final Set<Integer> gids = germplasmListData.stream().map(GermplasmListData::getGid).collect(toSet());
+
+		final Map<Integer, String> pedigreeStringMap =
+			this.pedigreeService.getCrossExpansionsBulk(gids, level, this.crossExpansionProperties);
+
+		for (final GermplasmListData entry : germplasmListData) {
+			entry.setGroupName(pedigreeStringMap.get(entry.getGid()));
+			this.daoFactory.getGermplasmListDataDAO().saveOrUpdate(entry);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/generationcp/middleware/api/germplasmlist/data/GermplasmListDataServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasmlist/data/GermplasmListDataServiceImpl.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -78,31 +77,13 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 			return response;
 		}
 
-		final boolean hasCrossData = view
-			.stream()
-			.anyMatch(c -> GermplasmListStaticColumns.CROSS.getTermId().equals(c.getStaticId()) || this.viewHasParentData(c));
-
-		if (hasCrossData) {
+		if (view.stream().anyMatch(this::viewHasParentData)) {
 			final Set<Integer> gids = response
 				.stream()
 				.map(r -> (Integer) r.getData().get(GermplasmListStaticColumns.GID.name()))
-				.collect(Collectors.toSet());
+				.collect(toSet());
 
-			final Map<Integer, String> pedigreeStringMap =
-				this.pedigreeService.getCrossExpansions(gids, null, this.crossExpansionProperties);
-
-			response.forEach(r -> {
-				final Integer gid = (Integer) r.getData().get(GermplasmListStaticColumns.GID.name());
-				r.getData().put(GermplasmListStaticColumns.CROSS.getName(), pedigreeStringMap.get(gid));
-			});
-
-			final boolean hasParentsData = view
-				.stream()
-				.anyMatch(this::viewHasParentData);
-
-			if (hasParentsData) {
-				this.addParentsFromPedigreeTable(gids, response);
-			}
+			this.addParentsFromPedigreeTable(gids, response);
 		}
 
 		return response;

--- a/src/main/java/org/generationcp/middleware/api/germplasmlist/data/GermplasmListDataServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasmlist/data/GermplasmListDataServiceImpl.java
@@ -239,6 +239,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 
 		for (final GermplasmListData entry : germplasmListData) {
 			entry.setGroupName(pedigreeStringMap.get(entry.getGid()));
+			entry.truncateGroupNameIfNeeded();
 			this.daoFactory.getGermplasmListDataDAO().saveOrUpdate(entry);
 		}
 	}

--- a/src/main/java/org/generationcp/middleware/api/germplasmlist/data/GermplasmListDataServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasmlist/data/GermplasmListDataServiceImpl.java
@@ -37,6 +37,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
 @Transactional
 @Service
 public class GermplasmListDataServiceImpl implements GermplasmListDataService {
@@ -116,7 +119,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 		final List<GermplasmListColumnDTO> columns = GermplasmListStaticColumns.getColumnsSortedByRank()
 			.map(column -> new GermplasmListColumnDTO(column.getTermId(), column.getName(), GermplasmListColumnCategory.STATIC,
 				selectedColumnIds.contains(column.getTermId())))
-			.collect(Collectors.toList());
+			.collect(toList());
 
 		final List<Integer> gids = this.daoFactory.getGermplasmListDataDAO().getGidsByListId(listId);
 		final List<UserDefinedField> nameTypes = this.daoFactory.getUserDefinedFieldDAO().getNameTypesByGIDList(gids);
@@ -125,7 +128,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 				.stream()
 				.map(nameType -> new GermplasmListColumnDTO(nameType.getFldno(), nameType.getFcode(), GermplasmListColumnCategory.NAMES,
 					selectedColumnIds.contains(nameType.getFldno())))
-				.collect(Collectors.toList());
+				.collect(toList());
 			columns.addAll(nameColumns);
 		}
 
@@ -150,7 +153,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 					return new GermplasmListColumnDTO(variable.getId(), variable.getName(), variable.getAlias(), typeId,
 						GermplasmListColumnCategory.VARIABLE, selectedColumnIds.contains(variable.getId()));
 				})
-				.collect(Collectors.toList());
+				.collect(toList());
 			columns.addAll(germplasmAttributeColumns);
 		}
 		return columns;
@@ -171,7 +174,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 		if (view.size() == entryDetailsColumnIds.size()) {
 			final List<GermplasmListMeasurementVariableDTO> defaultStaticColumns = this.transformDefaultStaticColumns();
 			final List<GermplasmListMeasurementVariableDTO> variableColumns = this.getVariableColumns(entryDetailsColumnIds, programUUID);
-			return Stream.concat(defaultStaticColumns.stream(), variableColumns.stream()).collect(Collectors.toList());
+			return Stream.concat(defaultStaticColumns.stream(), variableColumns.stream()).collect(toList());
 		}
 
 		final List<GermplasmListMeasurementVariableDTO> header = new ArrayList<>();
@@ -179,7 +182,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 			.stream()
 			.filter(GermplasmListDataView::isStaticColumn)
 			.map(GermplasmListDataView::getStaticId)
-			.collect(Collectors.toList());
+			.collect(toList());
 		if (!CollectionUtils.isEmpty(staticIds)) {
 			final List<GermplasmListMeasurementVariableDTO> staticColumns = staticIds
 				.stream()
@@ -189,7 +192,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 					return new GermplasmListMeasurementVariableDTO(staticColumn.getTermId(), staticColumn.getName(), staticColumn.name(),
 						GermplasmListColumnCategory.STATIC);
 				})
-				.collect(Collectors.toList());
+				.collect(toList());
 			header.addAll(staticColumns);
 		}
 
@@ -197,7 +200,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 			.stream()
 			.filter(GermplasmListDataView::isNameColumn)
 			.map(GermplasmListDataView::getNameFldno)
-			.collect(Collectors.toList());
+			.collect(toList());
 		if (!CollectionUtils.isEmpty(nameTypeIds)) {
 			final List<UserDefinedField> nameTypes = this.daoFactory.getUserDefinedFieldDAO().filterByColumnValues("fldno", nameTypeIds);
 			final List<GermplasmListMeasurementVariableDTO> nameColumns = nameTypes
@@ -205,7 +208,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 				.sorted(Comparator.comparing(UserDefinedField::getFcode))
 				.map(nameType -> new GermplasmListMeasurementVariableDTO(nameType.getFldno(), nameType.getFname(), nameType.getFcode(),
 					GermplasmListColumnCategory.NAMES))
-				.collect(Collectors.toList());
+				.collect(toList());
 			header.addAll(nameColumns);
 		}
 
@@ -213,7 +216,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 			.stream()
 			.filter(GermplasmListDataView::isVariableColumn)
 			.map(GermplasmListDataView::getCvtermId)
-			.collect(Collectors.toList());
+			.collect(toList());
 		final List<GermplasmListMeasurementVariableDTO> variableColumns = this.getVariableColumns(variableIds, programUUID);
 		if (!CollectionUtils.isEmpty(variableColumns)) {
 			header.addAll(variableColumns);
@@ -227,12 +230,12 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 		final List<GermplasmListDataView> entryDetailColumns = germplasmList.getView()
 			.stream()
 			.filter(GermplasmListDataView::isEntryDetailColumn)
-			.collect(Collectors.toList());
+			.collect(toList());
 
 		final List<GermplasmListDataView> updatedView = view
 			.stream()
 			.map(updateColumn -> GermplasmListDataViewFactory.create(germplasmList, updateColumn))
-			.collect(Collectors.toList());
+			.collect(toList());
 		if (!CollectionUtils.isEmpty(entryDetailColumns)) {
 			updatedView.addAll(entryDetailColumns);
 		}
@@ -307,26 +310,26 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 		}
 
 		final List<GermplasmListDataView> entryDetailsColumns =
-			view.stream().filter(GermplasmListDataView::isEntryDetailColumn).collect(Collectors.toList());
+			view.stream().filter(GermplasmListDataView::isEntryDetailColumn).collect(toList());
 		// Check if there are only entry details in view
 		if (view.size() == entryDetailsColumns.size()) {
 			final List<GermplasmListDataViewModel> defaultView = this.transformDefaultView();
 			final List<GermplasmListDataViewModel> entryDetailsModels =
-				entryDetailsColumns.stream().map(GermplasmListDataViewModel::new).collect(Collectors.toList());
-			return Stream.concat(defaultView.stream(), entryDetailsModels.stream()).collect(Collectors.toList());
+				entryDetailsColumns.stream().map(GermplasmListDataViewModel::new).collect(toList());
+			return Stream.concat(defaultView.stream(), entryDetailsModels.stream()).collect(toList());
 		}
 
 		return view
 			.stream()
 			.map(GermplasmListDataViewModel::new)
-			.collect(Collectors.toList());
+			.collect(toList());
 	}
 
 	private List<GermplasmListDataViewModel> transformDefaultView() {
 		return this.getDefaultColumns()
 			.stream()
 			.map(column -> GermplasmListDataViewModel.buildStaticGermplasmListDataViewModel(column.getTermId()))
-			.collect(Collectors.toList());
+			.collect(toList());
 	}
 
 	private List<Integer> getSelectedGermplasmListColumns(final List<GermplasmListDataView> view) {
@@ -337,7 +340,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 		final List<Integer> selectedColumnIds = view
 			.stream()
 			.map(GermplasmListDataView::getColumnId)
-			.collect(Collectors.toList());
+			.collect(toList());
 
 		final List<Integer> entryDetailsColumnsIds = this.getEntryDetailsColumnsIds(view);
 		// Check if there are only entry details added. If it's the case, add the default columns
@@ -351,7 +354,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 		return this.getDefaultColumns()
 			.stream()
 			.map(GermplasmListStaticColumns::getTermId)
-			.collect(Collectors.toList());
+			.collect(toList());
 	}
 
 	private List<GermplasmListMeasurementVariableDTO> transformDefaultStaticColumns() {
@@ -359,7 +362,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 			.stream()
 			.map(column -> new GermplasmListMeasurementVariableDTO(column.getTermId(), column.getName(), column.name(),
 				GermplasmListColumnCategory.STATIC))
-			.collect(Collectors.toList());
+			.collect(toList());
 	}
 
 	private List<GermplasmListStaticColumns> getDefaultColumns() {
@@ -369,7 +372,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 				.stream()
 				.map(GermplasmListDataDefaultView::getName)
 				.sorted(Comparator.comparingInt(GermplasmListStaticColumns::getRank))
-				.collect(Collectors.toList());
+				.collect(toList());
 		}
 		return this.defaultColumns;
 	}
@@ -379,7 +382,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 			.stream()
 			.filter(GermplasmListDataView::isEntryDetailColumn)
 			.map(GermplasmListDataView::getCvtermId)
-			.collect(Collectors.toList());
+			.collect(toList());
 	}
 
 	/**
@@ -420,7 +423,7 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 						entryDetailsColumns.add(measurementVariableDTO);
 					}
 				});
-			return Stream.concat(descriptorColumns.stream(), entryDetailsColumns.stream()).collect(Collectors.toList());
+			return Stream.concat(descriptorColumns.stream(), entryDetailsColumns.stream()).collect(toList());
 		}
 		return new ArrayList<>();
 	}

--- a/src/main/java/org/generationcp/middleware/api/germplasmlist/data/GermplasmListDataServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasmlist/data/GermplasmListDataServiceImpl.java
@@ -227,6 +227,10 @@ public class GermplasmListDataServiceImpl implements GermplasmListDataService {
 
 	@Override
 	public void fillWithCrossExpansion(final Integer listId, final Integer level) {
+		final GermplasmList germplasmList = this.daoFactory.getGermplasmListDAO().getById(listId);
+		germplasmList.setGenerationLevel(level);
+		this.daoFactory.getGermplasmListDAO().saveOrUpdate(germplasmList);
+
 		final List<GermplasmListData> germplasmListData = this.daoFactory.getGermplasmListDataDAO().getByListId(listId);
 		final Set<Integer> gids = germplasmListData.stream().map(GermplasmListData::getGid).collect(toSet());
 

--- a/src/main/java/org/generationcp/middleware/dao/germplasmlist/GermplasmListDataSearchDAO.java
+++ b/src/main/java/org/generationcp/middleware/dao/germplasmlist/GermplasmListDataSearchDAO.java
@@ -379,6 +379,7 @@ public class GermplasmListDataSearchDAO extends GenericDAO<GermplasmListData, In
 		selectClause.add(this.addSelectExpression(scalars, "listData.lrecid", LIST_DATA_ID_ALIAS));
 		selectClause.add(this.addSelectExpression(scalars, "listData.entryid", GermplasmListStaticColumns.ENTRY_NO.name()));
 		selectClause.add(this.addSelectExpression(scalars, "listData.entrycd", GermplasmListStaticColumns.ENTRY_CODE.name()));
+		selectClause.add(this.addSelectExpression(scalars, "listData.grpname", GermplasmListStaticColumns.CROSS.name()));
 		selectClause.add(this.addSelectExpression(scalars, "g.gid", GermplasmListStaticColumns.GID.name()));
 		selectClause.add(this.addSelectExpression(scalars, "g.mgid", GermplasmListStaticColumns.GROUP_ID.name()));
 		selectClause.add(this.addSelectExpression(scalars, "g.germplsm_uuid", GermplasmListStaticColumns.GUID.name()));
@@ -540,7 +541,7 @@ public class GermplasmListDataSearchDAO extends GenericDAO<GermplasmListData, In
 
 	private String addSelectExpression(final List<String> scalars, final String expression, final String columnAlias) {
 		scalars.add(columnAlias);
-		return String.format("%s AS %s", expression, columnAlias);
+		return String.format("%s AS `%s`", expression, columnAlias);
 	}
 
 	private String formatQuery(final String selectExpression, final String joinClause, final String whereClause, final String groupClause,

--- a/src/main/java/org/generationcp/middleware/pojos/GermplasmList.java
+++ b/src/main/java/org/generationcp/middleware/pojos/GermplasmList.java
@@ -113,6 +113,9 @@ public class GermplasmList implements Serializable {
 	@Column(name = "notes")
 	private String notes;
 
+	@Column(name = "generation_level")
+	private Integer generationLevel;
+
 	@OneToMany(mappedBy = "list", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
 	@OrderBy("entryId asc")
 	private List<GermplasmListData> listData = new ArrayList<>();
@@ -338,6 +341,14 @@ public class GermplasmList implements Serializable {
 
 	public void setNotes(final String notes) {
 		this.notes = notes;
+	}
+
+	public Integer getGenerationLevel() {
+		return generationLevel;
+	}
+
+	public void setGenerationLevel(final Integer generationLevel) {
+		this.generationLevel = generationLevel;
 	}
 
 	public List<GermplasmListData> getListData() {

--- a/src/main/java/org/generationcp/middleware/pojos/GermplasmList.java
+++ b/src/main/java/org/generationcp/middleware/pojos/GermplasmList.java
@@ -152,7 +152,7 @@ public class GermplasmList implements Serializable {
 	}
 
 	public GermplasmList(final Integer id, final String name, final Long date, final String type, final Integer userId,
-			final String description, final GermplasmList parent, final Integer status, final String notes) {
+		final String description, final GermplasmList parent, final Integer status, final String notes, final Integer generationLevel) {
 		super();
 		this.id = id;
 		this.name = name;
@@ -163,6 +163,7 @@ public class GermplasmList implements Serializable {
 		this.parent = parent;
 		this.status = status;
 		this.notes = notes;
+		this.generationLevel = generationLevel;
 	}
 
 	public GermplasmList(final Integer id, final String name, final Long date, final String type, final Integer userId,

--- a/src/main/java/org/generationcp/middleware/pojos/GermplasmListData.java
+++ b/src/main/java/org/generationcp/middleware/pojos/GermplasmListData.java
@@ -57,6 +57,9 @@ public class GermplasmListData implements Serializable, GermplasmExportSource {
 	// string contants for name of queries
 	public static final String DELETE_BY_LIST_ID = "deleteGermplasmListDataByListId";
 
+	public static final int MAX_CROSS_NAME_SIZE = 240;
+	public static final String CROSS_NAME_TRUNCATED_SUFFIX = "(truncated)";
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Basic(optional = false)
@@ -251,6 +254,15 @@ public class GermplasmListData implements Serializable, GermplasmExportSource {
 
 	public void setGroupName(final String groupName) {
 		this.groupName = groupName;
+	}
+
+	public void truncateGroupNameIfNeeded() {
+		String groupName = getGroupName();
+		if (groupName.length() > MAX_CROSS_NAME_SIZE) {
+			groupName = groupName.substring(0, MAX_CROSS_NAME_SIZE - 1);
+			groupName = groupName + CROSS_NAME_TRUNCATED_SUFFIX;
+			setGroupName(groupName);
+		}
 	}
 
 	public Integer getStatus() {

--- a/src/main/resources/liquibase/crop_changelog/19_5_0.xml
+++ b/src/main/resources/liquibase/crop_changelog/19_5_0.xml
@@ -6,7 +6,9 @@
 
 	<changeSet author="nahuel" id="v19.5.0-1">
 		<preConditions onFail="MARK_RAN">
-
+			<not>
+				<columnExists tableName="listnms" columnName="generation_level" />
+			</not>
 		</preConditions>
 		<comment>
 			Add generation_level column: indicates preferred cross expansion (pedigree) level for the entire list

--- a/src/main/resources/liquibase/crop_changelog/19_5_0.xml
+++ b/src/main/resources/liquibase/crop_changelog/19_5_0.xml
@@ -1,0 +1,21 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+				   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+	<changeSet author="nahuel" id="v19.5.0-1">
+		<preConditions onFail="MARK_RAN">
+
+		</preConditions>
+		<comment>
+			Add generation_level column: indicates preferred cross expansion (pedigree) level for the entire list
+		</comment>
+		<sql dbms="mysql" splitStatements="true">
+			# a property to complement (or potentially migrate) the stored pedigree in listdata.grpname
+			alter table listnms
+				add generation_level int null comment 'cross expansion (pedigree) level';
+		</sql>
+	</changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/crop_master.xml
+++ b/src/main/resources/liquibase/crop_master.xml
@@ -83,6 +83,7 @@
 	<include file="crop_changelog/19_3_0.xml" relativeToChangelogFile="true"/>
 	<include file="crop_changelog/19_4_0.xml" relativeToChangelogFile="true"/>
 	<include file="crop_changelog/19_4_3.xml" relativeToChangelogFile="true"/>
+	<include file="crop_changelog/19_5_0.xml" relativeToChangelogFile="true"/>
 
 	<!-- The following change sets must be executed at last in order to ensure that all crop change sets has already been executed at this moment -->
 	<include file="crop_changelog/functions/functions.xml" relativeToChangelogFile="true"/>

--- a/src/test/java/org/generationcp/middleware/dao/germplasmlist/GermplasmListDataDAOTest.java
+++ b/src/test/java/org/generationcp/middleware/dao/germplasmlist/GermplasmListDataDAOTest.java
@@ -25,6 +25,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.generationcp.middleware.pojos.GermplasmListData.CROSS_NAME_TRUNCATED_SUFFIX;
+import static org.generationcp.middleware.pojos.GermplasmListData.MAX_CROSS_NAME_SIZE;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
@@ -236,6 +239,20 @@ public class GermplasmListDataDAOTest extends IntegrationTestBase {
 			Assert.assertEquals("Male Parent designation should be " + parentGermplasm.getPreferredName().getNval(),
 				parentGermplasm.getPreferredName().getNval(), currentGermplasmListData.getMaleParents().get(0).getDesignation());
 		}
+	}
+
+	@Test
+	public void testTruncateGroupName() {
+		final GermplasmListData listData = this.createTestListWithListData();
+		final String groupName = randomAlphanumeric(MAX_CROSS_NAME_SIZE + 1);
+		listData.setGroupName(groupName);
+		listData.truncateGroupNameIfNeeded();
+
+		// should not thrown exception
+		this.germplasmListDataDAO.saveOrUpdate(listData);
+
+		Assert.assertThat(listData.getGroupName(), is(groupName.substring(0, MAX_CROSS_NAME_SIZE - 1) + CROSS_NAME_TRUNCATED_SUFFIX));
+
 	}
 
 	private GermplasmListData createTestListWithListData() {


### PR DESCRIPTION
- new service method: fill with cross expansion
- Store cross expansion **generationLevel** in `listnms`:
  - a property to complement (or potentially migrate in the future) the stored pedigree in listdata.grpname.
  - Set it when filling with cross expansion.
  - Use it for:
    - pre-select generation level dropdown in CROSS column
    - "add to list" actions: fill with cross expansion according to list generation level.