### PR TITLE
IBP-5621: CopZ for unknown parents should be 0 for btype=0

### DIFF
--- a/src/main/java/org/generationcp/middleware/api/germplasm/pedigree/cop/CopCalculation.java
+++ b/src/main/java/org/generationcp/middleware/api/germplasm/pedigree/cop/CopCalculation.java
@@ -69,7 +69,7 @@ public class CopCalculation {
 	private static final int UNKNOWN_INBREEDING_GENERATIONS = 4;
 	private static final int UNKNOWN_GID = 0;
 
-	private static final double COPZ_CROSS_FERTILIZING_UNKNOWN_PARENTS = 1;
+	private static final double COPZ_CROSS_FERTILIZING_UNKNOWN_PARENTS = 0;
 	private static final double COPZ_UNKNOWN_DERIVATIVE = 1;
 	private static final double COPZ_CROSS_FERTILIZING_WIDE_VARIABILITY = -1;
 


### PR DESCRIPTION
Original value was copied from python implementation:
https://github.com/IntegratedBreedingPlatform/AWSApps/blob/80756ceae4ccf6d330d8c9a8e9f02dcedeaffa50/COP/ibp_smart-module-lambda-import-master/sm-lambda-import/cop_src/cop/algorithm_v2.py#L147