### PR TITLE
IBP-5962-move-code-of-cross-and-advance-name-generation-from-commons-to-middleware

### DIFF
--- a/src/main/java/org/generationcp/middleware/ruleengine/BranchingRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/BranchingRule.java
@@ -1,0 +1,23 @@
+
+package org.generationcp.middleware.ruleengine;
+
+import java.util.List;
+
+/**
+ * An abstract class used for defining rules that branch out from the pre-defined sequence. Provides an method that is used to ensure that
+ * context state is properly maintained even when branching out from the sequence.
+ */
+public abstract class BranchingRule<T extends OrderedRuleExecutionContext> extends OrderedRule<T> {
+
+	public void prepareContextForBranchingToKey(T context, String targetKey) {
+		List<String> executionOrder = context.getExecutionOrder();
+		int currentExecutionIndex = context.getCurrentExecutionIndex();
+		List<String> previousRuleKeys = executionOrder.subList(0, currentExecutionIndex);
+		int index = previousRuleKeys.lastIndexOf(targetKey);
+
+		if (index != -1) {
+			context.setCurrentExecutionIndex(index);
+		}
+
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/Expression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/Expression.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 public interface Expression {
 
-	public void apply(List<StringBuilder> values, final String capturedText, final NamingConfiguration namingConfiguration);
+	void apply(List<StringBuilder> values, String capturedText, NamingConfiguration namingConfiguration);
 
-	public String getExpressionKey();
+	String getExpressionKey();
 
 }

--- a/src/main/java/org/generationcp/middleware/ruleengine/Expression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/Expression.java
@@ -1,0 +1,13 @@
+package org.generationcp.middleware.ruleengine;
+
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+
+import java.util.List;
+
+public interface Expression {
+
+	public void apply(List<StringBuilder> values, final String capturedText, final NamingConfiguration namingConfiguration);
+
+	public String getExpressionKey();
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/ExpressionUtils.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/ExpressionUtils.java
@@ -1,0 +1,48 @@
+package org.generationcp.middleware.ruleengine;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class ExpressionUtils {
+
+	public static final Integer DEFAULT_LENGTH = 3;
+
+	private ExpressionUtils() {
+		// utility class
+	}
+
+	public static void replaceExpressionWithValue(final String expressionKey, final StringBuilder container, final String value) {
+		final int startIndex = container.toString().toUpperCase().indexOf(expressionKey);
+		final int endIndex = startIndex + expressionKey.length();
+
+		final String replaceValue = value == null ? "" : value;
+		container.replace(startIndex, endIndex, replaceValue);
+	}
+
+	public static void replaceRegularExpressionKeyWithValue (final Pattern pattern, final StringBuilder container, final String value) {
+		final Matcher matcher = pattern.matcher(container.toString().toUpperCase());
+		if (matcher.find()) {
+			final String replaceValue = value == null ? "" : value;
+			container.replace(matcher.start(), matcher.end(), replaceValue);
+		}
+
+	}
+
+	public static Integer getNumberOfDigitsFromKey(final Pattern pattern, final StringBuilder container) {
+		final Matcher matcher = pattern.matcher(container.toString().toUpperCase());
+		// If pattern is matched but no digit specified, use default number of digits
+		Integer numberOfDigits = ExpressionUtils.DEFAULT_LENGTH;
+		if (matcher.find()) {
+			final String processCode = matcher.group();
+			// Look for a digit withing the process code, if present
+			final Pattern patternDigit = Pattern.compile("[[0-9]*]");
+			final Matcher matcherDigit = patternDigit.matcher(processCode);
+			if (matcherDigit.find()) {
+				numberOfDigits = Integer.valueOf(matcherDigit.group());
+			}
+			return numberOfDigits;
+		}
+		return 0;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/OrderedRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/OrderedRule.java
@@ -1,0 +1,27 @@
+
+package org.generationcp.middleware.ruleengine;
+
+import java.util.List;
+
+/**
+ * An abstract class that represent rules that are expected to be executed in a pre-defined sequence. Defines an implementation used by the
+ * rule engine for retrieving the next rule within the sequence
+ */
+public abstract class OrderedRule<T extends OrderedRuleExecutionContext> implements Rule<T> {
+
+	@Override
+	public String getNextRuleStepKey(T context) {
+		List<String> sequenceOrder = context.getExecutionOrder();
+		int executionIndex = context.getCurrentExecutionIndex();
+
+		// increment to the next rule in the sequence
+		executionIndex++;
+		if (executionIndex < sequenceOrder.size()) {
+			String nextKey = sequenceOrder.get(executionIndex);
+			context.setCurrentExecutionIndex(executionIndex);
+			return nextKey;
+		} else {
+			return null;
+		}
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/OrderedRuleExecutionContext.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/OrderedRuleExecutionContext.java
@@ -1,0 +1,30 @@
+
+package org.generationcp.middleware.ruleengine;
+
+import java.util.List;
+
+/**
+ * An abstract class used to define common state regarding sequential rule execution
+ */
+public abstract class OrderedRuleExecutionContext implements RuleExecutionContext {
+
+	private final List<String> executionOrder;
+	private int executionIndex;
+
+	public OrderedRuleExecutionContext(List<String> executionOrder) {
+		this.executionOrder = executionOrder;
+	}
+
+	public int getCurrentExecutionIndex() {
+		return this.executionIndex;
+	}
+
+	@Override
+	public List<String> getExecutionOrder() {
+		return this.executionOrder;
+	}
+
+	public void setCurrentExecutionIndex(int index) {
+		this.executionIndex = index;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/ProcessCodeOrderedRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/ProcessCodeOrderedRule.java
@@ -1,0 +1,8 @@
+package org.generationcp.middleware.ruleengine;
+
+/**
+ * Created by Daniel Villafuerte on 6/6/2015.
+ */
+public abstract class ProcessCodeOrderedRule<T extends OrderedRuleExecutionContext> extends OrderedRule<T> {
+    public abstract String getProcessCode();
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/ProcessCodeRuleFactory.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/ProcessCodeRuleFactory.java
@@ -1,0 +1,30 @@
+package org.generationcp.middleware.ruleengine;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by Daniel Villafuerte on 6/6/2015.
+ */
+public class ProcessCodeRuleFactory extends RuleFactory{
+
+    private Map<String, ProcessCodeOrderedRule> rulesByProcessCode;
+
+    public ProcessCodeRuleFactory() {
+        rulesByProcessCode = new HashMap<>();
+    }
+
+    @Override
+    public void addRule(Rule rule) {
+        if (rule instanceof ProcessCodeOrderedRule) {
+            ProcessCodeOrderedRule processCodeRule = (ProcessCodeOrderedRule) rule;
+            rulesByProcessCode.put(processCodeRule.getProcessCode(), processCodeRule);
+        }
+
+        super.addRule(rule);
+    }
+
+    public ProcessCodeOrderedRule getRuleByProcessCode(String processCode) {
+        return rulesByProcessCode.get(processCode);
+    }
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/Rule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/Rule.java
@@ -1,0 +1,11 @@
+
+package org.generationcp.middleware.ruleengine;
+
+public interface Rule<T extends RuleExecutionContext> {
+
+	public Object runRule(T context) throws RuleException;
+
+	public String getNextRuleStepKey(T context);
+
+	public String getKey();
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/Rule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/Rule.java
@@ -3,9 +3,9 @@ package org.generationcp.middleware.ruleengine;
 
 public interface Rule<T extends RuleExecutionContext> {
 
-	public Object runRule(T context) throws RuleException;
+	Object runRule(T context) throws RuleException;
 
-	public String getNextRuleStepKey(T context);
+	String getNextRuleStepKey(T context);
 
-	public String getKey();
+	String getKey();
 }

--- a/src/main/java/org/generationcp/middleware/ruleengine/RuleException.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/RuleException.java
@@ -1,0 +1,36 @@
+
+package org.generationcp.middleware.ruleengine;
+
+import java.util.Locale;
+
+public class RuleException extends Exception {
+
+	private static final long serialVersionUID = 5937934311090989339L;
+
+	private Object[] objects;
+
+	private Locale locale;
+
+	public RuleException(final String message, final Object[] objects, final Locale locale) {
+		super(message);
+		this.objects = objects;
+		this.locale = locale;
+	}
+
+	public RuleException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+	public RuleException(final String message) {
+		super(message);
+	}
+
+	public Object[] getObjects() {
+		return this.objects;
+	}
+
+	public Locale getLocale() {
+		return this.locale;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/RuleExecutionContext.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/RuleExecutionContext.java
@@ -1,0 +1,15 @@
+
+package org.generationcp.middleware.ruleengine;
+
+import java.util.List;
+
+/**
+ * Base interface for context objects used to store state for rule executions
+ */
+public interface RuleExecutionContext {
+
+	public List<String> getExecutionOrder();
+
+	public Object getRuleExecutionOutput();
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/RuleExecutionContext.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/RuleExecutionContext.java
@@ -8,8 +8,8 @@ import java.util.List;
  */
 public interface RuleExecutionContext {
 
-	public List<String> getExecutionOrder();
+	List<String> getExecutionOrder();
 
-	public Object getRuleExecutionOutput();
+	Object getRuleExecutionOutput();
 
 }

--- a/src/main/java/org/generationcp/middleware/ruleengine/RuleFactory.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/RuleFactory.java
@@ -1,0 +1,65 @@
+
+package org.generationcp.middleware.ruleengine;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Resource;
+
+import org.generationcp.middleware.ruleengine.provider.RuleConfigurationProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RuleFactory {
+
+	private static Logger LOG = LoggerFactory.getLogger(RuleFactory.class);
+
+	private Map<String, Rule> availableRules;
+
+	private Map<String, String[]> ruleOrder;
+
+	@Resource
+	private RuleConfigurationProvider configProvider;
+
+	public RuleFactory() {
+		this.availableRules = new HashMap<>();
+		this.ruleOrder = new HashMap<>();
+	}
+
+	public void init() {
+		this.ruleOrder = this.configProvider.getRuleSequenceConfiguration();
+	}
+
+	public void setAvailableRules(Map<String, Rule> availableRulesMap) {
+		this.availableRules = availableRulesMap;
+	}
+
+	public void addRule(Rule rule) {
+		this.availableRules.put(rule.getKey(), rule);
+	}
+
+	public Rule getRule(String key) {
+		if (key == null) {
+			return null;
+		}
+
+		return this.availableRules.get(key);
+	}
+
+	public int getAvailableRuleCount() {
+		return this.availableRules.size();
+	}
+
+	public String[] getRuleSequenceForNamespace(String namespace) {
+		if (!this.ruleOrder.containsKey(namespace)) {
+			return null;
+		}
+
+		return this.ruleOrder.get(namespace);
+	}
+
+	public Collection<String> getAvailableConfiguredNamespaces() {
+		return this.ruleOrder.keySet();
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/RulesNotConfiguredException.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/RulesNotConfiguredException.java
@@ -1,0 +1,8 @@
+package org.generationcp.middleware.ruleengine;
+
+public class RulesNotConfiguredException extends RuleException {
+
+	public RulesNotConfiguredException(final String message) {
+		super(message);
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/RulesPostProcessor.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/RulesPostProcessor.java
@@ -1,0 +1,35 @@
+
+package org.generationcp.middleware.ruleengine;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+/**
+ * Spring utility class that allows Rule objects managed by the Spring IoC container to be automatically registered into the RuleFactory
+ * object
+ */
+public class RulesPostProcessor implements BeanPostProcessor {
+
+	private RuleFactory ruleFactory;
+
+	@Override
+	public Object postProcessBeforeInitialization(Object o, String s) throws BeansException {
+		// do nothing
+		return o;
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(Object o, String s) throws BeansException {
+
+		if (o instanceof Rule) {
+			Rule rule = (Rule) o;
+			this.ruleFactory.addRule(rule);
+		}
+
+		return o;
+	}
+
+	public void setRuleFactory(RuleFactory ruleFactory) {
+		this.ruleFactory = ruleFactory;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/coding/CodingRuleExecutionContext.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/coding/CodingRuleExecutionContext.java
@@ -1,0 +1,49 @@
+package org.generationcp.middleware.ruleengine.coding;
+
+import org.generationcp.middleware.ruleengine.OrderedRuleExecutionContext;
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+
+import java.util.List;
+
+public class CodingRuleExecutionContext extends OrderedRuleExecutionContext {
+
+	private static final String EMPTY_STRING = "";
+	private final NamingConfiguration namingConfiguration;
+	private Integer startNumber;
+	private String currentData = EMPTY_STRING;
+
+	public CodingRuleExecutionContext(final List<String> executionOrder, final NamingConfiguration namingConfiguration) {
+		super(executionOrder);
+		this.namingConfiguration = namingConfiguration;
+	}
+
+	@Override
+	public Object getRuleExecutionOutput() {
+		return this.currentData;
+	}
+
+	public NamingConfiguration getNamingConfiguration() {
+		return namingConfiguration;
+	}
+
+	public Integer getStartNumber() {
+		return startNumber;
+	}
+
+	public void setStartNumber(final Integer startNumber) {
+		this.startNumber = startNumber;
+	}
+
+	public String getCurrentData() {
+		return currentData;
+	}
+
+	public void setCurrentData(final String currentData) {
+		this.currentData = currentData;
+	}
+
+	public void reset() {
+		this.setCurrentData(EMPTY_STRING);
+		this.setCurrentExecutionIndex(0);
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/coding/CountRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/coding/CountRule.java
@@ -1,0 +1,41 @@
+package org.generationcp.middleware.ruleengine.coding;
+
+import org.generationcp.middleware.ruleengine.OrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.coding.expression.CodingExpressionResolver;
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+
+@Component
+public class CountRule extends OrderedRule<CodingRuleExecutionContext> {
+
+	public static final String KEY = "Count";
+
+	@Resource
+	private CodingExpressionResolver codingExpressionResolver;
+
+	@Override
+	public Object runRule(final CodingRuleExecutionContext context) throws RuleException {
+
+		final NamingConfiguration namingConfiguration = context.getNamingConfiguration();
+		String count = context.getNamingConfiguration().getCount();
+
+		if (count == null) {
+			count = "";
+		}
+
+		final String resolvedData = codingExpressionResolver.resolve(context.getCurrentData(), count, namingConfiguration).get(0);
+
+		context.setCurrentData(resolvedData);
+
+		return resolvedData;
+
+	}
+
+	@Override
+	public String getKey() {
+		return CountRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/coding/PrefixRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/coding/PrefixRule.java
@@ -1,0 +1,41 @@
+package org.generationcp.middleware.ruleengine.coding;
+
+import org.generationcp.middleware.ruleengine.OrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.coding.expression.CodingExpressionResolver;
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+
+@Component
+public class PrefixRule extends OrderedRule<CodingRuleExecutionContext> {
+
+	public static final String KEY = "Prefix";
+
+	@Resource
+	private CodingExpressionResolver codingExpressionResolver;
+
+	@Override
+	public Object runRule(final CodingRuleExecutionContext context) throws RuleException {
+
+		final NamingConfiguration namingConfiguration = context.getNamingConfiguration();
+		String prefix = context.getNamingConfiguration().getPrefix();
+
+		if (prefix == null) {
+			prefix = "";
+		}
+
+		final String resolvedData = codingExpressionResolver.resolve(context.getCurrentData(), prefix, namingConfiguration).get(0);
+
+		context.setCurrentData(resolvedData);
+
+		return resolvedData;
+
+	}
+
+	@Override
+	public String getKey() {
+		return PrefixRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/coding/SuffixRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/coding/SuffixRule.java
@@ -1,0 +1,41 @@
+package org.generationcp.middleware.ruleengine.coding;
+
+import org.generationcp.middleware.ruleengine.OrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.coding.expression.CodingExpressionResolver;
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+
+@Component
+public class SuffixRule extends OrderedRule<CodingRuleExecutionContext> {
+
+	public static final String KEY = "Suffix";
+
+	@Resource
+	private CodingExpressionResolver codingExpressionResolver;
+
+	@Override
+	public Object runRule(final CodingRuleExecutionContext context) throws RuleException {
+
+		final NamingConfiguration namingConfiguration = context.getNamingConfiguration();
+		String suffix = context.getNamingConfiguration().getSuffix();
+
+		if (suffix == null) {
+			suffix = "";
+		}
+
+		final String resolvedData = codingExpressionResolver.resolve(context.getCurrentData(), suffix, namingConfiguration).get(0);
+
+		context.setCurrentData(resolvedData);
+
+		return resolvedData;
+
+	}
+
+	@Override
+	public String getKey() {
+		return SuffixRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/coding/expression/BaseCodingExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/coding/expression/BaseCodingExpression.java
@@ -1,0 +1,16 @@
+package org.generationcp.middleware.ruleengine.coding.expression;
+
+import org.generationcp.middleware.ruleengine.Expression;
+import org.generationcp.middleware.ruleengine.ExpressionUtils;
+
+import java.util.regex.Pattern;
+
+public abstract class BaseCodingExpression implements Expression {
+
+	void replaceRegularExpressionKeyWithValue(final StringBuilder container, final String value) {
+		ExpressionUtils.replaceRegularExpressionKeyWithValue(this.getPattern(), container, value);
+	}
+
+	abstract Pattern getPattern();
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/coding/expression/CodingExpressionFactory.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/coding/expression/CodingExpressionFactory.java
@@ -1,0 +1,39 @@
+package org.generationcp.middleware.ruleengine.coding.expression;
+
+import org.generationcp.middleware.ruleengine.Expression;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CodingExpressionFactory {
+
+	private Map<String, Expression> expressionMap;
+
+	public void init() {
+
+		this.expressionMap = new HashMap<>();
+
+	}
+
+	/**
+	 * @param pattern
+	 * @return the first Expression that match the pattern
+	 */
+	public Expression lookup(final String pattern) {
+		if (this.expressionMap.containsKey(pattern)) {
+			return this.expressionMap.get(pattern);
+		}
+		for (final String key : this.expressionMap.keySet()) {
+			if (key != null && pattern.matches(key)) {
+				final Expression expression = this.expressionMap.get(key);
+				this.expressionMap.put(pattern, expression); // memoize
+				return expression;
+			}
+		}
+		return null;
+	}
+
+	public void addExpression(final Expression expression) {
+		this.expressionMap.put(expression.getExpressionKey(), expression);
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/coding/expression/CodingExpressionPostProcessor.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/coding/expression/CodingExpressionPostProcessor.java
@@ -1,0 +1,26 @@
+package org.generationcp.middleware.ruleengine.coding.expression;
+
+import org.generationcp.middleware.ruleengine.Expression;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+public class CodingExpressionPostProcessor implements BeanPostProcessor {
+
+	private CodingExpressionFactory codingExpressionFactory;
+
+	@Override
+	public Object postProcessBeforeInitialization(final Object o, final String s) {
+		return o;
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(final Object o, final String s) {
+		if (o instanceof BaseCodingExpression) {
+			codingExpressionFactory.addExpression((Expression) o);
+		}
+		return o;
+	}
+
+	public void setCodingExpressionFactory(final CodingExpressionFactory codingExpressionFactory) {
+		this.codingExpressionFactory = codingExpressionFactory;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/coding/expression/CodingExpressionResolver.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/coding/expression/CodingExpressionResolver.java
@@ -1,0 +1,51 @@
+package org.generationcp.middleware.ruleengine.coding.expression;
+
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+import org.generationcp.middleware.ruleengine.Expression;
+import org.generationcp.middleware.ruleengine.util.ExpressionHelper;
+import org.generationcp.middleware.ruleengine.util.ExpressionHelperCallback;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+public class CodingExpressionResolver {
+
+	@Resource
+	private CodingExpressionFactory factory;
+
+	public List<String> resolve(final String currentInput, final String processCode, final NamingConfiguration namingConfiguration) {
+		final List<String> newNames = new ArrayList<>();
+
+		if (processCode == null) {
+			return newNames;
+		}
+
+		final List<StringBuilder> builders = new ArrayList<>();
+		builders.add(new StringBuilder(currentInput + processCode));
+
+		ExpressionHelper.evaluateExpression(processCode, ExpressionHelper.PROCESS_CODE_PATTERN, new ExpressionHelperCallback() {
+
+			@Override
+			public void evaluateCapturedExpression(final String capturedText, final String originalInput, final int start, final int end) {
+				final Expression expression = CodingExpressionResolver.this.factory.lookup(capturedText);
+
+				// It's possible for the expression to add more elements to the builders variable.
+				if (expression != null) {
+					expression.apply(builders, capturedText, namingConfiguration);
+				}
+			}
+		});
+
+		for (final StringBuilder builder : builders) {
+			newNames.add(builder.toString());
+		}
+
+		return newNames;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/coding/expression/PaddedSequenceExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/coding/expression/PaddedSequenceExpression.java
@@ -1,0 +1,30 @@
+package org.generationcp.middleware.ruleengine.coding.expression;
+
+import org.generationcp.middleware.ruleengine.ExpressionUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+@Component
+public class PaddedSequenceExpression extends SequenceExpression {
+
+	private static final String PADSEQ_BASE = "PADSEQ";
+	public static final String PATTERN_KEY = "\\[" + PADSEQ_BASE + "(\\.[0-9]+)*\\]";
+	public static final Pattern PATTERN = Pattern.compile(PATTERN_KEY);
+
+	@Override
+	public Integer getNumberOfDigits(final StringBuilder container) {
+		return ExpressionUtils.getNumberOfDigitsFromKey(PATTERN, container);
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return PaddedSequenceExpression.PATTERN_KEY;
+	}
+
+	@Override
+	public Pattern getPattern() {
+		return PaddedSequenceExpression.PATTERN;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/coding/expression/SequenceExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/coding/expression/SequenceExpression.java
@@ -1,0 +1,51 @@
+package org.generationcp.middleware.ruleengine.coding.expression;
+
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+import org.generationcp.middleware.ruleengine.naming.service.GermplasmNamingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+@Component
+public class SequenceExpression extends BaseCodingExpression {
+
+	// Insert double black slash since we're replacing by regular expressions
+	private static final String KEY = "\\[SEQUENCE\\]";
+	private static final Pattern PATTERN = Pattern.compile(SequenceExpression.KEY);
+
+	@Autowired
+	protected GermplasmNamingService germplasmNamingService;
+
+	// This setter is only used to inject this service only in test
+	public void setGermplasmNamingService(final GermplasmNamingService germplasmNamingService) {
+		this.germplasmNamingService = germplasmNamingService;
+	}
+
+	@Override
+	public void apply(final List<StringBuilder> values, final String capturedText, final NamingConfiguration namingConfiguration) {
+		final String prefix = namingConfiguration.getPrefix();
+		for (final StringBuilder container : values) {
+			final Integer lastUsedSequence = this.germplasmNamingService.getNextNumberAndIncrementSequence(prefix);
+			final String numberString =
+				this.germplasmNamingService.getNumberWithLeadingZeroesAsString(lastUsedSequence, this.getNumberOfDigits(container));
+			this.replaceRegularExpressionKeyWithValue(container, numberString);
+		}
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return SequenceExpression.KEY;
+	}
+
+	@Override
+	public Pattern getPattern() {
+		return SequenceExpression.PATTERN;
+	}
+
+	public Integer getNumberOfDigits(final StringBuilder container) {
+		return 1;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/cross/BackCrossSuffixRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/cross/BackCrossSuffixRule.java
@@ -1,0 +1,51 @@
+
+package org.generationcp.middleware.ruleengine.cross;
+
+import org.generationcp.middleware.ruleengine.ProcessCodeOrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.exceptions.MiddlewareQueryException;
+import org.generationcp.middleware.manager.PedigreeDataManagerImpl;
+import org.springframework.stereotype.Component;
+
+/**
+ * Created by Daniel Villafuerte on 6/6/2015.
+ */
+@Component
+public class BackCrossSuffixRule extends ProcessCodeOrderedRule<CrossingRuleExecutionContext> {
+
+	static final String KEY = "BACKCROSSSUFFIX";
+	static final String MALE_RECURRENT_SUFFIX = "M";
+	static final String FEMALE_RECURRENT_SUFFIX = "F";
+	static final String PROCESS_CODE = "[BC]";
+
+	@Override
+	public String getKey() {
+		return KEY;
+	}
+
+	@Override
+	public Object runRule(final CrossingRuleExecutionContext context) throws RuleException {
+		try {
+			final int computation = context.getPedigreeDataManager().calculateRecurrentParent(context.getMaleGid(), context.getFemaleGid());
+
+			String output = context.getCurrentCrossName() == null ? "" : context.getCurrentCrossName();
+			if (PedigreeDataManagerImpl.FEMALE_RECURRENT == computation) {
+				output += FEMALE_RECURRENT_SUFFIX;
+			} else if (PedigreeDataManagerImpl.MALE_RECURRENT == computation) {
+				output += MALE_RECURRENT_SUFFIX;
+			}
+
+			context.setCurrentCrossName(output);
+
+			return output;
+		} catch (MiddlewareQueryException e) {
+			throw new RuleException(e.getMessage(), e);
+		}
+
+	}
+
+	@Override
+	public String getProcessCode() {
+		return PROCESS_CODE;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/cross/CrossingRuleExecutionContext.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/cross/CrossingRuleExecutionContext.java
@@ -1,0 +1,91 @@
+
+package org.generationcp.middleware.ruleengine.cross;
+
+import java.util.List;
+
+import org.generationcp.middleware.ruleengine.OrderedRuleExecutionContext;
+import org.generationcp.middleware.ruleengine.settings.CrossSetting;
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.manager.api.PedigreeDataManager;
+
+/**
+ * Created by Daniel Villafuerte on 6/6/2015.
+ */
+public class CrossingRuleExecutionContext extends OrderedRuleExecutionContext {
+
+	private GermplasmDataManager germplasmDataManager;
+	private PedigreeDataManager pedigreeDataManager;
+
+	private Integer maleGid;
+	private Integer femaleGid;
+	private String currentCrossName;
+	private CrossSetting crossSetting;
+
+	public CrossingRuleExecutionContext(final List<String> executionOrder, final CrossSetting crossSetting, final Integer maleGid,
+			final Integer femaleGid, final GermplasmDataManager germplasmDataManager, final PedigreeDataManager pedigreeDataManager) {
+		super(executionOrder);
+		this.crossSetting = crossSetting;
+		this.maleGid = maleGid;
+		this.germplasmDataManager = germplasmDataManager;
+		this.pedigreeDataManager = pedigreeDataManager;
+		this.femaleGid = femaleGid;
+		this.currentCrossName = "";
+	}
+
+	public CrossingRuleExecutionContext(final List<String> executionOrder) {
+		super(executionOrder);
+	}
+
+	@Override
+	public Object getRuleExecutionOutput() {
+		return null;
+	}
+
+	public Integer getFemaleGid() {
+		return femaleGid;
+	}
+
+	public void setFemaleGid(final Integer femaleGid) {
+		this.femaleGid = femaleGid;
+	}
+
+	public Integer getMaleGid() {
+		return maleGid;
+	}
+
+	public void setMaleGid(final Integer maleGid) {
+		this.maleGid = maleGid;
+	}
+
+	public String getCurrentCrossName() {
+		return currentCrossName;
+	}
+
+	public void setCurrentCrossName(final String currentCrossName) {
+		this.currentCrossName = currentCrossName;
+	}
+
+	public GermplasmDataManager getGermplasmDataManager() {
+		return germplasmDataManager;
+	}
+
+	public void setGermplasmDataManager(final GermplasmDataManager germplasmDataManager) {
+		this.germplasmDataManager = germplasmDataManager;
+	}
+
+	public CrossSetting getCrossSetting() {
+		return crossSetting;
+	}
+
+	public void setCrossSetting(final CrossSetting crossSetting) {
+		this.crossSetting = crossSetting;
+	}
+
+	public PedigreeDataManager getPedigreeDataManager() {
+		return pedigreeDataManager;
+	}
+
+	public void setPedigreeDataManager(final PedigreeDataManager pedigreeDataManager) {
+		this.pedigreeDataManager = pedigreeDataManager;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/generator/BreedersCrossIDGenerator.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/generator/BreedersCrossIDGenerator.java
@@ -1,0 +1,90 @@
+package org.generationcp.middleware.ruleengine.generator;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.ontology.VariableType;
+import org.generationcp.middleware.manager.api.StudyDataManager;
+import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
+import org.generationcp.middleware.ruleengine.resolver.HabitatDesignationResolver;
+import org.generationcp.middleware.ruleengine.resolver.KeyComponentValueResolver;
+import org.generationcp.middleware.ruleengine.resolver.LocationAbbreviationResolver;
+import org.generationcp.middleware.ruleengine.resolver.LocationResolver;
+import org.generationcp.middleware.ruleengine.resolver.ProjectPrefixResolver;
+import org.generationcp.middleware.ruleengine.resolver.SeasonResolver;
+import org.generationcp.middleware.ruleengine.service.GermplasmNamingProperties;
+import org.generationcp.middleware.service.api.dataset.DatasetService;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitRow;
+import org.generationcp.middleware.service.api.study.StudyInstanceService;
+import org.generationcp.middleware.service.impl.study.StudyInstance;
+
+import javax.annotation.Nullable;
+import javax.annotation.Resource;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class BreedersCrossIDGenerator {
+
+	protected static final List<Integer> ENVIRONMENT_VARIABLE_TYPES = Lists.newArrayList(VariableType.ENVIRONMENT_DETAIL.getId());
+
+	@Resource
+	private GermplasmNamingProperties germplasmNamingProperties;
+
+	@Resource
+	private OntologyVariableDataManager ontologyVariableDataManager;
+
+	@Resource
+	private DatasetService datasetService;
+
+	@Resource
+	private StudyDataManager studyDataManager;
+
+	@Resource
+	private StudyInstanceService studyInstanceMiddlewareService;
+
+	@SuppressWarnings("Duplicates")
+	public String generateBreedersCrossID(final int studyId, final Integer environmentDatasetId,
+		final List<MeasurementVariable> conditions, final ObservationUnitRow observationUnitRow) {
+
+		final KeyCodeGenerationService service = new KeyCodeGenerationServiceImpl();
+		final Map<String, String> locationIdNameMap = this.studyDataManager.createInstanceLocationIdToNameMapFromStudy(studyId);
+		final Map<Integer, StudyInstance> studyInstanceMap =
+			this.studyInstanceMiddlewareService.getStudyInstances(studyId).stream().collect(
+			Collectors.toMap(StudyInstance::getInstanceNumber, i -> i));
+
+		final Map<Integer, MeasurementVariable> environmentVariablesByTermId =
+			Maps.uniqueIndex(this.datasetService.getObservationSetVariables(environmentDatasetId, ENVIRONMENT_VARIABLE_TYPES),
+				new Function<MeasurementVariable, Integer>() {
+
+					@Nullable
+					@Override
+					public Integer apply(@Nullable final MeasurementVariable measurementVariable) {
+						return measurementVariable.getTermId();
+					}
+				});
+
+		final Map<KeyComponent, KeyComponentValueResolver> keyComponentValueResolvers = new HashMap<>();
+		keyComponentValueResolvers.put(KeyComponent.PROJECT_PREFIX,
+			new ProjectPrefixResolver(this.ontologyVariableDataManager, conditions, observationUnitRow,
+				environmentVariablesByTermId));
+		keyComponentValueResolvers.put(KeyComponent.HABITAT_DESIGNATION,
+			new HabitatDesignationResolver(this.ontologyVariableDataManager, conditions, observationUnitRow,
+				environmentVariablesByTermId));
+		keyComponentValueResolvers.put(KeyComponent.SEASON,
+			new SeasonResolver(this.ontologyVariableDataManager, conditions, observationUnitRow,
+				environmentVariablesByTermId));
+		keyComponentValueResolvers.put(KeyComponent.LOCATION,
+				new LocationResolver(conditions, observationUnitRow, locationIdNameMap));
+		keyComponentValueResolvers.put(KeyComponent.LABBR,
+			new LocationAbbreviationResolver(observationUnitRow, studyInstanceMap));
+		return service
+				.generateKey(new BreedersCrossIDTemplateProvider(this.germplasmNamingProperties), keyComponentValueResolvers);
+	}
+
+	protected void setGermplasmNamingProperties(final GermplasmNamingProperties germplasmNamingProperties) {
+		this.germplasmNamingProperties = germplasmNamingProperties;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/generator/BreedersCrossIDTemplateProvider.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/generator/BreedersCrossIDTemplateProvider.java
@@ -1,0 +1,20 @@
+package org.generationcp.middleware.ruleengine.generator;
+
+import org.generationcp.middleware.ruleengine.service.GermplasmNamingProperties;
+import org.generationcp.middleware.ruleengine.service.KeyTemplateProvider;
+
+public class BreedersCrossIDTemplateProvider implements KeyTemplateProvider {
+
+	private final GermplasmNamingProperties germplasmNamingProperties;
+
+	public BreedersCrossIDTemplateProvider(final GermplasmNamingProperties germplasmNamingProperties){
+		this.germplasmNamingProperties = germplasmNamingProperties;
+	}
+
+	@Override
+	public String getKeyTemplate() {
+		String breedersCrossIDTemplate = "";
+		breedersCrossIDTemplate = this.germplasmNamingProperties.getBreedersCrossIDStudy();
+		return breedersCrossIDTemplate;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/generator/KeyCodeGenerationService.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/generator/KeyCodeGenerationService.java
@@ -1,0 +1,29 @@
+package org.generationcp.middleware.ruleengine.generator;
+
+import org.generationcp.middleware.ruleengine.resolver.KeyComponentValueResolver;
+import org.generationcp.middleware.ruleengine.service.KeyTemplateProvider;
+
+import java.util.Map;
+
+/**
+ * Common interface to generate "key codes". Key codes are essentially business keys and are usually constructed from real world entities
+ * and events e.g. Germplasm, Nurseries, Locations, Planting Seasons, Plot Numbers, Breeding Program Codes, People etc.
+ * 
+ */
+public interface KeyCodeGenerationService {
+
+	/**
+	 * Generate key code. First calls the supplied template provider to locate the template. Then replaces each placeholder within the
+	 * template with a value by calling the corresponding key component value resolver.
+	 * 
+	 * @param keyTemplateProvider - Implementation of a {@link KeyTemplateProvider} that knows how to locate the template for the key. This
+	 *        parameters must not be {@code null}.
+	 * @param keyComponentValueResolvers - Registrty map of {@link KeyComponentValueResolver}'s that know how to resolve values for each of
+	 *        the {@link KeyComponent} place holder present in the template. It is responsibility of the clients of the service to ensure
+	 *        that each placeholder in the template has a corresponding value resolver, the service does not validate this at the moment. If
+	 *        value resolvers are missing for some placeholders in the template, those placeholders will come out as it is in template. This
+	 *        parameter must not be {@code null}.
+	 * @return The generated key code.
+	 */
+	String generateKey(KeyTemplateProvider keyTemplateProvider, Map<KeyComponent, KeyComponentValueResolver> keyComponentValueResolvers);
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/generator/KeyCodeGenerationServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/generator/KeyCodeGenerationServiceImpl.java
@@ -1,0 +1,46 @@
+
+package org.generationcp.middleware.ruleengine.generator;
+
+import com.google.common.base.Strings;
+import org.generationcp.middleware.ruleengine.resolver.KeyComponentValueResolver;
+import org.generationcp.middleware.ruleengine.service.KeyTemplateProvider;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class KeyCodeGenerationServiceImpl implements KeyCodeGenerationService {
+
+
+	@Override
+	public String generateKey(KeyTemplateProvider keyTemplateProvider, Map<KeyComponent, KeyComponentValueResolver> keyComponentValueResolvers) {
+
+		String key = keyTemplateProvider.getKeyTemplate();
+		Set<KeyComponent> keySet = keyComponentValueResolvers.keySet();
+		Iterator<KeyComponent> iterator = keySet.iterator();
+
+		while (iterator.hasNext()) {
+			KeyComponent keyComponent = iterator.next();
+
+			Pattern pattern = Pattern.compile("(\\[" + keyComponent.name() + "\\])");
+			Matcher matcher = pattern.matcher(key);
+
+			KeyComponentValueResolver keyComponentValueResolver = keyComponentValueResolvers.get(keyComponent);
+			String resolvedValue = keyComponentValueResolver.resolve();
+
+			if (!keyComponentValueResolver.isOptional()) {
+				key = matcher.replaceAll(Strings.nullToEmpty(resolvedValue));
+			} else {
+				if (!Strings.isNullOrEmpty(resolvedValue)) {
+					key = matcher.replaceAll("-" + resolvedValue);
+				} else {
+					key = matcher.replaceAll("");
+				}
+			}
+		}
+		return key;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/generator/KeyComponent.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/generator/KeyComponent.java
@@ -1,0 +1,21 @@
+
+package org.generationcp.middleware.ruleengine.generator;
+
+/**
+ * Entities or events that are used as placeholders in key code templates.
+ * 
+ */
+public enum KeyComponent {
+
+	NAME,
+	LOCATION,
+	SEASON,
+	PLOTNO,
+	SELECTION_NUMBER,
+	PROJECT_PREFIX,
+	HABITAT_DESIGNATION,
+	CROSS_TYPE,
+	PLANT_NO,
+	LABBR;
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/generator/SeedSourceGenerator.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/generator/SeedSourceGenerator.java
@@ -1,0 +1,165 @@
+package org.generationcp.middleware.ruleengine.generator;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.generationcp.middleware.ContextHolder;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
+import org.generationcp.middleware.pojos.Name;
+import org.generationcp.middleware.ruleengine.pojo.ImportedCross;
+import org.generationcp.middleware.ruleengine.resolver.KeyComponentValueResolver;
+import org.generationcp.middleware.ruleengine.resolver.LocationAbbreviationResolver;
+import org.generationcp.middleware.ruleengine.resolver.LocationResolver;
+import org.generationcp.middleware.ruleengine.resolver.SeasonResolver;
+import org.generationcp.middleware.ruleengine.service.GermplasmNamingProperties;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitRow;
+import org.generationcp.middleware.service.impl.study.StudyInstance;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class SeedSourceGenerator {
+
+	private static final String MULTIPARENT_BEGIN_CHAR = "[";
+	private static final String MULTIPARENT_END_CHAR = "]";
+	private static final String SEEDSOURCE_SEPARATOR = "/";
+
+	@Resource
+	private GermplasmNamingProperties germplasmNamingProperties;
+
+	@Resource
+	private OntologyVariableDataManager ontologyVariableDataManager;
+
+	public SeedSourceGenerator() {
+
+	}
+
+	public String generateSeedSource(final ObservationUnitRow observationUnitRow,
+		final List<MeasurementVariable> conditions, final String selectionNumber,
+		final String plotNumber, final String studyName, final String plantNumber, final Map<String, String> locationIdNameMap,
+		final Map<Integer, StudyInstance> studyInstanceMap,
+		final List<MeasurementVariable> environmentVariables) {
+
+		if ("0".equals(plotNumber)) {
+			return Name.UNKNOWN;
+		}
+
+		final KeyCodeGenerationService service = new KeyCodeGenerationServiceImpl();
+
+		final KeyComponentValueResolver nameResolver = new KeyComponentValueResolver() {
+
+			@Override
+			public String resolve() {
+				return studyName;
+			}
+
+			@Override
+			public boolean isOptional() {
+				return false;
+			}
+		};
+
+		final KeyComponentValueResolver plotNumberResolver = new KeyComponentValueResolver() {
+
+			@Override
+			public String resolve() {
+				return plotNumber;
+			}
+
+			@Override
+			public boolean isOptional() {
+				return false;
+			}
+		};
+
+		final KeyComponentValueResolver selectionNumberResolver = new KeyComponentValueResolver() {
+
+			@Override
+			public String resolve() {
+				return selectionNumber;
+			}
+
+			@Override
+			public boolean isOptional() {
+				return true;
+			}
+		};
+
+		final KeyComponentValueResolver plantNumberResolver = new KeyComponentValueResolver() {
+
+			@Override
+			public String resolve() {
+				return plantNumber;
+			}
+
+			@Override
+			public boolean isOptional() {
+				// Setting to not optional so that "-" wont be appended before plant number when it is specified
+				return false;
+			}
+		};
+
+		final Map<Integer, MeasurementVariable> environmentVariablesByTermId =
+			environmentVariables.stream().collect(Collectors.toMap(MeasurementVariable::getTermId, v -> v));
+
+
+		final Map<KeyComponent, KeyComponentValueResolver> keyComponentValueResolvers = new HashMap<>();
+		keyComponentValueResolvers.put(KeyComponent.NAME, nameResolver);
+		keyComponentValueResolvers.put(KeyComponent.PLOTNO, plotNumberResolver);
+		keyComponentValueResolvers.put(KeyComponent.SELECTION_NUMBER, selectionNumberResolver);
+		keyComponentValueResolvers.put(KeyComponent.PLANT_NO, plantNumberResolver);
+		keyComponentValueResolvers.put(KeyComponent.LOCATION,
+			new LocationResolver(conditions, observationUnitRow, locationIdNameMap));
+		keyComponentValueResolvers.put(KeyComponent.LABBR,
+			new LocationAbbreviationResolver(observationUnitRow, studyInstanceMap));
+		keyComponentValueResolvers.put(KeyComponent.SEASON,
+			new SeasonResolver(this.ontologyVariableDataManager, conditions, observationUnitRow,
+				environmentVariablesByTermId));
+
+		return service.generateKey(new SeedSourceTemplateProvider(this.germplasmNamingProperties,
+			ContextHolder.getCurrentCrop()), keyComponentValueResolvers);
+	}
+
+	public String generateSeedSourceForCross(final Pair<ObservationUnitRow, ObservationUnitRow> environmentRow,
+		final Pair<List<MeasurementVariable>, List<MeasurementVariable>> conditions,
+		final Pair<Map<String, String>, Map<String, String>> locationIdNameMap,
+		final Pair<Map<Integer, StudyInstance>, Map<Integer, StudyInstance>> studyInstanceMap,
+		final Pair<List<MeasurementVariable>, List<MeasurementVariable>> environmentVariables, final ImportedCross crossInfo) {
+
+		final List<String> generatedSeedSources = new ArrayList<>();
+
+		final Integer femalePlotNo = crossInfo.getFemalePlotNo();
+		final String femaleSeedSource =
+			this.generateSeedSource(environmentRow.getLeft(),
+				conditions.getLeft(), null, femalePlotNo != null? femalePlotNo.toString() : "", crossInfo.getFemaleStudyName(), null,
+				locationIdNameMap.getLeft(), studyInstanceMap.getLeft(), environmentVariables.getLeft());
+
+		final List<Integer> malePlotNos = crossInfo.getMalePlotNos();
+		for (final Integer malePlotNo : malePlotNos) {
+			final String maleSeedSource =
+				this.generateSeedSource(environmentRow.getRight(),
+					conditions.getRight(), null, malePlotNo != null ? malePlotNo.toString() : "", crossInfo.getMaleStudyName(), null,
+					locationIdNameMap.getRight(), studyInstanceMap.getRight(),
+					environmentVariables.getRight());
+			generatedSeedSources.add(maleSeedSource);
+		}
+		if (malePlotNos.size() > 1) {
+			return femaleSeedSource + SeedSourceGenerator.SEEDSOURCE_SEPARATOR + SeedSourceGenerator.MULTIPARENT_BEGIN_CHAR
+				+ StringUtils.join(generatedSeedSources, ", ") + SeedSourceGenerator.MULTIPARENT_END_CHAR;
+		}
+
+		return femaleSeedSource + SeedSourceGenerator.SEEDSOURCE_SEPARATOR + generatedSeedSources.get(0);
+	}
+
+
+	protected void setGermplasmNamingProperties(final GermplasmNamingProperties germplasmNamingProperties) {
+		this.germplasmNamingProperties = germplasmNamingProperties;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/generator/SeedSourceTemplateProvider.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/generator/SeedSourceTemplateProvider.java
@@ -1,0 +1,44 @@
+
+package org.generationcp.middleware.ruleengine.generator;
+
+import org.generationcp.middleware.ruleengine.service.GermplasmNamingProperties;
+import org.generationcp.middleware.ruleengine.service.KeyTemplateProvider;
+
+/**
+ * Locates the key code templates for seed source (currently, from properties file, in future this may be loaded from database configuration
+ * service).
+ * 
+ */
+public class SeedSourceTemplateProvider implements KeyTemplateProvider {
+
+	public static final String WHEAT = "wheat";
+	public static final String MAIZE = "maize";
+	private GermplasmNamingProperties germplasmNamingProperties;
+	private final String crop;
+
+	public SeedSourceTemplateProvider(final GermplasmNamingProperties germplasmNamingProperties, final String crop) {
+		this.germplasmNamingProperties = germplasmNamingProperties;
+		this.crop = crop;
+	}
+
+	@Override
+	public String getKeyTemplate() {
+		String seedSourceTemplate;
+
+		seedSourceTemplate = this.germplasmNamingProperties.getGermplasmOriginStudiesDefault();
+
+		if (this.crop.equals(WHEAT)) {
+			seedSourceTemplate = this.germplasmNamingProperties.getGermplasmOriginStudiesWheat();
+		} else if (this.crop.equals(MAIZE)) {
+			seedSourceTemplate = this.germplasmNamingProperties.getGermplasmOriginStudiesMaize();
+		} else {
+			seedSourceTemplate = this.germplasmNamingProperties.getGermplasmOriginStudiesDefault();
+		}
+		return seedSourceTemplate;
+	}
+
+	public void setGermplasmNamingProperties(final GermplasmNamingProperties germplasmNamingProperties) {
+		this.germplasmNamingProperties = germplasmNamingProperties;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/impl/RulesServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/impl/RulesServiceImpl.java
@@ -30,7 +30,7 @@ public class RulesServiceImpl implements RulesService {
 	@Override
 	public Object runRules(RuleExecutionContext context) throws RuleException {
 
-		Monitor monitor = MonitorFactory.start("AdvanceNursery:org.generationcp.commons.ruleengine.impl.RulesServiceImpl.runRules");
+		Monitor monitor = MonitorFactory.start(this.getClass().getName() + ".runRules");
 		
 		try{
 		

--- a/src/main/java/org/generationcp/middleware/ruleengine/impl/RulesServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/impl/RulesServiceImpl.java
@@ -1,0 +1,57 @@
+
+package org.generationcp.middleware.ruleengine.impl;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.generationcp.middleware.ruleengine.Rule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.RuleExecutionContext;
+import org.generationcp.middleware.ruleengine.RuleFactory;
+import org.generationcp.middleware.ruleengine.service.RulesService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.jamonapi.Monitor;
+import com.jamonapi.MonitorFactory;
+
+public class RulesServiceImpl implements RulesService {
+
+	@Resource
+	private RuleFactory ruleFactory;
+	
+	public static final Logger LOG = LoggerFactory.getLogger(RulesServiceImpl.class);
+
+	public RulesServiceImpl() {
+	}
+
+	// FIXME : catch RuleExceptions here?
+	@Override
+	public Object runRules(RuleExecutionContext context) throws RuleException {
+
+		Monitor monitor = MonitorFactory.start("AdvanceNursery:org.generationcp.commons.ruleengine.impl.RulesServiceImpl.runRules");
+		
+		try{
+		
+  		List<String> sequenceOrder = context.getExecutionOrder();
+  
+  		assert !sequenceOrder.isEmpty();
+  		Rule rule = this.ruleFactory.getRule(sequenceOrder.get(0));
+  
+  		while (rule != null) {
+  			rule.runRule(context);
+  			rule = this.ruleFactory.getRule(rule.getNextRuleStepKey(context));
+  		}
+		} finally {
+		  monitor.stop();
+		}
+
+		return context.getRuleExecutionOutput();
+
+	}
+
+	public void setRuleFactory(RuleFactory ruleFactory) {
+		this.ruleFactory = ruleFactory;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeExpression.java
@@ -1,0 +1,43 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+
+public abstract class AttributeExpression implements Expression {
+
+	// TODO: move to a global app constants
+	protected static String METHOD_TYPE_GEN = "GEN";
+	protected static String	METHOD_TYPE_DER = "DER";
+	protected static String METHOD_TYPE_MAN= "MAN";
+
+	protected Integer getGroupSourceGID(final AdvancingSource source) {
+
+		final Integer sourceGpid1 = source.getGermplasm().getGpid1();
+		final Integer sourceGpid2 = source.getGermplasm().getGpid2();
+		final Method sourceMethod = source.getSourceMethod();
+
+		if (sourceMethod != null && sourceMethod.getMtype() != null && METHOD_TYPE_GEN
+				.equals(sourceMethod.getMtype()) || source.getGermplasm().getGnpgs() < 0 && (sourceGpid1 != null && sourceGpid1.equals(0))
+				&& (sourceGpid2 != null && sourceGpid2.equals(0))) {
+			// If the source germplasm is a new CROSS, then the group source is the cross itself
+			return Integer.valueOf(source.getGermplasm().getGid());
+		} else {
+			// Else group source gid is always the female parent of the source germplasm.
+			return source.getGermplasm().getGpid1();
+		}
+
+	}
+
+	protected void replaceAttributeExpressionWithValue(final StringBuilder container, final String attributeKey, final Integer variableId,
+			final String value) {
+		final String key = "[" + attributeKey + "." + variableId + "]";
+		int start = container.indexOf(key, 0);
+		while (start > -1) {
+			int end = start + key.length();
+			int nextSearchStart = start + value.length();
+			container.replace(start, end, value);
+			start = container.indexOf(key, nextSearchStart);
+		}
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeFemaleParentExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeFemaleParentExpression.java
@@ -1,0 +1,59 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.pojos.Germplasm;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class AttributeFemaleParentExpression extends AttributeExpression {
+
+	// Example: ATTRFP.2000
+	public static final String ATTRIBUTE_KEY = "ATTRFP";
+	public static final String PATTERN_KEY = "\\[" + ATTRIBUTE_KEY + "\\.([^\\.]*)\\]";
+
+	@Autowired
+	private GermplasmDataManager germplasmDataManager;
+
+	@Override
+	public void apply(final List<StringBuilder> values, final AdvancingSource source, final String capturedText) {
+
+		final Method breedingMethod = source.getBreedingMethod();
+		Integer gpid1 = null;
+		if (METHOD_TYPE_GEN.equals(breedingMethod.getMtype())) {
+			// If the method is Generative, GPID1 refers to the GID of the female parent
+			gpid1 = Integer.valueOf(source.getFemaleGid());
+		} else if (METHOD_TYPE_DER.equals(breedingMethod.getMtype()) || METHOD_TYPE_MAN.equals(breedingMethod.getMtype())) {
+
+			// if the method is Derivative or Maintenance, GPID1 refers to the female parent of the group source
+			final Integer groupSourceGID = getGroupSourceGID(source);
+			gpid1 = getSourceParentGID(groupSourceGID);
+
+		}
+
+		final Integer variableId = Integer.valueOf(capturedText.substring(1, capturedText.length() - 1).split("\\.")[1]);
+		final String attributeValue = germplasmDataManager.getAttributeValue(gpid1, variableId);
+
+		for (final StringBuilder value : values) {
+			replaceAttributeExpressionWithValue(value, ATTRIBUTE_KEY, variableId, attributeValue);
+		}
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return AttributeFemaleParentExpression.PATTERN_KEY;
+	}
+
+	protected Integer getSourceParentGID(final Integer gid) {
+		final Germplasm groupSource = this.germplasmDataManager.getGermplasmByGID(gid);
+		if (groupSource != null) {
+			return groupSource.getGpid1();
+		} else {
+			return null;
+		}
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeMaleParentExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeMaleParentExpression.java
@@ -1,0 +1,59 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.pojos.Germplasm;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class AttributeMaleParentExpression extends AttributeExpression {
+
+	// Example: ATTRMP.2000
+	public static final String ATTRIBUTE_KEY = "ATTRMP";
+	public static final String PATTERN_KEY = "\\[" + ATTRIBUTE_KEY + "\\.([^\\.]*)\\]";
+
+	@Autowired
+	private GermplasmDataManager germplasmDataManager;
+
+	@Override
+	public void apply(final List<StringBuilder> values, final AdvancingSource source, final String capturedText) {
+
+		final Method breedingMethod = source.getBreedingMethod();
+		Integer gpid2 = null;
+		if (METHOD_TYPE_GEN.equals(breedingMethod.getMtype())) {
+			// If the method is Generative, GPID2 refers to male parent of the cross
+			gpid2 = Integer.valueOf(source.getMaleGid());
+		} else if (METHOD_TYPE_DER.equals(breedingMethod.getMtype()) || METHOD_TYPE_MAN.equals(breedingMethod.getMtype())) {
+
+			// If the method is Derivative or Maintenance, GPID2 refers to the male parent of the group source
+			final Integer groupSourceGid = this.getGroupSourceGID(source);
+			gpid2 = this.getSourceParentGID(groupSourceGid);
+
+		}
+
+		final Integer variableId = Integer.valueOf(capturedText.substring(1, capturedText.length() - 1).split("\\.")[1]);
+		final String attributeValue = germplasmDataManager.getAttributeValue(gpid2, variableId);
+
+		for (final StringBuilder value : values) {
+			this.replaceAttributeExpressionWithValue(value, ATTRIBUTE_KEY, variableId, attributeValue);
+		}
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return AttributeMaleParentExpression.PATTERN_KEY;
+	}
+
+	protected Integer getSourceParentGID(final Integer gid) {
+		final Germplasm groupSource = this.germplasmDataManager.getGermplasmByGID(gid);
+		if (groupSource != null) {
+			return groupSource.getGpid2();
+		} else {
+			return null;
+		}
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeSourceExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeSourceExpression.java
@@ -1,0 +1,37 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class AttributeSourceExpression extends AttributeExpression {
+
+	@Autowired
+	private GermplasmDataManager germplasmDataManager;
+
+	public static final String ATTRIBUTE_KEY = "ATTRSC";
+	public static final String PATTERN_KEY = "\\[" + ATTRIBUTE_KEY + "\\.([^\\.]*)\\]"; // Example: ATTRSC.1010
+
+	@Override
+	public void apply(final List<StringBuilder> values, final AdvancingSource source, final String capturedText) {
+		for (final StringBuilder value : values) {
+			String newValue = "";
+			final Integer variableId = Integer.valueOf(capturedText.substring(1, capturedText.length() - 1).split("\\.")[1]);
+			if (METHOD_TYPE_DER.equals(source.getBreedingMethod().getMtype())
+				|| METHOD_TYPE_MAN.equals(source.getBreedingMethod().getMtype())) {
+				newValue = germplasmDataManager.getAttributeValue(Integer.parseInt(source.getGermplasm().getGid()), variableId);
+			}
+			this.replaceAttributeExpressionWithValue(value, ATTRIBUTE_KEY, variableId, newValue);
+		}
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return AttributeSourceExpression.PATTERN_KEY;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/BackcrossExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/BackcrossExpression.java
@@ -1,0 +1,46 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.manager.PedigreeDataManagerImpl;
+import org.generationcp.middleware.manager.api.PedigreeDataManager;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class BackcrossExpression extends BaseExpression {
+
+	public static final String KEY = "[BC]";
+	static final String MALE_RECURRENT_SUFFIX = "M";
+	static final String FEMALE_RECURRENT_SUFFIX = "F";
+
+	@Autowired
+	private PedigreeDataManager pedigreeDataManager;
+
+	@Override
+	public void apply(final List<StringBuilder> values, final AdvancingSource source, final String capturedText) {
+
+		String output = "";
+
+		final int computation = pedigreeDataManager.calculateRecurrentParent(source.getMaleGid(), source.getFemaleGid());
+
+		if (PedigreeDataManagerImpl.FEMALE_RECURRENT == computation) {
+			output += FEMALE_RECURRENT_SUFFIX;
+		} else if (PedigreeDataManagerImpl.MALE_RECURRENT == computation) {
+			output += MALE_RECURRENT_SUFFIX;
+		}
+
+		for (StringBuilder value : values) {
+
+			this.replaceExpressionWithValue(value, output);
+
+		}
+
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return BackcrossExpression.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/BaseExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/BaseExpression.java
@@ -1,0 +1,10 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.ExpressionUtils;
+
+public abstract class BaseExpression implements Expression {
+
+	protected void replaceExpressionWithValue(final StringBuilder container, final String value) {
+		ExpressionUtils.replaceExpressionWithValue(this.getExpressionKey(), container, value);
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/BracketsExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/BracketsExpression.java
@@ -1,0 +1,47 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.manager.GermplasmNameType;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class BracketsExpression extends BaseExpression {
+
+	public static final String KEY = "[BRACKETS]";
+
+	public BracketsExpression() {
+	}
+
+	@Override
+	public void apply(List<StringBuilder> values, AdvancingSource source, final String capturedText) {
+		for (StringBuilder container : values) {
+
+			String newRootName = source.getRootName();
+
+			if (source.getRootNameType() != null && this.isCrossNameType(source.getRootNameType())) {
+
+				// if root name already has parentheses
+				if (newRootName.charAt(0) != '(' || newRootName.charAt(newRootName.length() - 1) != ')') {
+					this.replaceExpressionWithValue(container, ")");
+					container.insert(0, "(");
+					continue;
+				}
+			} else {
+				this.replaceExpressionWithValue(container, "");
+			}
+		}
+	}
+
+	protected boolean isCrossNameType(Integer nameTypeId) {
+		return GermplasmNameType.CROSS_NAME.getUserDefinedFieldID() == nameTypeId
+				|| GermplasmNameType.ALTERNATE_CROSS_NAME.getUserDefinedFieldID() == nameTypeId;
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return BracketsExpression.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/BreedersCrossIDExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/BreedersCrossIDExpression.java
@@ -1,0 +1,43 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.generator.BreedersCrossIDGenerator;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static org.generationcp.middleware.service.api.dataset.ObservationUnitUtils.fromMeasurementRow;
+
+@Component
+public class BreedersCrossIDExpression extends BaseExpression {
+
+	@Autowired
+	private BreedersCrossIDGenerator breedersCrossIDGenerator;
+
+	public static final String KEY = "[CIMCRS]";
+
+	public BreedersCrossIDExpression() {
+	}
+
+	@Override
+	public void apply(final List<StringBuilder> values, final AdvancingSource source, final String capturedText) {
+
+		/**
+		 * Refer NamingConventionServiceImpl.addImportedGermplasmToList method
+		 * It requires AdvancingStudy as well, here we are not able to get AdvancingStudy instance
+		 * Basic Implementation has been added to calculate SelectionNumber
+		 */
+		for (final StringBuilder container : values) {
+			final String newValue = this.breedersCrossIDGenerator
+				.generateBreedersCrossID(source.getStudyId(), source.getEnvironmentDatasetId(), source.getConditions(),
+					fromMeasurementRow(source.getTrailInstanceObservation()));
+			this.replaceExpressionWithValue(container, newValue);
+		}
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return BreedersCrossIDExpression.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/BulkCountExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/BulkCountExpression.java
@@ -1,0 +1,68 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.apache.commons.lang3.math.NumberUtils;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.ruleengine.util.ExpressionHelper;
+import org.generationcp.middleware.ruleengine.util.ExpressionHelperCallback;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class BulkCountExpression extends BaseExpression {
+
+	public static final String KEY = "[BCOUNT]";
+
+	public BulkCountExpression() {
+	}
+
+	@Override
+	public void apply(List<StringBuilder> values, AdvancingSource source, final String capturedText) {
+		for (StringBuilder container : values) {
+            String computedValue;
+			if (source.getRootName() != null) {
+				BulkExpressionHelperCallback callback = new BulkExpressionHelperCallback();
+				ExpressionHelper.evaluateExpression(source.getRootName(), "-([0-9]*)B", callback);
+
+				StringBuilder lastBulkCount = callback.getLastBulkCount();
+
+				if (lastBulkCount.length() > 0) {
+					computedValue = (Integer.valueOf(lastBulkCount.toString()) + 1) + "B";
+				} else {
+					computedValue = "-B";
+				}
+			} else {
+                computedValue = "-B";
+			}
+
+            this.replaceExpressionWithValue(container, computedValue);
+		}
+	}
+
+	private class BulkExpressionHelperCallback implements ExpressionHelperCallback {
+
+		final StringBuilder lastBulkCount = new StringBuilder();
+
+		@Override
+		public void evaluateCapturedExpression(String capturedText, String originalInput, int start, int end) {
+			if ("-B".equals(capturedText)) {
+				this.lastBulkCount.replace(0, this.lastBulkCount.length(), "1");
+			} else {
+				String newCapturedText = capturedText.replaceAll("[-B]*", "");
+				if (newCapturedText != null && NumberUtils.isNumber(newCapturedText)) {
+					this.lastBulkCount.replace(0, this.lastBulkCount.length(), newCapturedText);
+				}
+			}
+		}
+
+		public StringBuilder getLastBulkCount() {
+			return this.lastBulkCount;
+		}
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return BulkCountExpression.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/ChangeLocationExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/ChangeLocationExpression.java
@@ -1,0 +1,46 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.exceptions.MiddlewareQueryException;
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.pojos.Germplasm;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+import java.util.List;
+
+@Component
+public class ChangeLocationExpression extends BaseExpression {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ChangeLocationExpression.class);
+
+    public static final String KEY = "[CLABBR]";
+
+    @Resource
+    private GermplasmDataManager germplasmDataManager;
+
+    @Override
+    public void apply(List<StringBuilder> values, AdvancingSource source, final String capturedText) {
+        for (StringBuilder container : values) {
+
+            try {
+                Germplasm originalGermplasm = germplasmDataManager.getGermplasmByGID(Integer.valueOf(source.getGermplasm().getGid()));
+                String suffixValue = "";
+                if (source.getHarvestLocationId() != null && !originalGermplasm.getLocationId().equals(source.getHarvestLocationId())) {
+                    suffixValue = source.getLocationAbbreviation();
+                }
+
+                this.replaceExpressionWithValue(container, suffixValue);
+            } catch (MiddlewareQueryException e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+    }
+
+    @Override
+    public String getExpressionKey() {
+        return KEY;
+    }
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/ComponentPostProcessor.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/ComponentPostProcessor.java
@@ -1,0 +1,35 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.RulesPostProcessor;
+import org.generationcp.middleware.ruleengine.naming.impl.ProcessCodeFactory;
+import org.springframework.beans.BeansException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Created by Daniel Villafuerte on 6/15/2015.
+ */
+public class ComponentPostProcessor extends RulesPostProcessor{
+
+    private ProcessCodeFactory processCodeFactory;
+
+    @Override
+    public Object postProcessAfterInitialization(Object o, String s) throws BeansException {
+        super.postProcessAfterInitialization(o, s);
+        if (o instanceof Expression) {
+            processCodeFactory.addExpression((Expression) o);
+        }
+
+        return o;
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object o, String s) throws BeansException {
+        return super.postProcessBeforeInitialization(o, s);
+    }
+
+    @Autowired
+    public void setProcessCodeFactory(ProcessCodeFactory processCodeFactory) {
+        this.processCodeFactory = processCodeFactory;
+    }
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/CrossTypeExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/CrossTypeExpression.java
@@ -1,0 +1,90 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ContextHolder;
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.pojos.Germplasm;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.ruleengine.pojo.ImportedGermplasm;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CrossTypeExpression extends BaseExpression {
+
+	public static final String KEY = "[CRSTYP]";
+
+	private static final String SINGLE_CROSS = "Single cross";
+	private static final String DOUBLE_CROSS = "Double cross";
+	private static final String TOP_CROSS_MAIZE = "Test cross";
+	private static final String TOP_CROSS_WHEAT = "Three-way cross";
+	private static final String BACK_CROSS = "Backcross";
+
+	public static final String WHEAT = "wheat";
+	public static final String MAIZE = "maize";
+
+	@Autowired
+	private GermplasmDataManager germplasmDataManager;
+
+	public CrossTypeExpression() {
+	}
+
+	@Override
+	public void apply(final List<StringBuilder> values, final AdvancingSource source, final String capturedText) {
+		String crossTypeAbbreviation = "";
+		final Method breedingMethod = source.getBreedingMethod();
+
+		if (breedingMethod.getMname().equals(SINGLE_CROSS)) {
+			crossTypeAbbreviation = "S";
+		} else if (breedingMethod.getMname().equals(DOUBLE_CROSS)) {
+			crossTypeAbbreviation = "D";
+		} else if (breedingMethod.getMname().equals(BACK_CROSS)) {
+			crossTypeAbbreviation = getRecurrentParentType(source.getGermplasm());
+		} else if(this.isTopCrossMethod(breedingMethod)){
+			crossTypeAbbreviation = "T";
+		}
+
+		for (final StringBuilder container : values) {
+
+			this.replaceExpressionWithValue(container, crossTypeAbbreviation);
+		}
+	}
+
+	private String getRecurrentParentType(final ImportedGermplasm importedGermplasm){
+
+		final Integer gid = Integer.parseInt(importedGermplasm.getGid());
+
+		final Germplasm germplasm = this.germplasmDataManager.getGermplasmByGID(gid);
+
+		if(germplasm.getGpid1() == null || germplasm.getGpid2() == null) {
+			return "";
+		}
+
+		final Germplasm femaleParent = this.germplasmDataManager.getGermplasmByGID(germplasm.getGpid1());
+		final Germplasm maleParent = this.germplasmDataManager.getGermplasmByGID(germplasm.getGpid2());
+
+		if (maleParent.getGnpgs() >= 2
+				&& (femaleParent.getGid().equals(maleParent.getGpid1()) || femaleParent.getGid().equals(maleParent.getGpid2()))) {
+
+			return "F";
+		} else if (femaleParent.getGnpgs() >= 2
+				&& (maleParent.getGid().equals(femaleParent.getGpid1()) || maleParent.getGid().equals(femaleParent.getGpid2()))) {
+			return "M";
+		}
+
+		return "";
+	}
+
+	private boolean isTopCrossMethod(final Method breedingMethod){
+		final String cropName = ContextHolder.getCurrentCrop();
+		return cropName.equalsIgnoreCase(WHEAT) && breedingMethod.getMname().equals(TOP_CROSS_WHEAT)
+				|| cropName.equalsIgnoreCase(MAIZE) && breedingMethod.getMname().equals(TOP_CROSS_MAIZE);
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return CrossTypeExpression.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/DoubleHaploidSourceExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/DoubleHaploidSourceExpression.java
@@ -1,0 +1,65 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.service.api.KeySequenceRegisterService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class DoubleHaploidSourceExpression extends BaseExpression {
+
+	public static final String KEY = "[DHSOURCE]";
+
+	@Autowired
+	protected KeySequenceRegisterService keySequenceRegisterService;
+
+	// This setter is only used to inject this service only in test
+	public void setKeySequenceRegisterService(final KeySequenceRegisterService keySequenceRegisterService) {
+		this.keySequenceRegisterService = keySequenceRegisterService;
+	}
+
+	/**
+	 * Method to append '@' + [lastUsedSequence] in designation column ex. @1, @2 etc.
+	 * @param values       Designation column value
+	 * @param source       Advancing Source object contains information about source
+	 * @param capturedText
+	 */
+	@Override
+	public void apply(final List<StringBuilder> values, final AdvancingSource source, final String capturedText) {
+		for (final StringBuilder value : values) {
+			final int checkIndex = value.lastIndexOf("@0");
+			if (checkIndex != -1) {
+				synchronized (DoubleHaploidSourceExpression.class) {
+					final String keyPrefix = value.substring(0, checkIndex + 1);
+					// Get last sequence number for KeyPrefix with synchronization at class level
+					final int lastUsedSequence = this.keySequenceRegisterService.incrementAndGetNextSequence(keyPrefix);
+					this.replaceExistingSuffixValue(value, checkIndex + 1);
+					this.replaceExpressionWithValue(value, String.valueOf(lastUsedSequence));
+				}
+
+			} else {
+				// If designation does not contains @0 string then keep its value as it is
+				this.replaceExpressionWithValue(value, "");
+			}
+		}
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return KEY;
+	}
+
+	/**
+	 * Replace the existing suffix value '0' from designation with empty String
+	 *
+	 * @param container  designation value
+	 * @param startIndex starting index of 0
+	 */
+	private void replaceExistingSuffixValue(final StringBuilder container, final int startIndex) {
+		final int endIndex = startIndex + 1;
+		container.replace(startIndex, endIndex, "");
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/Expression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/Expression.java
@@ -1,0 +1,13 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+
+import java.util.List;
+
+public interface Expression {
+
+	void apply(List<StringBuilder> values, AdvancingSource source, final String capturedText);
+
+	String getExpressionKey();
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/FirstExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/FirstExpression.java
@@ -1,0 +1,52 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Used as a separator with a string literal immediately following it. Otherwise, it will be disregarded.
+ */
+
+@Component
+public class FirstExpression extends BaseExpression {
+
+	public static final String KEY = "[FIRST]";
+
+	public FirstExpression() {
+
+	}
+
+	@Override
+	public void apply(List<StringBuilder> values, AdvancingSource source, final String capturedText) {
+		String separatorExpression = source.getBreedingMethod().getSeparator();
+
+		for (StringBuilder value : values) {
+			if (separatorExpression != null && separatorExpression.toString().toUpperCase().contains(FirstExpression.KEY)) {
+				int start = separatorExpression.toString().toUpperCase().indexOf(FirstExpression.KEY) + FirstExpression.KEY.length();
+				int end = separatorExpression.indexOf("[", start);
+				if (end == -1) {
+					end = separatorExpression.length();
+				}
+				String literalSeparator = separatorExpression.substring(start, end);
+
+				int index = source.getRootName().indexOf(literalSeparator);
+				if (index > -1) {
+					String newRootName = source.getRootName().substring(0, index);
+					start = value.indexOf(source.getRootName());
+					end = start + source.getRootName().length();
+					value.replace(start, end, newRootName);
+				}
+			}
+
+			this.replaceExpressionWithValue(value, "");
+		}
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return FirstExpression.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/GroupCountExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/GroupCountExpression.java
@@ -1,0 +1,165 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.apache.commons.lang3.StringUtils;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class GroupCountExpression extends BaseExpression {
+
+	public static final String KEY = "[COUNT]";
+	public static final Integer MINIMUM_BULK_COUNT = 2;
+	public static final String BULK_COUNT_PREFIX = "B*";
+	public static final String POUND_COUNT_PREFIX = "#*";
+	public static final int CAPTURED_FINAL_EXPRESSION_GROUP = 1;
+
+	@Override
+	public void apply(final List<StringBuilder> values, final AdvancingSource source, final String capturedText) {
+		for (final StringBuilder value : values) {
+			String currentValue = value.toString();
+
+			// this code handles two variants of this process code : B*[COUNT] and #*[COUNT]. Here we retrieve the "prefix" to determine
+			// which (B* or #*)
+			final String countPrefix = this.getCountPrefix(currentValue);
+
+			// when processing B*[COUNT], we count B's. for #*[COUNT], #. Here we determine which
+			final String targetCountExpression = this.getTargetCountExpression(countPrefix);
+
+			// we remove meta characters added by our process code system so that they don't interfere with processing
+			final String noMetaString = removeMetaCharacters(currentValue, countPrefix, source);
+
+			final CountResultBean result = this.countExpressionOccurence(targetCountExpression, noMetaString);
+			int generatedCountValue = result.getCount();
+
+			// if the method is a bulking method, we're expected to increment the count
+			if (source.getBreedingMethod().isBulkingMethod()) {
+				generatedCountValue = result.getCount() + 1;
+			}
+
+			// we remove the captured expression entirely so that we have a blank slate when writing the resulting count
+			currentValue = this.cleanupString(new StringBuilder(noMetaString), result);
+
+			if (generatedCountValue >= MINIMUM_BULK_COUNT) {
+
+				currentValue = currentValue + targetCountExpression + "*" + String.valueOf(generatedCountValue);
+				value.delete(0, value.length());
+				value.append(currentValue);
+			} else {
+				value.delete(0, value.length());
+				value.append(currentValue);
+
+				// do while loop is used because there should be a -B or -# appended if the count is 0
+				int i = 0;
+				do {
+                    if (!StringUtils.isEmpty(source.getBreedingMethod().getSeparator())) {
+                        value.append(source.getBreedingMethod().getSeparator());
+                    }
+
+					value.append(targetCountExpression);
+					i++;
+				} while (i < result.getCount());
+
+			}
+
+		}
+	}
+
+	protected String removeMetaCharacters(final String value, final String countPrefix, final AdvancingSource source) {
+		// we strip the B*[COUNT] or #*COUNT from the name being processed
+		String valueWithoutProcessCode = value.replace(countPrefix + this.getExpressionKey(), "");
+
+		// if in case a separator is defined for the breeding method, it will have been added to the end of the name. we'll need to remove
+		// it so that it doesn't hide the character we're looking to count (which is expected to be at the end of the line)
+		if (!StringUtils.isEmpty(source.getBreedingMethod().getSeparator())
+				&& valueWithoutProcessCode.endsWith(source.getBreedingMethod().getSeparator())) {
+			final int lastIndex = valueWithoutProcessCode.lastIndexOf(source.getBreedingMethod().getSeparator());
+			valueWithoutProcessCode = valueWithoutProcessCode.substring(0, lastIndex);
+		}
+
+		return valueWithoutProcessCode;
+	}
+
+	protected String cleanupString(final StringBuilder value, final CountResultBean result) {
+		value.replace(result.getStart(), result.getEnd(), "");
+
+		return value.toString();
+	}
+
+	protected String getCountPrefix(final String input) {
+		final int start = input.indexOf(GroupCountExpression.KEY);
+        // the prefix is the first two characters ahead of the [COUNT]; e.g., B* or #*
+		return input.substring(start - 2, start);
+	}
+
+	protected String getTargetCountExpression(final String countPrefix) {
+		if (GroupCountExpression.BULK_COUNT_PREFIX.equals(countPrefix)) {
+			return "B";
+		} else if (GroupCountExpression.POUND_COUNT_PREFIX.equals(countPrefix)) {
+			return "#";
+		} else {
+			throw new IllegalArgumentException("Invalid count expression");
+		}
+	}
+
+	public CountResultBean countExpressionOccurence(final String expression, final String currentValue) {
+		final Pattern pattern = Pattern.compile("(" + expression + "([*][1-9])*)$");
+		final Matcher matcher = pattern.matcher(currentValue);
+
+		int startIndex = 0;
+		int endIndex = 0;
+		int count = 0;
+		if (matcher.find()) {
+			count = 1;
+			// if there is a *n instance found
+			if (matcher.groupCount() == 2) {
+				final String existingCountString = matcher.group(2);
+				if (!StringUtils.isEmpty(existingCountString)) {
+					final int existingCount = Integer.parseInt(existingCountString.replace("*", ""));
+					count += existingCount - 1;
+				}
+
+			}
+
+			startIndex = matcher.start(CAPTURED_FINAL_EXPRESSION_GROUP);
+			endIndex = matcher.end(CAPTURED_FINAL_EXPRESSION_GROUP);
+		}
+
+		return new CountResultBean(count, startIndex, endIndex);
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return GroupCountExpression.KEY;
+	}
+
+	class CountResultBean {
+
+		private final int count;
+		private final int start;
+		private final int end;
+
+		public CountResultBean(final int count, final int start, final int end) {
+			this.count = count;
+			this.start = start;
+			this.end = end;
+		}
+
+		public int getCount() {
+			return this.count;
+		}
+
+		public int getStart() {
+			return this.start;
+		}
+
+		public int getEnd() {
+			return this.end;
+		}
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/LocationAbbreviationExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/LocationAbbreviationExpression.java
@@ -1,0 +1,29 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class LocationAbbreviationExpression extends BaseExpression {
+
+	public static final String KEY = "[LABBR]";
+
+	public LocationAbbreviationExpression() {
+	}
+
+	@Override
+	public void apply(List<StringBuilder> values, AdvancingSource source, final String capturedText) {
+		for (StringBuilder container : values) {
+			String newValue = source.getLocationAbbreviation();
+			this.replaceExpressionWithValue(container, newValue);
+		}
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return LocationAbbreviationExpression.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/NumberExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/NumberExpression.java
@@ -1,0 +1,71 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class NumberExpression extends BaseExpression implements Expression {
+
+	public static final String KEY = "[NUMBER]";
+
+	public NumberExpression() {
+
+	}
+
+	@Override
+	public void apply(final List<StringBuilder> values, final AdvancingSource source, final String capturedText) {
+		if (source.isForceUniqueNameGeneration()) {
+			for (final StringBuilder container : values) {
+				this.replaceExpressionWithValue(container, "(" + (source.getCurrentMaxSequence() + 1) + ")");
+
+			}
+
+			return;
+		}
+
+		if (source.isBulk()) {
+			for (final StringBuilder container : values) {
+				if (source.getPlantsSelected() != null && source.getPlantsSelected() > 1) {
+					final Integer newValue = source.getPlantsSelected();
+					this.replaceExpressionWithValue(container, newValue != null ? newValue.toString() : "");
+				} else {
+					this.replaceExpressionWithValue(container, "");
+				}
+			}
+		} else {
+			final List<StringBuilder> newNames = new ArrayList<>();
+			int startCount = 1;
+
+			if (source.getCurrentMaxSequence() > -1) {
+				startCount = source.getCurrentMaxSequence() + 1;
+			}
+
+			for (final StringBuilder value : values) {
+				if (source.getPlantsSelected() != null && source.getPlantsSelected() > 0) {
+
+					for (int i = startCount; i < startCount + source.getPlantsSelected(); i++) {
+						final StringBuilder newName = new StringBuilder(value);
+						this.replaceExpressionWithValue(newName, String.valueOf(i));
+						newNames.add(newName);
+					}
+				} else {
+					this.replaceExpressionWithValue(value, "");
+					newNames.add(value);
+				}
+			}
+
+			values.clear();
+			values.addAll(newNames);
+		}
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return NumberExpression.KEY;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/PaddedSequenceExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/PaddedSequenceExpression.java
@@ -1,0 +1,29 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.ExpressionUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+@Component
+public class PaddedSequenceExpression extends SequenceExpression {
+
+
+
+	@Override
+	public Integer getNumberOfDigits(final StringBuilder container) {
+		return ExpressionUtils.getNumberOfDigitsFromKey(org.generationcp.middleware.ruleengine.coding.expression.PaddedSequenceExpression.PATTERN, container);
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return org.generationcp.middleware.ruleengine.coding.expression.PaddedSequenceExpression.PATTERN_KEY;
+	}
+
+	@Override
+	public Pattern getPattern() {
+		return org.generationcp.middleware.ruleengine.coding.expression.PaddedSequenceExpression.PATTERN;
+	}
+
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/RootNameExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/RootNameExpression.java
@@ -1,0 +1,130 @@
+/**
+ * Snametype: is null or contains a name type id number from the UDFLDS table. See below for some example Snametypes. If not null and if the
+ * germplasm being advanced has a name of the specified type, then this is used as the root name of the advanced strain otherwise the
+ * preferred name of the source is used. If the root name is a cross string (contains one or more /s not enclosed within the range of a pair
+ * of parentheses) then enclose the root name in parentheses.
+ */
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.manager.GermplasmNameType;
+import org.generationcp.middleware.pojos.Name;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class RootNameExpression implements Expression {
+
+	@Override
+	public void apply(final List<StringBuilder> values, final AdvancingSource source, final String capturedText) {
+		for (final StringBuilder value : values) {
+			final Integer snametype = source.getBreedingMethod().getSnametype();
+			Name name = null;
+			final List<Name> names = source.getNames();
+
+			// this checks the matching sname type of the method to the names
+			if (snametype != null) {
+				name = this.findNameUsingNameType(snametype, names);
+			}
+			// this checks the names with nstat == 1
+			if (name == null) {
+				// if no sname type defined or if no name found that matched the snametype
+				name = this.findPreferredName(names);
+			}
+			// this checks the type id equal to 5
+			if (name == null) {
+				name = this.findNameUsingNameType(GermplasmNameType.DERIVATIVE_NAME.getUserDefinedFieldID(), names);
+			}
+			String nameString = "";
+			// the default is type id 5
+			Integer typeId = GermplasmNameType.DERIVATIVE_NAME.getUserDefinedFieldID();
+			// if the snametype for the method is not null, we use the method sname type
+			if (snametype != null) {
+				typeId = snametype;
+			}
+			// if we found a matching name, we use the name type id instead
+			if (name != null) {
+				nameString = name.getNval();
+				typeId = name.getTypeId();
+			}
+
+			source.setRootNameType(typeId);
+			source.setRootName(nameString);
+
+			if (!this.checkNameIfEnclosed(nameString)) {
+				value.append("(").append(nameString).append(")");
+			} else {
+				value.append(nameString);
+			}
+		}
+	}
+
+	public Name findNameUsingNameType(final Integer nameType, final List<Name> names) {
+		if (names == null) {
+			return null;
+		}
+
+		for (final Name name : names) {
+			if (name.getTypeId() != null && name.getTypeId().equals(nameType)) {
+				return name;
+			}
+		}
+
+		return null;
+	}
+
+	public Name findPreferredName(final List<Name> names) {
+		if (names == null) {
+			return null;
+		}
+
+		for (final Name name : names) {
+			if (name.getNstat() != null && name.getNstat().equals(1)) {
+				return name;
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return null;
+	}
+
+	private boolean checkNameIfEnclosed(final String name) {
+		int index = name.indexOf("/", 0);
+		while (index > -1 && index < name.length()) {
+			if (!this.checkIfEnclosed(name, index)) {
+				return false;
+			}
+
+			index = name.indexOf("/", index + 1);
+		}
+		return true;
+	}
+
+	private boolean checkIfEnclosed(final String name, final int index) {
+
+		return this.checkNeighbor(name, index, '(', -1, 0, ')') && this.checkNeighbor(name, index, ')', 1, name.length() - 1, '(');
+	}
+
+	private boolean checkNeighbor(final String name, final int index, final char literal, final int delta, final int stopPoint,
+			final char oppositeLiteral) {
+		int oppositeCount = 0;
+		for (int i = index + delta; i != stopPoint + delta; i = i + delta) {
+			if (name.charAt(i) == literal) {
+				if (oppositeCount == 0) {
+					return true;
+				} else {
+					oppositeCount--;
+				}
+			} else if (name.charAt(i) == oppositeLiteral) {
+				oppositeCount++;
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/SeasonExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/SeasonExpression.java
@@ -1,0 +1,40 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+@Component
+public class SeasonExpression extends BaseExpression {
+
+	public static final String KEY = "[SEASON]";
+
+	public SeasonExpression() {
+
+	}
+
+	@Override
+	public void apply(List<StringBuilder> values, AdvancingSource source, final String capturedText) {
+		for (StringBuilder container : values) {
+
+
+			String newValue = source.getSeason();
+			// If a season value is not specified for a Nursery, then default to the current year-month
+			if (newValue == null || newValue.equals("")) {
+				SimpleDateFormat formatter = new SimpleDateFormat("YYYYMM");
+				newValue = formatter.format(new Date());
+			}
+
+            this.replaceExpressionWithValue(container, newValue);
+		}
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return SeasonExpression.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/SelectionTraitExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/SelectionTraitExpression.java
@@ -1,0 +1,28 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class SelectionTraitExpression extends BaseExpression {
+
+    public static final String KEY = "[SELTRAIT]";
+
+    public SelectionTraitExpression() {
+    }
+
+    @Override
+    public void apply(List<StringBuilder> values, AdvancingSource source, final String capturedText) {
+        for (StringBuilder container : values) {
+            this.replaceExpressionWithValue(container, source.getSelectionTraitValue());
+        }
+
+    }
+
+    @Override
+    public String getExpressionKey() {
+        return KEY;
+    }
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/SequenceExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/SequenceExpression.java
@@ -1,0 +1,104 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.apache.commons.lang3.BooleanUtils;
+import org.generationcp.middleware.ruleengine.ExpressionUtils;
+import org.generationcp.middleware.ruleengine.naming.service.GermplasmNamingService;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class SequenceExpression extends BaseExpression implements Expression {
+
+	// Insert double black slash since we're replacing by regular expressions
+	private static final String KEY = "\\[SEQUENCE\\]";
+	private static final Pattern PATTERN = Pattern.compile(SequenceExpression.KEY);
+
+
+	@Autowired
+	protected GermplasmNamingService germplasmNamingService;
+
+	// This setter is only used to inject this service only in test
+	public void setGermplasmNamingService(final GermplasmNamingService germplasmNamingService) {
+		this.germplasmNamingService = germplasmNamingService;
+	}
+
+	public SequenceExpression() {
+	}
+
+	@Override
+	public void apply(final List<StringBuilder> values, final AdvancingSource source, final String capturedText) {
+
+		final List<StringBuilder> newNames = new ArrayList<>();
+
+		for (final StringBuilder value : values) {
+			if (source.getPlantsSelected() != null && source.getPlantsSelected() > 0) {
+				synchronized (SequenceExpression.class) {
+					final int iterationCount = source.isBulk() ? 1 : source.getPlantsSelected();
+					for (int i = 0; i < iterationCount; i++) {
+						final StringBuilder newName = new StringBuilder(value);
+						final String upperCaseValue = value.toString().toUpperCase();
+
+						final Pattern pattern = Pattern.compile(this.getExpressionKey());
+						final Matcher matcher = pattern.matcher(upperCaseValue);
+						if (matcher.find()) {
+							final String keyPrefix = upperCaseValue.substring(0, matcher.start());
+
+							int nextNumberInSequence;
+							// In preview mode, do not increment the prefix in sequence registry
+							if (BooleanUtils.isTrue(source.getDesignationIsPreviewOnly())) {
+								if (source.getKeySequenceMap().containsKey(keyPrefix)) {
+									nextNumberInSequence = source.getKeySequenceMap().get(keyPrefix) + 1;
+								} else {
+									nextNumberInSequence = this.germplasmNamingService.getNextSequence(keyPrefix);
+								}
+								source.getKeySequenceMap().put(keyPrefix, nextNumberInSequence);
+
+							// Look up last sequence number from database for KeyPrefix with synchronization at class level
+							} else {
+								nextNumberInSequence = this.germplasmNamingService.getNextNumberAndIncrementSequence(keyPrefix);
+							}
+
+							final String numberString = this.germplasmNamingService
+								.getNumberWithLeadingZeroesAsString(nextNumberInSequence, this.getNumberOfDigits(value));
+
+							this.replaceRegularExpressionKeyWithValue(newName, numberString);
+							newNames.add(newName);
+						}
+
+					}
+				}
+
+			} else {
+				this.replaceRegularExpressionKeyWithValue(value, "");
+				newNames.add(value);
+			}
+		}
+
+		values.clear();
+		values.addAll(newNames);
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return SequenceExpression.KEY;
+	}
+
+	public Integer getNumberOfDigits(final StringBuilder container) {
+		return 1;
+	}
+
+	void replaceRegularExpressionKeyWithValue(final StringBuilder container, final String value) {
+		ExpressionUtils.replaceRegularExpressionKeyWithValue(this.getPattern(), container, value);
+	}
+
+	Pattern getPattern() {
+		return SequenceExpression.PATTERN;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/TopLocationAbbreviationExpression.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/expression/TopLocationAbbreviationExpression.java
@@ -1,0 +1,34 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class TopLocationAbbreviationExpression extends BaseExpression {
+
+	public static final String KEY = "[TLABBR]";
+
+	public TopLocationAbbreviationExpression() {
+	}
+
+	@Override
+	public void apply(List<StringBuilder> values, AdvancingSource source, final String capturedText) {
+		for (StringBuilder container : values) {
+			String rootName = source.getRootName();
+			String labbr = source.getLocationAbbreviation() != null ? source.getLocationAbbreviation() : "";
+			if (rootName != null && rootName.toString().endsWith("T")) {
+                this.replaceExpressionWithValue(container, "TOP" + labbr);
+			} else {
+				this.replaceExpressionWithValue(container, labbr);
+			}
+		}
+	}
+
+	@Override
+	public String getExpressionKey() {
+		return TopLocationAbbreviationExpression.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/impl/GermplasmNamingServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/impl/GermplasmNamingServiceImpl.java
@@ -1,0 +1,117 @@
+package org.generationcp.middleware.ruleengine.naming.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.generationcp.middleware.ruleengine.naming.service.GermplasmNamingService;
+import org.generationcp.middleware.exceptions.InvalidGermplasmNameSettingException;
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.pojos.germplasm.GermplasmNameSetting;
+import org.generationcp.middleware.service.api.KeySequenceRegisterService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class GermplasmNamingServiceImpl implements GermplasmNamingService {
+
+	@Autowired
+	private KeySequenceRegisterService keySequenceRegisterService;
+
+	@Autowired
+	private GermplasmDataManager germplasmDataManager;
+
+	@Override
+	public String getNextNameInSequence(final GermplasmNameSetting setting) throws InvalidGermplasmNameSettingException {
+		Integer nextNumberInSequence = this.getNextSequence(setting.getPrefix());
+
+		final Integer optionalStartNumber = setting.getStartNumber();
+
+		if (optionalStartNumber != null && optionalStartNumber > 0 && nextNumberInSequence > optionalStartNumber) {
+			final String nextName = this.buildDesignationNameInSequence(nextNumberInSequence, setting);
+			final String invalidStatingNumberErrorMessage =
+				"Starting sequence number should be higher than or equal to next name in the sequence: " + nextName + ".";
+			throw new InvalidGermplasmNameSettingException(invalidStatingNumberErrorMessage);
+		}
+
+		if (optionalStartNumber != null && nextNumberInSequence < optionalStartNumber) {
+			nextNumberInSequence = optionalStartNumber;
+		}
+
+		return this.buildDesignationNameInSequence(nextNumberInSequence, setting);
+	}
+
+	String buildDesignationNameInSequence(final Integer number, final GermplasmNameSetting setting) {
+		final StringBuilder sb = new StringBuilder();
+		sb.append(this.buildPrefixString(setting));
+		sb.append(this.getNumberWithLeadingZeroesAsString(number, setting.getNumOfDigits()));
+
+		if (!StringUtils.isEmpty(setting.getSuffix())) {
+			sb.append(this.buildSuffixString(setting));
+		}
+		return sb.toString();
+	}
+
+	String buildPrefixString(final GermplasmNameSetting setting) {
+		final String prefix = !StringUtils.isEmpty(setting.getPrefix()) ? setting.getPrefix().trim() : "";
+		if (setting.isAddSpaceBetweenPrefixAndCode()) {
+			return prefix + " ";
+		}
+		return prefix;
+	}
+
+	String buildSuffixString(final GermplasmNameSetting setting) {
+		final String suffix = setting.getSuffix();
+		if (suffix != null) {
+			if (setting.isAddSpaceBetweenSuffixAndCode()) {
+				return " " + suffix.trim();
+			}
+			return suffix.trim();
+		}
+		return "";
+	}
+
+	@Override
+	public String getNumberWithLeadingZeroesAsString(final Integer number, final Integer numOfDigits) {
+		if (numOfDigits == null || numOfDigits <= 0) {
+			return number.toString();
+		}
+		return String.format("%0" + numOfDigits + "d", number);
+	}
+
+	@Override
+	public String generateNextNameAndIncrementSequence(final GermplasmNameSetting setting) {
+		Integer nextNumberInSequence = this.getNextSequence(setting.getPrefix());
+		final Integer optionalStartNumber = setting.getStartNumber();
+		if (optionalStartNumber != null && nextNumberInSequence < optionalStartNumber) {
+			nextNumberInSequence = optionalStartNumber;
+		}
+		this.keySequenceRegisterService
+			.saveLastSequenceUsed(setting.getPrefix().trim(), nextNumberInSequence);
+
+		return this.buildDesignationNameInSequence(nextNumberInSequence, setting);
+	}
+
+	@Override
+	public int getNextSequence(final String keyPrefix) {
+		if (!StringUtils.isEmpty(keyPrefix)) {
+			final int nextSequenceNumber = this.keySequenceRegisterService.getNextSequence(keyPrefix.trim());
+			if (nextSequenceNumber > 1) {
+				return nextSequenceNumber;
+
+				// If the sequence doesn't exist yet in key_sequence_register table, query in NAMES table for the latest one used
+			} else {
+				return Integer.valueOf(this.germplasmDataManager.getNextSequenceNumberAsString(keyPrefix.trim()));
+			}
+		}
+
+		return 1;
+	}
+
+	@Override
+	public int getNextNumberAndIncrementSequence(final String keyPrefix) {
+		final int nextSequence = this.getNextSequence(keyPrefix);
+		this.saveLastSequenceUsed(keyPrefix, nextSequence);
+		return nextSequence;
+	}
+
+	@Override
+	public void saveLastSequenceUsed(final String keyPrefix, final Integer lastSequenceUsed) {
+		this.keySequenceRegisterService.saveLastSequenceUsed(keyPrefix, lastSequenceUsed);
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/impl/ProcessCodeFactory.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/impl/ProcessCodeFactory.java
@@ -1,0 +1,40 @@
+
+package org.generationcp.middleware.ruleengine.naming.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.generationcp.middleware.ruleengine.naming.expression.Expression;
+
+public class ProcessCodeFactory {
+
+	private Map<String, Expression> expressionMap;
+
+	public void init() {
+
+		this.expressionMap = new HashMap<>();
+
+	}
+
+	/**
+	 * @param pattern
+	 * @return the first Expression that match the pattern
+	 */
+	public Expression lookup(final String pattern) {
+		if (this.expressionMap.containsKey(pattern)) {
+			return this.expressionMap.get(pattern);
+		}
+		for (final String key : this.expressionMap.keySet()) {
+			if (key != null && pattern.matches(key)) {
+				final Expression expression = this.expressionMap.get(key);
+				this.expressionMap.put(pattern, expression); // memorize
+				return expression;
+			}
+		}
+		return null;
+	}
+
+	public void addExpression(final Expression expression) {
+		this.expressionMap.put(expression.getExpressionKey(), expression);
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/impl/ProcessCodeServiceImpl.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/impl/ProcessCodeServiceImpl.java
@@ -1,0 +1,50 @@
+
+package org.generationcp.middleware.ruleengine.naming.impl;
+
+import org.generationcp.middleware.ruleengine.naming.expression.Expression;
+import org.generationcp.middleware.ruleengine.naming.service.ProcessCodeService;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.ruleengine.util.ExpressionHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+public class ProcessCodeServiceImpl implements ProcessCodeService {
+
+	@Resource
+	private ProcessCodeFactory factory;
+
+	@Override
+	public List<String> applyProcessCode(final String currentInput, final String processCode, final AdvancingSource source) {
+		final List<String> newNames = new ArrayList<String>();
+
+		if (processCode == null) {
+			return newNames;
+		}
+
+		final List<StringBuilder> builders = new ArrayList<StringBuilder>();
+		builders.add(new StringBuilder(currentInput + processCode));
+
+		ExpressionHelper.evaluateExpression(processCode, ExpressionHelper.PROCESS_CODE_PATTERN,
+			(capturedText, originalInput, start, end) -> {
+				final Expression expression = ProcessCodeServiceImpl.this.factory.lookup(capturedText);
+
+				// It's possible for the expression to add more elements to the builders variable.
+				if (expression != null) {
+					expression.apply(builders, source, capturedText);
+				}
+			});
+
+		for (final StringBuilder builder : builders) {
+			newNames.add(builder.toString());
+		}
+
+		return newNames;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/CountRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/CountRule.java
@@ -1,0 +1,51 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import org.generationcp.middleware.ruleengine.OrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.naming.service.ProcessCodeService;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class CountRule extends OrderedRule<NamingRuleExecutionContext> {
+
+	public static final String KEY = "Count";
+	public static final String DEFAULT_COUNT = "[NUMBER]";
+
+	@Override
+	public Object runRule(NamingRuleExecutionContext context) throws RuleException {
+		// create counts first - we need a list in case we have a sequence
+
+		ProcessCodeService service = context.getProcessCodeService();
+		AdvancingSource source = context.getAdvancingSource();
+
+		List<String> input = context.getCurrentData();
+
+		List<String> counts = new ArrayList<>();
+
+		for (String currentInput : input) {
+			counts.addAll(service.applyProcessCode(currentInput, source.getBreedingMethod().getCount(), source));
+		}
+
+		// store current data in temp before overwriting it with count data, so that it can be restored for another try later on
+		context.setTempData(context.getCurrentData());
+
+		if (!counts.isEmpty()) {
+			// place the processed name data with count information as current rule execution output
+			context.setCurrentData(counts);
+			return counts;
+		} else {
+			return input;
+		}
+
+	}
+
+	@Override
+	public String getKey() {
+		return CountRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/EnforceUniqueNameRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/EnforceUniqueNameRule.java
@@ -1,0 +1,125 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import org.generationcp.middleware.exceptions.MiddlewareQueryException;
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.ruleengine.BranchingRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.pojo.AdvanceGermplasmChangeDetail;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Created by IntelliJ IDEA. User: Daniel Villafuerte Date: 2/17/2015 Time: 1:50 PM
+ */
+
+@Component
+public class EnforceUniqueNameRule extends BranchingRule<NamingRuleExecutionContext> {
+
+	public static final String KEY = "Unique";
+
+	@Override
+	public Object runRule(NamingRuleExecutionContext context) throws RuleException {
+
+		List<String> currentData = context.getCurrentData();
+		GermplasmDataManager germplasmDataManager = context.getGermplasmDataManager();
+		AdvancingSource source = context.getAdvancingSource();
+
+		// as per agreement, unique name checking can be limited to only the first entry for the germplasm
+		String nameForChecking = currentData.get(0);
+		try {
+			boolean duplicateExists = germplasmDataManager.checkIfMatches(nameForChecking);
+
+			if (!duplicateExists) {
+				// if necessary, update change detail object
+				this.updateChangeDetailForAdvancingSource(context);
+
+			} else {
+				this.processNonUniqueName(context, source);
+			}
+
+		} catch (MiddlewareQueryException e) {
+			throw new RuleException(e.getMessage(), e);
+		}
+
+		// this rule does not actually do any processing on the data
+		return null;
+	}
+
+	protected void processNonUniqueName(NamingRuleExecutionContext context, AdvancingSource source) {
+		// if a duplicate is found, initialize an AdvanceGermplasmChangeDetail object containing the original duplicate, for confirmation
+		// later on with the user
+		this.initializeChangeDetailForAdvancingSource(context);
+
+		// restore rule execution state to a previous temp save point
+		context.setCurrentData(context.getTempData());
+
+		if (!source.isForceUniqueNameGeneration()) {
+			// if there is no current count expression, use the default to provide incrementing support
+			if (source.getBreedingMethod().getCount() == null || source.getBreedingMethod().getCount().isEmpty()) {
+				source.getBreedingMethod().setCount(CountRule.DEFAULT_COUNT);
+				source.setForceUniqueNameGeneration(true);
+			} else if (source.isBulk()) {
+				source.setForceUniqueNameGeneration(true);
+			} else {
+				// simply increment the sequence used to generate the count. no other flags set so as to preserve previously used logic
+				source.setCurrentMaxSequence(source.getCurrentMaxSequence() + 1);
+			}
+		} else {
+			// if force unique name generation flag is set, then simply increment the current sequence used for generating the count
+			source.setCurrentMaxSequence(source.getCurrentMaxSequence() + 1);
+		}
+	}
+
+	@Override
+	public String getNextRuleStepKey(NamingRuleExecutionContext context) {
+		AdvancingSource source = context.getAdvancingSource();
+
+		AdvanceGermplasmChangeDetail changeDetailObject = source.getChangeDetail();
+
+		if (changeDetailObject == null || changeDetailObject.getNewAdvanceName() != null) {
+			return super.getNextRuleStepKey(context);
+		} else {
+			this.prepareContextForBranchingToKey(context, CountRule.KEY);
+			return CountRule.KEY;
+		}
+	}
+
+	protected void initializeChangeDetailForAdvancingSource(NamingRuleExecutionContext context) {
+		AdvanceGermplasmChangeDetail changeDetail = context.getAdvancingSource().getChangeDetail();
+
+		// change detail object only needs to be initialized once per advancing source
+		if (changeDetail == null) {
+			String offendingName = context.getCurrentData().get(0);
+			changeDetail = new AdvanceGermplasmChangeDetail();
+			changeDetail.setOldAdvanceName(offendingName);
+			changeDetail.setQuestionText(context.getMessageSource().getMessage("advance.study.duplicate.question.text",
+					new String[] {offendingName}, LocaleContextHolder.getLocale()));
+
+			context.getAdvancingSource().setChangeDetail(changeDetail);
+		}
+	}
+
+	protected void updateChangeDetailForAdvancingSource(NamingRuleExecutionContext context) {
+		AdvanceGermplasmChangeDetail changeDetail = context.getAdvancingSource().getChangeDetail();
+
+		if (changeDetail != null) {
+
+			// provide change detail object with the resulting name that passes the uniqueness check
+			String passingName = context.getCurrentData().get(0);
+			changeDetail.setNewAdvanceName(passingName);
+			Locale locale = LocaleContextHolder.getLocale();
+			changeDetail.setAddSequenceText(context.getMessageSource().getMessage("advance.study.duplicate.add.sequence.text",
+					new String[] {passingName}, locale));
+		}
+	}
+
+	@Override
+	public String getKey() {
+		return EnforceUniqueNameRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/NamingRuleExecutionContext.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/NamingRuleExecutionContext.java
@@ -1,0 +1,87 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.ruleengine.OrderedRuleExecutionContext;
+import org.generationcp.middleware.ruleengine.naming.service.ProcessCodeService;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.context.MessageSource;
+
+import java.util.List;
+
+/**
+ * Created by IntelliJ IDEA. User: Daniel Villafuerte Date: 2/14/2015 Time: 12:53 AM
+ */
+public class NamingRuleExecutionContext extends OrderedRuleExecutionContext {
+
+	private ProcessCodeService processCodeService;
+	private AdvancingSource advancingSource;
+	private GermplasmDataManager germplasmDataManager;
+	private List<String> currentData;
+	private MessageSource messageSource;
+
+	private List<String> tempData;
+
+	public NamingRuleExecutionContext(List<String> executionOrder, ProcessCodeService processCodeService, AdvancingSource advancingSource,
+			GermplasmDataManager germplasmDataManager, List<String> currentData) {
+		super(executionOrder);
+		this.processCodeService = processCodeService;
+		this.advancingSource = advancingSource;
+		this.currentData = currentData;
+		this.germplasmDataManager = germplasmDataManager;
+
+	}
+
+	@Override
+	public Object getRuleExecutionOutput() {
+		return this.currentData;
+	}
+
+	public ProcessCodeService getProcessCodeService() {
+		return this.processCodeService;
+	}
+
+	public void setProcessCodeService(ProcessCodeService processCodeService) {
+		this.processCodeService = processCodeService;
+	}
+
+	public AdvancingSource getAdvancingSource() {
+		return this.advancingSource;
+	}
+
+	public void setAdvancingSource(AdvancingSource advancingSource) {
+		this.advancingSource = advancingSource;
+	}
+
+	public List<String> getCurrentData() {
+		return this.currentData;
+	}
+
+	public void setCurrentData(List<String> currentData) {
+		this.currentData = currentData;
+	}
+
+	public GermplasmDataManager getGermplasmDataManager() {
+		return this.germplasmDataManager;
+	}
+
+	public void setGermplasmDataManager(GermplasmDataManager germplasmDataManager) {
+		this.germplasmDataManager = germplasmDataManager;
+	}
+
+	public List<String> getTempData() {
+		return this.tempData;
+	}
+
+	public void setTempData(List<String> tempData) {
+		this.tempData = tempData;
+	}
+
+	public MessageSource getMessageSource() {
+		return this.messageSource;
+	}
+
+	public void setMessageSource(MessageSource messageSource) {
+		this.messageSource = messageSource;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/PrefixRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/PrefixRule.java
@@ -1,0 +1,53 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import org.generationcp.middleware.ruleengine.OrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.naming.service.ProcessCodeService;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * The Prefix provided in this Rule refers to the prefix of the 'generated and appended generational tail' of a Germplasm name
+ * 
+ * Therefore the Prefix follows the existing germplasm name, and can appear to look like a suffix.
+ * 
+ * Rule Chain = RootName-separator-prefix-count-suffix
+ * 
+ *
+ */
+@Component
+public class PrefixRule extends OrderedRule<NamingRuleExecutionContext> {
+
+	public static final String KEY = "Prefix";
+
+	@Override
+	public Object runRule(NamingRuleExecutionContext context) throws RuleException {
+
+		// append a separator string onto each element of the list - in place
+		List<String> input = context.getCurrentData();
+
+		ProcessCodeService processCodeService = context.getProcessCodeService();
+		AdvancingSource advancingSource = context.getAdvancingSource();
+		String prefix = advancingSource.getBreedingMethod().getPrefix();
+
+		if (prefix == null) {
+			prefix = "";
+		}
+
+		for (int i = 0; i < input.size(); i++) {
+			input.set(i, processCodeService.applyProcessCode(input.get(i), prefix, advancingSource).get(0));
+		}
+
+		context.setCurrentData(input);
+
+		return input;
+	}
+
+	@Override
+	public String getKey() {
+		return PrefixRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/RootNameGeneratorRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/RootNameGeneratorRule.java
@@ -1,0 +1,43 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import org.generationcp.middleware.ruleengine.OrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.naming.expression.RootNameExpression;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class RootNameGeneratorRule extends OrderedRule<NamingRuleExecutionContext> {
+
+	public static final String KEY = "RootNameGenerator";
+
+	@Override
+	public Object runRule(NamingRuleExecutionContext context) throws RuleException {
+
+		RootNameExpression rootNameExpression = new RootNameExpression();
+		AdvancingSource advancingSource = context.getAdvancingSource();
+
+		List<StringBuilder> builders = new ArrayList<>();
+		builders.add(new StringBuilder());
+		rootNameExpression.apply(builders, advancingSource, null);
+
+		List<String> input = context.getCurrentData();
+
+		String name = builders.get(0).toString();
+
+		input.add(name);
+
+		context.setCurrentData(input);
+
+		return input;
+	}
+
+	@Override
+	public String getKey() {
+		return RootNameGeneratorRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/SeparatorRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/SeparatorRule.java
@@ -1,0 +1,43 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import org.generationcp.middleware.ruleengine.OrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.naming.service.ProcessCodeService;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class SeparatorRule extends OrderedRule<NamingRuleExecutionContext> {
+
+	public static final String KEY = "Separator";
+
+	@Override
+	public Object runRule(NamingRuleExecutionContext context) throws RuleException {
+		List<String> input = context.getCurrentData();
+		AdvancingSource source = context.getAdvancingSource();
+
+		ProcessCodeService processCodeService = context.getProcessCodeService();
+		String separatorExpression = source.getBreedingMethod().getSeparator();
+
+		if (separatorExpression == null) {
+			separatorExpression = "";
+		}
+
+		for (int i = 0; i < input.size(); i++) {
+			// some separator expressions perform operations on the root name, so we replace the current input with the result
+			input.set(i, processCodeService.applyProcessCode(input.get(i), separatorExpression, source).get(0));
+		}
+
+		context.setCurrentData(input);
+
+		return input;
+	}
+
+	@Override
+	public String getKey() {
+		return SeparatorRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/SuffixRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/rules/SuffixRule.java
@@ -1,0 +1,44 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import org.generationcp.middleware.ruleengine.OrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.naming.service.ProcessCodeService;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class SuffixRule extends OrderedRule<NamingRuleExecutionContext> {
+
+	public static final String KEY = "Suffix";
+
+	@Override
+	public Object runRule(NamingRuleExecutionContext context) throws RuleException {
+		// append a suffix string onto each element of the list - in place
+
+		ProcessCodeService processCodeService = context.getProcessCodeService();
+		AdvancingSource advancingSource = context.getAdvancingSource();
+		String suffix = advancingSource.getBreedingMethod().getSuffix();
+
+		if (suffix == null) {
+			suffix = "";
+		}
+
+		List<String> input = context.getCurrentData();
+
+		for (int i = 0; i < input.size(); i++) {
+			input.set(i, processCodeService.applyProcessCode(input.get(i), suffix, advancingSource).get(0));
+		}
+
+		context.setCurrentData(input);
+
+		return input;
+	}
+
+	@Override
+	public String getKey() {
+		return SuffixRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/service/GermplasmNamingService.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/service/GermplasmNamingService.java
@@ -1,0 +1,19 @@
+package org.generationcp.middleware.ruleengine.naming.service;
+
+import org.generationcp.middleware.exceptions.InvalidGermplasmNameSettingException;
+import org.generationcp.middleware.pojos.germplasm.GermplasmNameSetting;
+
+public interface GermplasmNamingService {
+
+	String getNextNameInSequence(final GermplasmNameSetting setting) throws InvalidGermplasmNameSettingException;
+
+	String generateNextNameAndIncrementSequence(final GermplasmNameSetting setting);
+
+	int getNextSequence(String keyPrefix);
+
+	int getNextNumberAndIncrementSequence(String keyPrefix);
+
+	void saveLastSequenceUsed(String keyPrefix, Integer lastSequenceUsed);
+
+	String getNumberWithLeadingZeroesAsString(final Integer number, final Integer numOfDigits);
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/naming/service/ProcessCodeService.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/naming/service/ProcessCodeService.java
@@ -1,0 +1,11 @@
+
+package org.generationcp.middleware.ruleengine.naming.service;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+
+import java.util.List;
+
+public interface ProcessCodeService {
+
+	List<String> applyProcessCode(String currentInput, String processCode, AdvancingSource source);
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/pojo/AdvanceGermplasmChangeDetail.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/pojo/AdvanceGermplasmChangeDetail.java
@@ -1,0 +1,85 @@
+
+package org.generationcp.middleware.ruleengine.pojo;
+
+public class AdvanceGermplasmChangeDetail {
+
+	private int status;
+	private int index;
+	private String newAdvanceName;
+	private String oldAdvanceName;
+	private String questionText;
+	private String addSequenceText;
+
+	public AdvanceGermplasmChangeDetail() {
+		super();
+	}
+
+	public AdvanceGermplasmChangeDetail(int status, int index, String newAdvanceName, String oldAdvanceName) {
+		super();
+		this.status = status;
+		this.index = index;
+		this.newAdvanceName = newAdvanceName;
+		this.oldAdvanceName = oldAdvanceName;
+	}
+
+	public int getStatus() {
+		return this.status;
+	}
+
+	public void setStatus(int status) {
+		this.status = status;
+	}
+
+	public int getIndex() {
+		return this.index;
+	}
+
+	public void setIndex(int index) {
+		this.index = index;
+	}
+
+	public String getNewAdvanceName() {
+		return this.newAdvanceName;
+	}
+
+	public void setNewAdvanceName(String newAdvanceName) {
+		this.newAdvanceName = newAdvanceName;
+	}
+
+	public String getOldAdvanceName() {
+		return this.oldAdvanceName;
+	}
+
+	public void setOldAdvanceName(String oldAdvanceName) {
+		this.oldAdvanceName = oldAdvanceName;
+	}
+
+	/**
+	 * @return the questionText
+	 */
+	public String getQuestionText() {
+		return this.questionText;
+	}
+
+	/**
+	 * @param questionText the questionText to set
+	 */
+	public void setQuestionText(String questionText) {
+		this.questionText = questionText;
+	}
+
+	/**
+	 * @return the addSequenceText
+	 */
+	public String getAddSequenceText() {
+		return this.addSequenceText;
+	}
+
+	/**
+	 * @param addSequenceText the addSequenceText to set
+	 */
+	public void setAddSequenceText(String addSequenceText) {
+		this.addSequenceText = addSequenceText;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/pojo/AdvancingSource.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/pojo/AdvancingSource.java
@@ -1,0 +1,478 @@
+/*******************************************************************************
+ * Copyright (c) 2013, All Rights Reserved.
+ *
+ * Generation Challenge Programme (GCP)
+ *
+ *
+ * This software is licensed for use under the terms of the GNU General Public License (http://bit.ly/8Ztv8M) and the provisions of Part F
+ * of the Generation Challenge Programme Amended Consortium Agreement (http://bit.ly/KQX1nL)
+ *
+ *******************************************************************************/
+
+package org.generationcp.middleware.ruleengine.pojo;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.generationcp.middleware.domain.etl.MeasurementRow;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.sample.SampleDTO;
+import org.generationcp.middleware.domain.study.StudyTypeDto;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.pojos.Name;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ * The POJO containing information needed for Advancing.
+ *
+ */
+public class AdvancingSource {
+
+	private ImportedGermplasm germplasm;
+	private List<Name> names;
+	private Integer plantsSelected;
+	private Method breedingMethod;
+	/**
+	 * This field is used to temporarily store the breeding method ID until such time as it can be resolved to a proper breeding Method object
+	 */
+	private Integer breedingMethodId;
+	private boolean isCheck;
+	private boolean isBulk;
+	private String studyName;
+	private Integer studyId;
+	private Integer environmentDatasetId;
+	private String season;
+	private String locationAbbreviation;
+	private String rootName;
+	private Method sourceMethod;
+	private int currentMaxSequence;
+	private AdvanceGermplasmChangeDetail changeDetail;
+	private String prefix;
+	private String suffix;
+	private Integer rootNameType;
+	private Integer harvestLocationId;
+	private String plotNumber;
+    private String selectionTraitValue;
+    
+    private String trialInstanceNumber;
+    private String replicationNumber;
+
+	private int maleGid;
+
+	private int femaleGid;
+
+	private boolean isForceUniqueNameGeneration;
+
+	//This will be used to store conditions
+	private List<MeasurementVariable> conditions;
+	//This will be used if we have trail
+	private MeasurementRow trailInstanceObservation;
+
+	private StudyTypeDto studyType;
+
+	private List<SampleDTO> samples = new ArrayList<>();
+	private Boolean designationIsPreviewOnly;
+	private Map<String, Integer> keySequenceMap = new HashMap<>();
+
+	public AdvancingSource(final ImportedGermplasm germplasm, final List<Name> names, final Integer plantsSelected, final Method breedingMethod, final boolean isCheck,
+			final String studyName, final String plotNumber) {
+		super();
+		this.germplasm = germplasm;
+		this.names = names;
+		this.plantsSelected = plantsSelected;
+		this.breedingMethod = breedingMethod;
+		this.isCheck = isCheck;
+		this.studyName = studyName;
+		this.plotNumber = plotNumber;
+	}
+
+	public AdvancingSource(final ImportedGermplasm germplasm) {
+		super();
+		this.germplasm = germplasm;
+	}
+
+    public AdvancingSource() {
+		super();
+	}
+
+	/**
+	 * @return the germplasm
+	 */
+	public ImportedGermplasm getGermplasm() {
+		return this.germplasm;
+	}
+
+	/**
+	 * @param germplasm the germplasm to set
+	 */
+	public void setGermplasm(final ImportedGermplasm germplasm) {
+		this.germplasm = germplasm;
+	}
+
+	/**
+	 * @return the plantsSelected
+	 */
+	public Integer getPlantsSelected() {
+		return this.plantsSelected;
+	}
+
+	/**
+	 * @param plantsSelected the plantsSelected to set
+	 */
+	public void setPlantsSelected(final Integer plantsSelected) {
+		this.plantsSelected = plantsSelected;
+	}
+
+	/**
+	 * @return the isCheck
+	 */
+	public boolean isCheck() {
+		return this.isCheck;
+	}
+
+	/**
+	 * @param isCheck the isCheck to set
+	 */
+	public void setCheck(final boolean isCheck) {
+		this.isCheck = isCheck;
+	}
+
+	/**
+	 * @return the isBulk
+	 */
+	public boolean isBulk() {
+		final Boolean isBulk = this.getBreedingMethod().isBulkingMethod();
+		return this.getBreedingMethod() != null && isBulk != null ? isBulk : false;
+	}
+
+	/**
+	 * @param isBulk the isBulk to set
+	 */
+	public void setBulk(final boolean isBulk) {
+		this.isBulk = isBulk;
+	}
+
+	/**
+	 * @return the names
+	 */
+	public List<Name> getNames() {
+		return this.names;
+	}
+
+	/**
+	 * @param names the names to set
+	 */
+	public void setNames(final List<Name> names) {
+		this.names = names;
+	}
+
+	/**
+	 * @return the breedingMethod
+	 */
+	public Method getBreedingMethod() {
+		return this.breedingMethod;
+	}
+
+	/**
+	 * @param breedingMethod the breedingMethod to set
+	 */
+	public void setBreedingMethod(final Method breedingMethod) {
+		this.breedingMethod = breedingMethod;
+	}
+
+	/**
+	 * @return the studyName
+	 */
+	public String getStudyName() {
+		return this.studyName;
+	}
+
+	/**
+	 * @param studyName the studyName to set
+	 */
+	public void setStudyName(final String studyName) {
+		this.studyName = studyName;
+	}
+
+	public Integer getStudyId() {
+		return studyId;
+	}
+
+	public void setStudyId(final Integer studyId) {
+		this.studyId = studyId;
+	}
+
+	public Integer getEnvironmentDatasetId() {
+		return this.environmentDatasetId;
+	}
+
+	public void setEnvironmentDatasetId(final Integer environmentDatasetId) {
+		this.environmentDatasetId = environmentDatasetId;
+	}
+
+	/**
+	 * @return the season
+	 */
+	public String getSeason() {
+		return this.season;
+	}
+
+	/**
+	 * @param season the season to set
+	 */
+	public void setSeason(final String season) {
+		this.season = season;
+	}
+
+	/**
+	 * @return the locationAbbreviation
+	 */
+	public String getLocationAbbreviation() {
+		return this.locationAbbreviation;
+	}
+
+	/**
+	 * @param locationAbbreviation the locationAbbreviation to set
+	 */
+	public void setLocationAbbreviation(final String locationAbbreviation) {
+		this.locationAbbreviation = locationAbbreviation;
+	}
+
+	/**
+	 * @return the rootName
+	 */
+	public String getRootName() {
+		return this.rootName;
+	}
+
+	/**
+	 * @param rootName the rootName to set
+	 */
+	public void setRootName(final String rootName) {
+		this.rootName = rootName;
+	}
+
+	/**
+	 * @return the sourceMethod
+	 */
+	public Method getSourceMethod() {
+		return this.sourceMethod;
+	}
+
+	/**
+	 * @param sourceMethod the sourceMethod to set
+	 */
+	public void setSourceMethod(final Method sourceMethod) {
+		this.sourceMethod = sourceMethod;
+	}
+
+	/**
+	 * @return the currentMaxSequence
+	 */
+	public int getCurrentMaxSequence() {
+		return this.currentMaxSequence;
+	}
+
+	/**
+	 * @param currentMaxSequence the currentMaxSequence to set
+	 */
+	public void setCurrentMaxSequence(final int currentMaxSequence) {
+		this.currentMaxSequence = currentMaxSequence;
+	}
+
+	/**
+	 * @return the changeDetail
+	 */
+	public AdvanceGermplasmChangeDetail getChangeDetail() {
+		return this.changeDetail;
+	}
+
+	/**
+	 * @param changeDetail the changeDetail to set
+	 */
+	public void setChangeDetail(final AdvanceGermplasmChangeDetail changeDetail) {
+		this.changeDetail = changeDetail;
+	}
+
+	/**
+	 * @return the prefix
+	 */
+	public String getPrefix() {
+		return this.prefix;
+	}
+
+	/**
+	 * @param prefix the prefix to set
+	 */
+	public void setPrefix(final String prefix) {
+		this.prefix = prefix;
+	}
+
+	/**
+	 * @return the suffix
+	 */
+	public String getSuffix() {
+		return this.suffix;
+	}
+
+	/**
+	 * @param suffix the suffix to set
+	 */
+	public void setSuffix(final String suffix) {
+		this.suffix = suffix;
+	}
+
+	public boolean isForceUniqueNameGeneration() {
+		return this.isForceUniqueNameGeneration;
+	}
+
+	public void setForceUniqueNameGeneration(final boolean isForceUniqueNameGeneration) {
+		this.isForceUniqueNameGeneration = isForceUniqueNameGeneration;
+	}
+
+	public Integer getRootNameType() {
+		return this.rootNameType;
+	}
+
+	public void setRootNameType(final Integer rootNameType) {
+		this.rootNameType = rootNameType;
+	}
+
+	public String getPlotNumber() {
+		return this.plotNumber;
+	}
+
+	public void setPlotNumber(final String plotNumber) {
+		this.plotNumber = plotNumber;
+	}
+
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
+
+	public Integer getHarvestLocationId() {
+		return this.harvestLocationId;
+	}
+
+	public void setHarvestLocationId(final Integer harvestLocationId) {
+		this.harvestLocationId = harvestLocationId;
+	}
+
+    public String getSelectionTraitValue() {
+        return selectionTraitValue;
+    }
+
+    public void setSelectionTraitValue(final String selectionTraitValue) {
+        this.selectionTraitValue = selectionTraitValue;
+    }
+
+	public String getTrialInstanceNumber() {
+		return this.trialInstanceNumber;
+	}
+
+	public void setTrialInstanceNumber(final String trialInstanceNumber) {
+		this.trialInstanceNumber = trialInstanceNumber;
+	}
+
+	public String getReplicationNumber() {
+		return this.replicationNumber;
+	}
+
+	public void setReplicationNumber(final String replicationNumber) {
+		this.replicationNumber = replicationNumber;
+	}
+
+	public List<MeasurementVariable> getConditions() {
+		return conditions;
+	}
+
+	public void setConditions(final List<MeasurementVariable> conditions) {
+		this.conditions = conditions;
+	}
+
+	public MeasurementRow getTrailInstanceObservation() {
+		return trailInstanceObservation;
+	}
+
+	public void setTrailInstanceObservation(final MeasurementRow trailInstanceObservation) {
+		this.trailInstanceObservation = trailInstanceObservation;
+	}
+
+	public StudyTypeDto getStudyType() {
+		return studyType;
+	}
+
+	public void setStudyType(final StudyTypeDto studyType) {
+		this.studyType = studyType;
+	}
+
+	public Integer getBreedingMethodId() {
+		return breedingMethodId;
+	}
+
+	public void setBreedingMethodId(final Integer breedingMethodId) {
+		this.breedingMethodId = breedingMethodId;
+	}
+
+	public AdvancingSource copy() {
+        final AdvancingSource source = new AdvancingSource(germplasm, names, plantsSelected, breedingMethod, isCheck, studyName, plotNumber);
+        source.setSeason(this.season);
+        source.setLocationAbbreviation(this.locationAbbreviation);
+        source.setRootName(this.rootName);
+        source.setSourceMethod(this.sourceMethod);
+        source.setCurrentMaxSequence(this.currentMaxSequence);
+        source.setChangeDetail(this.changeDetail);
+        source.setPrefix(this.prefix);
+        source.setSuffix(this.suffix);
+        source.setRootNameType(this.rootNameType);
+        source.setHarvestLocationId(this.harvestLocationId);
+        source.setSelectionTraitValue(this.selectionTraitValue);
+        source.setTrialInstanceNumber(this.trialInstanceNumber);
+        source.setReplicationNumber(this.replicationNumber);
+        return source;
+    }
+
+	public int getMaleGid() {
+		return maleGid;
+	}
+
+	public void setMaleGid(final int maleGid) {
+		this.maleGid = maleGid;
+	}
+
+	public int getFemaleGid() {
+		return femaleGid;
+	}
+
+	public void setFemaleGid(final int femaleGid) {
+		this.femaleGid = femaleGid;
+	}
+
+	public List<SampleDTO> getSamples() {
+		return samples;
+	}
+
+	public void setSamples(final List<SampleDTO> samples) {
+		this.samples = samples;
+	}
+
+	public Boolean getDesignationIsPreviewOnly() {
+		return designationIsPreviewOnly;
+	}
+
+	public void setDesignationIsPreviewOnly(Boolean designationIsPreviewOnly) {
+		this.designationIsPreviewOnly = designationIsPreviewOnly;
+	}
+
+	public Map<String, Integer> getKeySequenceMap() {
+		return keySequenceMap;
+	}
+
+	public void setKeySequenceMap(Map<String, Integer> keySequenceMap) {
+		this.keySequenceMap = keySequenceMap;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/pojo/ImportedCross.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/pojo/ImportedCross.java
@@ -1,0 +1,295 @@
+/*******************************************************************************
+ * Copyright (c) 2013, All Rights Reserved.
+ *
+ * Generation Challenge Programme (GCP)
+ *
+ *
+ * This software is licensed for use under the terms of the GNU General Public License (http://bit.ly/8Ztv8M) and the provisions of Part F
+ * of the Generation Challenge Programme Amended Consortium Agreement (http://bit.ly/KQX1nL)
+ *
+ *******************************************************************************/
+
+package org.generationcp.middleware.ruleengine.pojo;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.CollectionUtils;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The Class ImportedCross.
+ */
+public class ImportedCross extends ImportedGermplasm implements Serializable {
+
+	private static final String MULTIPARENT_BEGIN_CHAR = "[";
+	private static final String MULTIPARENT_END_CHAR = "]";
+
+	/**
+	 * The Constant serialVersionUID.
+	 */
+	private static final long serialVersionUID = 1L;
+
+	public static final String PLOT_DUPE_PREFIX = "Plot Dupe: ";
+	public static final String PEDIGREE_DUPE_PREFIX = "Pedigree Dupe: ";
+	public static final String PLOT_RECIP_PREFIX = "Plot Recip: ";
+	public static final String PEDIGREE_RECIP_PREFIX = "Pedigree Recip: ";
+
+	public static final String SEED_SOURCE_PENDING = "Pending";
+
+	private String notes;
+	private Integer crossingDate;
+	private String rawBreedingMethod;
+
+	private ImportedGermplasmParent femaleParent;
+	private List<ImportedGermplasmParent> maleParents = new ArrayList<>();
+
+	private String duplicate;
+	private String duplicatePrefix;
+
+	private Set<Integer> duplicateEntries;
+
+	/**
+	 * Instantiates a new imported germplasm.
+	 */
+	public ImportedCross() {
+
+	}
+
+	/**
+	 * Instantiates a new imported germplasm.
+	 *
+	 * @param entryNumber the entry number
+	 */
+	public ImportedCross(final Integer entryNumber) {
+		this.setEntryNumber(entryNumber);
+	}
+
+
+
+	/**
+	 * Instantiates a new imported germplasm.
+	 *
+	 * @param entryNumber the entry number
+	 * @param desig the desig
+	 * @param gid the gid
+	 * @param cross the cross
+	 * @param source the source
+	 * @param entryCode the entry code
+	 * @param check the check
+	 */
+	public ImportedCross(final Integer entryNumber, final String desig, final String gid, final String cross, final String source, final String entryCode, final String check) {
+		super(entryNumber, desig, gid, cross, source, entryCode, check);
+	}
+
+	public ImportedCross(final Integer entryNumber, final String desig, final String gid, final String cross, final String source, final String entryCode, final String check,
+			final Integer breedingMethodId) {
+
+		super(entryNumber, desig, gid, cross, source, entryCode, check, breedingMethodId);
+	}
+
+	public void setOptionalFields(final String rawBreedingMethod, final Integer crossingDate, final String notes) {
+		this.rawBreedingMethod = rawBreedingMethod;
+		this.crossingDate = crossingDate;
+		this.notes = notes;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return "ImportedCross [entryNumber=" + this.getEntryNumber() + ", desig=" + this.getDesig() + ", femaleParent=" + this.femaleParent
+				+ ", maleParents=" + this.maleParents + ", gid=" + this.getGid() + ", cross=" + this.getCross() + ", source="
+				+ this.getSource() + ", entryCode=" + this.getEntryCode() + ", check=" + this.getEntryTypeValue() + ", breedingMethodId="
+				+ this.getBreedingMethodId() + ", gpid1=" + this.getGpid1() + ", gpid2=" + this.getGpid2() + ", gnpgs=" + this.getGnpgs()
+				+ ", names=" + this.getNames() + "]";
+	}
+
+	@Override
+	public ImportedCross copy() {
+		final ImportedCross rec =
+				new ImportedCross(this.getEntryNumber(), this.getDesig(), this.getGid(), this.getCross(), this.getSource(),
+						this.getEntryCode(), this.getEntryTypeValue(), this.getBreedingMethodId());
+
+		rec.setGpid1(this.getGpid1());
+		rec.setGpid2(this.getGpid2());
+		rec.setGnpgs(this.getGnpgs());
+		rec.setNames(this.getNames());
+		rec.setEntryTypeCategoricalID(this.getEntryTypeCategoricalID());
+		rec.setEntryTypeName(this.getEntryTypeName());
+		rec.setIndex(this.getIndex());
+		rec.setFemaleParent(this.femaleParent);
+		rec.setMaleParents(this.maleParents);
+		return rec;
+	}
+
+	public String getFemaleDesignation() {
+		return this.femaleParent.getDesignation();
+	}
+
+	public List<String> getMaleDesignations() {
+		return this.maleParents.stream().map(ImportedGermplasmParent::getDesignation).collect(Collectors.toList());
+	}
+
+	private String getMaleParentsValue(final List<String> list) {
+		if (list.size() == 1) {
+			return list.get(0);
+		}
+		return MULTIPARENT_BEGIN_CHAR + StringUtils.join(list, ",") + MULTIPARENT_END_CHAR;
+	}
+
+	public String getMaleDesignationsAsString() {
+		return this.getMaleParentsValue(this.getMaleDesignations());
+	}
+
+	public String getFemaleGid() {
+		return this.femaleParent.getGid().toString();
+	}
+
+	public List<Integer> getMaleGids() {
+		return this.maleParents.stream().map(ImportedGermplasmParent::getGid).collect(Collectors.toList());
+	}
+
+	public String getNotes() {
+		return this.notes;
+	}
+
+	public void setNotes(final String notes) {
+		this.notes = notes;
+	}
+
+	public Integer getCrossingDate() {
+		return this.crossingDate;
+	}
+
+	public void setCrossingDate(final Integer crossingDate) {
+		this.crossingDate = crossingDate;
+	}
+
+	/**
+	 * Retrieves the breeding method of this cross. Note that this breeding method is unprocessed, its possible that this might not exists
+	 * in the methods table at all to process the method, retrieve the method from the database and set this.breedingMethodId
+	 *
+	 * @return
+	 */
+	public String getRawBreedingMethod() {
+		return this.rawBreedingMethod;
+	}
+
+	public void setRawBreedingMethod(final String rawBreedingMethod) {
+		this.rawBreedingMethod = rawBreedingMethod;
+	}
+
+	public String getDuplicate() {
+		return this.duplicate;
+	}
+
+	public void setDuplicate(final String duplicate) {
+		this.duplicate = duplicate;
+	}
+
+	public Integer getFemalePlotNo() {
+		return this.femaleParent.getPlotNo();
+	}
+
+	public List<Integer> getMalePlotNos() {
+		return this.maleParents.stream().map(ImportedGermplasmParent::getPlotNo).collect(Collectors.toList());
+	}
+
+	public boolean isPedigreeDupe() {
+		return ImportedCross.PEDIGREE_DUPE_PREFIX.equals(this.duplicatePrefix);
+	}
+
+	public boolean isPlotDupe() {
+		return ImportedCross.PLOT_DUPE_PREFIX.equals(this.duplicatePrefix);
+	}
+
+	public boolean isPedigreeRecip() {
+		return ImportedCross.PEDIGREE_RECIP_PREFIX.equals(this.duplicatePrefix);
+	}
+
+	public boolean isPlotRecip() {
+		return ImportedCross.PLOT_RECIP_PREFIX.equals(this.duplicatePrefix);
+	}
+
+	public Set<Integer> getDuplicateEntries() {
+		return this.duplicateEntries;
+	}
+
+	public void setDuplicateEntries(final Set<Integer> duplicateEntries) {
+		this.duplicateEntries = duplicateEntries;
+	}
+
+	public String getDuplicatePrefix() {
+		return this.duplicatePrefix;
+	}
+
+	public void setDuplicatePrefix(final String duplicatePrefix) {
+		this.duplicatePrefix = duplicatePrefix;
+	}
+
+	public String getFemaleStudyName() {
+		return this.femaleParent.getStudyName();
+	}
+
+	public String getMaleStudyName() {
+		if (!CollectionUtils.isEmpty(this.maleParents)) {
+			return this.maleParents.get(0).getStudyName();
+		}
+		return "";
+	}
+
+	public boolean isBreedingMethodInformationAvailable() {
+		return ((this.getBreedingMethodId() != null && this.getBreedingMethodId() != 0) || !StringUtils.isEmpty(this.getRawBreedingMethod()));
+	}
+
+	public String getFemalePedigree() {
+	  return this.femaleParent.getPedigree();
+	}
+
+	public List<String> getMalePedigree() {
+		return this.maleParents.stream().map(ImportedGermplasmParent::getPedigree).collect(Collectors.toList());
+	}
+
+	public String getFemaleCross() {
+		return this.femaleParent.getCross();
+	}
+
+	public List<String> getMaleCross() {
+		return this.maleParents.stream().map(ImportedGermplasmParent::getCross).collect(Collectors.toList());
+	}
+
+	public ImportedGermplasmParent getFemaleParent() {
+		return this.femaleParent;
+	}
+
+
+	public void setFemaleParent(final ImportedGermplasmParent femaleParent) {
+		this.femaleParent = femaleParent;
+	}
+
+
+	public List<ImportedGermplasmParent> getMaleParents() {
+		return this.maleParents;
+	}
+
+	public void setMaleParents(final List<ImportedGermplasmParent> maleParents) {
+		this.maleParents = maleParents;
+	}
+
+	public void setMaleStudyname(final String maleStudyName) {
+		for (final ImportedGermplasmParent maleParent : this.maleParents) {
+			maleParent.setStudyName(maleStudyName);
+		}
+	}
+
+	public Boolean isPolyCross() {
+		return this.maleParents.size() > 1;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/pojo/ImportedGermplasm.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/pojo/ImportedGermplasm.java
@@ -1,0 +1,488 @@
+/*******************************************************************************
+ * Copyright (c) 2013, All Rights Reserved.
+ *
+ * Generation Challenge Programme (GCP)
+ *
+ *
+ * This software is licensed for use under the terms of the GNU General Public License (http://bit.ly/8Ztv8M) and the provisions of Part F
+ * of the Generation Challenge Programme Amended Consortium Agreement (http://bit.ly/KQX1nL)
+ *
+ *******************************************************************************/
+
+package org.generationcp.middleware.ruleengine.pojo;
+
+import org.generationcp.middleware.pojos.Name;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * The Class ImportedGermplasm.
+ */
+public class ImportedGermplasm implements Serializable {
+
+	public static final String GID_PENDING = "Pending";
+
+	/** The Constant serialVersionUID. */
+	private static final long serialVersionUID = 1L;
+
+	private Integer id;
+
+	/** The entry number. */
+	private Integer entryNumber;
+
+	/** The desig. */
+	private String desig;
+
+	/** The gid. */
+	private String gid;
+
+	/** The cross. */
+	private String cross;
+
+	/** The source. */
+	private String source;
+
+	/** The entry code. */
+	private String entryCode;
+
+	/** The check. */
+	private String entryTypeValue;
+
+	/** The breeding method id. */
+	private Integer breedingMethodId;
+
+	/** The breeding method name. */
+	private String breedingMethodName;
+
+	/** Germplasm's GPID1 */
+	private Integer gpid1;
+
+	/** Germplasm's GPID2 */
+	private Integer gpid2;
+
+	/** Germplasm's Number of Parents */
+	private Integer gnpgs;
+	
+	/** The maintenance group this germplasm belongs to */
+	private Integer mgid;
+
+	/** List of Names associated with the Germplasm */
+	private List<Name> names;
+
+    private Integer entryTypeCategoricalID;
+
+	private String entryTypeName;
+
+	private Integer index;
+
+	private String groupName;
+
+	private String trialInstanceNumber;
+	private String replicationNumber;
+    private String plotNumber;
+
+	private String plantNumber;
+
+	/** GroupId associated with Germplsm **/
+	private Integer groupId;
+
+	private Integer locationId;
+
+	/**
+	 * Instantiates a new imported germplasm.
+	 */
+	public ImportedGermplasm() {
+
+	}
+
+	/**
+	 * Instantiates a new imported germplasm.
+	 *
+	 * @param entryNumber the entry number
+	 * @param desig the desig
+	 * @param entryTypeValue the check
+	 */
+	public ImportedGermplasm(final Integer entryNumber, final String desig, final String entryTypeValue) {
+		this.entryNumber = entryNumber;
+		this.desig = desig;
+		this.entryTypeValue = entryTypeValue;
+	}
+
+	/**
+	 * Instantiates a new imported germplasm.
+	 *
+	 * @param entryNumber the entry number
+	 * @param desig the desig
+	 * @param gid the gid
+	 * @param cross the cross
+	 * @param source the source
+	 * @param entryCode the entry code
+	 * @param entryTypeValue the check
+	 */
+	public ImportedGermplasm(final Integer entryNumber, final String desig, final String gid, final String cross, final String source, final String entryCode, final String entryTypeValue) {
+		this.entryNumber = entryNumber;
+		this.desig = desig;
+		this.gid = gid;
+		this.cross = cross;
+		this.source = source;
+		this.entryCode = entryCode;
+		this.entryTypeValue = entryTypeValue;
+	}
+
+	public ImportedGermplasm(Integer entryId, String desig, String gid, String cross, String source, String entryCode, String entryTypeValue,
+			Integer breedingMethodId) {
+
+		this(entryId, desig, gid, cross, source, entryCode, entryTypeValue);
+		this.breedingMethodId = breedingMethodId;
+	}
+
+	/**
+	 * Gets the gid.
+	 *
+	 * @return the gid
+	 */
+	public String getGid() {
+		return this.gid;
+	}
+
+	/**
+	 * Sets the gid.
+	 *
+	 * @param gid the new gid
+	 */
+	public void setGid(String gid) {
+		this.gid = gid;
+	}
+
+	/**
+	 * Gets the cross.
+	 *
+	 * @return the cross
+	 */
+	public String getCross() {
+		return this.cross;
+	}
+
+	/**
+	 * Sets the cross.
+	 *
+	 * @param cross the new cross
+	 */
+	public void setCross(String cross) {
+		this.cross = cross;
+	}
+
+	/**
+	 * Gets the source.
+	 *
+	 * @return the source
+	 */
+	public String getSource() {
+		return this.source;
+	}
+
+	/**
+	 * Sets the source.
+	 *
+	 * @param source the new source
+	 */
+	public void setSource(String source) {
+		this.source = source;
+	}
+
+	/**
+	 * Gets the entry code.
+	 *
+	 * @return the entry code
+	 */
+	public String getEntryCode() {
+		return this.entryCode;
+	}
+
+	/**
+	 * Sets the entry code.
+	 *
+	 * @param entryCode the new entry code
+	 */
+	public void setEntryCode(String entryCode) {
+		this.entryCode = entryCode;
+	}
+
+	/**
+	 * Gets the entry number.
+	 *
+	 * @return the entry number
+	 */
+	public Integer getEntryNumber() {
+		return this.entryNumber;
+	}
+
+	/**
+	 * Sets the entry number.
+	 *
+	 * @param entryNumber the new entry number
+	 */
+	public void setEntryNumber(final Integer entryNumber) {
+		this.entryNumber = entryNumber;
+	}
+
+	public void setId(final Integer id) {
+		this.id = id;
+	}
+
+	public Integer getId() {
+		return this.id;
+	}
+
+	/**
+	 * Gets the desig.
+	 *
+	 * @return the desig
+	 */
+	public String getDesig() {
+		return this.desig;
+	}
+
+	/**
+	 * Sets the desig.
+	 *
+	 * @param desig the new desig
+	 */
+	public void setDesig(String desig) {
+		this.desig = desig;
+	}
+
+	/**
+	 * Gets the check.
+	 *
+	 * @return the check
+	 */
+	public String getEntryTypeValue() {
+		return this.entryTypeValue;
+	}
+
+	/**
+	 * Sets the check.
+	 *
+	 * @param entryTypeValue the new check
+	 */
+	public void setEntryTypeValue(String entryTypeValue) {
+		this.entryTypeValue = entryTypeValue;
+	}
+
+	/**
+	 * @return the breedingMethodId
+	 */
+	public Integer getBreedingMethodId() {
+		return this.breedingMethodId;
+	}
+
+	/**
+	 * @param breedingMethodId the breedingMethodId to set
+	 */
+	public void setBreedingMethodId(Integer breedingMethodId) {
+		this.breedingMethodId = breedingMethodId;
+	}
+
+	/**
+	 * @return the breeding method name
+	 */
+	public String getBreedingMethodName() {
+		return breedingMethodName;
+	}
+
+	/**
+	 * @param breedingMethodName the breeding method name to set
+	 */
+	public void setBreedingMethodName(String breedingMethodName) {
+		this.breedingMethodName = breedingMethodName;
+	}
+
+	/**
+	 * @return the gpid1
+	 */
+	public Integer getGpid1() {
+		return this.gpid1;
+	}
+
+	/**
+	 * @param gpid1 the gpid1 to set
+	 */
+	public void setGpid1(Integer gpid1) {
+		this.gpid1 = gpid1;
+	}
+
+	/**
+	 * @return the gpid2
+	 */
+	public Integer getGpid2() {
+		return this.gpid2;
+	}
+
+	/**
+	 * @param gpid2 the gpid2 to set
+	 */
+	public void setGpid2(Integer gpid2) {
+		this.gpid2 = gpid2;
+	}
+
+	/**
+	 * @return the gnpgs
+	 */
+	public Integer getGnpgs() {
+		return this.gnpgs;
+	}
+
+	/**
+	 * @param gnpgs the gnpgs to set
+	 */
+	public void setGnpgs(Integer gnpgs) {
+		this.gnpgs = gnpgs;
+	}
+
+	
+	public Integer getMgid() {
+		return mgid;
+	}
+
+	
+	public void setMgid(Integer mgid) {
+		this.mgid = mgid;
+	}
+
+	/**
+	 * @return the names
+	 */
+	public List<Name> getNames() {
+		return this.names;
+	}
+
+	/**
+	 * @param names the names to set
+	 */
+	public void setNames(List<Name> names) {
+		this.names = names;
+	}
+
+	/**
+	 * @return the entryTypeCategoricalID
+	 */
+	public Integer getEntryTypeCategoricalID() {
+		return this.entryTypeCategoricalID;
+	}
+
+	/**
+	 * @param entryTypeCategoricalID the entryTypeCategoricalID to set
+	 */
+	public void setEntryTypeCategoricalID(Integer entryTypeCategoricalID) {
+		this.entryTypeCategoricalID = entryTypeCategoricalID;
+	}
+
+	/**
+	 * @return the entryTypeName
+	 */
+	public String getEntryTypeName() {
+		return this.entryTypeName;
+	}
+
+	/**
+	 * @param entryTypeName the entryTypeName to set
+	 */
+	public void setEntryTypeName(String entryTypeName) {
+		this.entryTypeName = entryTypeName;
+	}
+
+	public String getTrialInstanceNumber() {
+		return this.trialInstanceNumber;
+	}
+
+	public void setTrialInstanceNumber(String trialInstanceNumber) {
+		this.trialInstanceNumber = trialInstanceNumber;
+	}
+
+	public String getReplicationNumber() {
+		return this.replicationNumber;
+	}
+
+	public void setReplicationNumber(String replicationNumber) {
+		this.replicationNumber = replicationNumber;
+	}
+
+    public String getPlotNumber() {
+        return plotNumber;
+    }
+
+    public void setPlotNumber(String plotNumber) {
+        this.plotNumber = plotNumber;
+    }
+
+    /*
+         * (non-Javadoc)
+         *
+         * @see java.lang.Object#toString()
+         */
+	@Override
+	public String toString() {
+		return "ImportedGermplasm [id=" + this.id + ", entryNumber=" + this.entryNumber + ", desig=" + this.desig + ", gid=" + this.gid + ", cross=" + this.cross
+				+ ", source=" + this.source + ", entryCode=" + this.entryCode + ", entryTypeValue=" + this.entryTypeValue + ", breedingMethodId="
+				+ this.breedingMethodId + ", gpid1=" + this.gpid1 + ", gpid2=" + this.gpid2 + ", gnpgs=" + this.gnpgs + ", names="
+				+ this.names + "]";
+	}
+
+	public ImportedGermplasm copy() {
+		ImportedGermplasm rec =
+				new ImportedGermplasm(this.entryNumber, this.desig, this.gid, this.cross, this.source, this.entryCode, this.entryTypeValue,
+						this.breedingMethodId);
+
+		rec.setGpid1(this.gpid1);
+		rec.setGpid2(this.gpid2);
+		rec.setGnpgs(this.gnpgs);
+		rec.setNames(this.names);
+		rec.setEntryTypeCategoricalID(this.entryTypeCategoricalID);
+		rec.setEntryTypeName(this.entryTypeName);
+		rec.setIndex(this.index);
+
+		return rec;
+	}
+
+	public String getGroupName() {
+		return this.groupName;
+	}
+
+	public void setGroupName(String groupName) {
+		this.groupName = groupName;
+	}
+
+	public Integer getGroupId() {
+		return groupId;
+	}
+
+	public void setGroupId(Integer groupId) {
+		this.groupId = groupId;
+	}
+
+	public String getPlantNumber() {
+		return plantNumber;
+	}
+
+	public void setPlantNumber(final String plantNumber) {
+		this.plantNumber = plantNumber;
+	}
+
+	public Integer getIndex() {
+		return this.index;
+	}
+
+	public void setIndex(Integer index) {
+		this.index = index;
+	}
+
+	public Integer getLocationId() {
+		return locationId;
+	}
+
+	public void setLocationId(final Integer locationId) {
+		this.locationId = locationId;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/pojo/ImportedGermplasmParent.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/pojo/ImportedGermplasmParent.java
@@ -1,0 +1,56 @@
+
+package org.generationcp.middleware.ruleengine.pojo;
+
+import org.generationcp.middleware.pojos.germplasm.GermplasmParent;
+
+public class ImportedGermplasmParent extends GermplasmParent {
+
+	private static final long serialVersionUID = 1L;
+
+	private Integer plotNo;
+
+	private String studyName;
+
+	private String cross;
+
+	public ImportedGermplasmParent(final Integer gid, final String designation, final String pedigree) {
+		super(gid, designation, pedigree);
+	}
+
+	public ImportedGermplasmParent(final Integer gid, final String designation, final Integer plotNo, final String studyName) {
+		super(gid, designation, null);
+		this.plotNo = plotNo;
+		this.studyName = studyName;
+	}
+
+	public Integer getPlotNo() {
+		return this.plotNo;
+	}
+
+	public void setPlotNo(final Integer plotNo) {
+		this.plotNo = plotNo;
+	}
+
+	public String getStudyName() {
+		return this.studyName;
+	}
+
+	public void setStudyName(final String studyName) {
+		this.studyName = studyName;
+	}
+
+	public String getCross() {
+		return this.cross;
+	}
+
+	public void setCross(final String cross) {
+		this.cross = cross;
+	}
+
+	@Override
+	public String toString() {
+		return "ImportedGermplasmParent [plotNo=" + this.plotNo + ", studyName=" + this.studyName + ", cross=" + this.cross + ", gid="
+				+ this.gid + ", designation=" + this.designation + ", pedigree=" + this.pedigree + "]";
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/provider/PropertyFileRuleConfigurationProvider.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/provider/PropertyFileRuleConfigurationProvider.java
@@ -1,0 +1,21 @@
+
+package org.generationcp.middleware.ruleengine.provider;
+
+import java.util.Map;
+
+/**
+ * Created by IntelliJ IDEA. User: Daniel Villafuerte Date: 2/14/2015 Time: 6:55 AM
+ */
+public class PropertyFileRuleConfigurationProvider implements RuleConfigurationProvider {
+
+	private Map<String, String[]> ruleSequenceConfiguration;
+
+	@Override
+	public Map<String, String[]> getRuleSequenceConfiguration() {
+		return this.ruleSequenceConfiguration;
+	}
+
+	public void setRuleSequenceConfiguration(final Map<String, String[]> ruleSequenceConfiguration) {
+		this.ruleSequenceConfiguration = ruleSequenceConfiguration;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/provider/RuleConfigurationProvider.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/provider/RuleConfigurationProvider.java
@@ -1,0 +1,12 @@
+
+package org.generationcp.middleware.ruleengine.provider;
+
+import java.util.Map;
+
+/**
+ * Created by IntelliJ IDEA. User: Daniel Villafuerte Date: 2/14/2015 Time: 6:52 AM
+ */
+public interface RuleConfigurationProvider {
+
+	public Map<String, String[]> getRuleSequenceConfiguration();
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/provider/RuleConfigurationProvider.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/provider/RuleConfigurationProvider.java
@@ -8,5 +8,5 @@ import java.util.Map;
  */
 public interface RuleConfigurationProvider {
 
-	public Map<String, String[]> getRuleSequenceConfiguration();
+	Map<String, String[]> getRuleSequenceConfiguration();
 }

--- a/src/main/java/org/generationcp/middleware/ruleengine/resolver/CategoricalKeyCodeResolverBase.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/resolver/CategoricalKeyCodeResolverBase.java
@@ -1,0 +1,101 @@
+
+package org.generationcp.middleware.ruleengine.resolver;
+
+import org.apache.commons.lang3.StringUtils;
+import org.generationcp.middleware.ContextHolder;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.domain.oms.TermSummary;
+import org.generationcp.middleware.domain.ontology.Variable;
+import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitData;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitRow;
+
+import java.util.List;
+import java.util.Map;
+
+public abstract class CategoricalKeyCodeResolverBase implements KeyComponentValueResolver {
+
+	protected OntologyVariableDataManager ontologyVariableDataManager;
+
+	protected List<MeasurementVariable> conditions;
+	protected ObservationUnitRow observationUnitRow;
+	protected Map<Integer, MeasurementVariable> environmentVariablesByTermId;
+
+	public CategoricalKeyCodeResolverBase(final OntologyVariableDataManager ontologyVariableDataManager,
+		final List<MeasurementVariable> conditions, final ObservationUnitRow observationUnitRow,
+		final Map<Integer, MeasurementVariable> environmentVariablesByTermId) {
+
+		this.ontologyVariableDataManager = ontologyVariableDataManager;
+		this.observationUnitRow = observationUnitRow;
+		this.environmentVariablesByTermId = environmentVariablesByTermId;
+		this.conditions = conditions;
+	}
+
+	protected abstract TermId getKeyCodeId();
+
+	protected abstract boolean isAbbreviationRequired();
+
+	protected abstract String getDefaultValue();
+
+	protected abstract String getValueFromObservationUnitData(ObservationUnitData observationUnitData);
+
+	protected abstract String getValueFromTrialConditions(MeasurementVariable trialCondition);
+
+	@Override
+	public String resolve() {
+		String resolvedValue = "";
+
+		MeasurementVariable measurementVariable = null;
+
+		if (this.conditions != null) {
+			for (final MeasurementVariable mv : this.conditions) {
+				if (mv.getTermId() == this.getKeyCodeId().getId()) {
+					measurementVariable = mv;
+				}
+			}
+		}
+
+		if (measurementVariable != null && StringUtils.isNotBlank(measurementVariable.getValue())) {
+			final String programUUID = ContextHolder.getCurrentProgramOptional().orElse(null);
+
+			final Variable variable = this.ontologyVariableDataManager
+					.getVariable(programUUID, measurementVariable.getTermId(), true);
+
+			for (final TermSummary prefix : variable.getScale().getCategories()) {
+				if (measurementVariable.getValue().equals(prefix.getId().toString()) || measurementVariable.getValue()
+					.equals(prefix.getDefinition())) {
+					resolvedValue = this.isAbbreviationRequired() ? prefix.getName() : prefix.getDefinition();
+					break;
+				}
+			}
+		}
+
+		if (this.observationUnitRow != null) {
+			for (final ObservationUnitData observationUnitData : this.observationUnitRow.getVariables().values()) {
+				if (observationUnitData.getVariableId() == this.getKeyCodeId().getId()) {
+					resolvedValue = this.getValueFromObservationUnitData(observationUnitData);
+					break;
+				}
+			}
+		}
+		if (StringUtils.isBlank(resolvedValue) && this.conditions != null) {
+			for (final MeasurementVariable trialCondition : this.conditions) {
+				if (trialCondition.getTermId() == this.getKeyCodeId().getId()) {
+					resolvedValue = this.getValueFromTrialConditions(trialCondition);
+					break;
+				}
+			}
+		}
+		if (StringUtils.isBlank(resolvedValue)) {
+			resolvedValue = this.getDefaultValue();
+		}
+
+		return resolvedValue;
+	}
+
+	@Override
+	public boolean isOptional() {
+		return false;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/resolver/HabitatDesignationResolver.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/resolver/HabitatDesignationResolver.java
@@ -1,0 +1,52 @@
+
+package org.generationcp.middleware.ruleengine.resolver;
+
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitData;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class HabitatDesignationResolver extends CategoricalKeyCodeResolverBase {
+
+	private static final Logger LOG = LoggerFactory.getLogger(HabitatDesignationResolver.class);
+
+	public HabitatDesignationResolver(final OntologyVariableDataManager ontologyVariableDataManager,
+		final List<MeasurementVariable> conditions, final ObservationUnitRow observationUnitRow,
+		final Map<Integer, MeasurementVariable> measurementVariableByTermId) {
+
+		super(ontologyVariableDataManager, conditions, observationUnitRow, measurementVariableByTermId);
+	}
+
+	@Override
+	protected TermId getKeyCodeId() {
+		return TermId.HABITAT_DESIGNATION;
+	}
+
+	@Override
+	protected boolean isAbbreviationRequired() {
+		return true;
+	}
+
+	@Override
+	protected String getDefaultValue() {
+		HabitatDesignationResolver.LOG.debug("No Habitat_Designation(3002) variable was found or it is present but no value is set."
+				+ "Resolving Habitat value to be an empty string.");
+		return "";
+	}
+
+	@Override
+	protected String getValueFromObservationUnitData(final ObservationUnitData observationUnitData) {
+		return observationUnitData.getValue();
+	}
+
+	@Override
+	protected String getValueFromTrialConditions(final MeasurementVariable trialCondition) {
+		return trialCondition.getValue();
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/resolver/KeyComponentValueResolver.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/resolver/KeyComponentValueResolver.java
@@ -1,0 +1,21 @@
+package org.generationcp.middleware.ruleengine.resolver;
+
+/**
+ * Interface to be implemented by classes that act as value resolvers for various placeholders in key code templates.
+ *
+ */
+public interface KeyComponentValueResolver {
+
+	/**
+	 * Revolve the value of the key code component.
+	 */
+	String resolve();
+
+	/**
+	 * Specify whether the value that this resolver resolves, is required or optional. If optional, the key code generation service will do
+	 * the substitution (with a separator) only when the value returned by the {@link #resolve()} contract is not null/empty. Example of
+	 * such optional behavior is SELECTION_NUMBER component used in seed source where ear/plants selected is only added to the key in case
+	 * multiple plant/ears are selected from a single plot.
+	 */
+	boolean isOptional();
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/resolver/LocationAbbreviationResolver.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/resolver/LocationAbbreviationResolver.java
@@ -1,0 +1,72 @@
+package org.generationcp.middleware.ruleengine.resolver;
+
+import org.apache.commons.lang3.StringUtils;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitData;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitRow;
+import org.generationcp.middleware.service.impl.study.StudyInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Revolves Location value for Nurseries and Trials.
+ */
+public class LocationAbbreviationResolver implements KeyComponentValueResolver {
+
+	protected ObservationUnitRow observationUnitRow;
+	protected Map<Integer, StudyInstance> studyInstanceMap;
+
+	private static final Logger LOG = LoggerFactory.getLogger(LocationAbbreviationResolver.class);
+
+	public LocationAbbreviationResolver(final ObservationUnitRow observationUnitRow, final Map<Integer, StudyInstance> studyInstanceMap) {
+
+		this.observationUnitRow = observationUnitRow;
+		this.studyInstanceMap = studyInstanceMap;
+	}
+
+	@Override
+	public String resolve() {
+		String location = "";
+
+		if (!CollectionUtils.isEmpty(this.studyInstanceMap)) {
+			if (this.observationUnitRow != null) {
+
+				final Optional<ObservationUnitData> instanceNoUnitData =
+					Optional.ofNullable(this.observationUnitRow.getVariables().entrySet().stream().collect(Collectors
+						.toMap(k -> k.getValue().getVariableId(),
+							Map.Entry::getValue)).get(TermId.TRIAL_INSTANCE_FACTOR.getId()));
+
+				if (instanceNoUnitData.isPresent()) {
+					final String instanceNo = instanceNoUnitData.get().getValue();
+					if (instanceNo != null && this.studyInstanceMap.containsKey(Integer.valueOf(instanceNo))) {
+						location = this.studyInstanceMap.get(Integer.valueOf(instanceNo)).getLocationAbbreviation();
+					}
+
+				}
+			} else {
+				final StudyInstance firstInstance = this.studyInstanceMap.get(1);
+				if (firstInstance != null) {
+					location = firstInstance.getLocationAbbreviation();
+				}
+			}
+		}
+
+		if (StringUtils.isBlank(location)) {
+			LocationAbbreviationResolver.LOG.debug(
+				"No Location Abbreviation was resolved");
+			return "";
+		}
+		return location;
+	}
+
+	@Override
+	public boolean isOptional() {
+		return false;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/resolver/LocationResolver.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/resolver/LocationResolver.java
@@ -1,0 +1,101 @@
+package org.generationcp.middleware.ruleengine.resolver;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.apache.commons.lang3.StringUtils;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitData;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Revolves Location value for Nurseries and Trials.
+ */
+public class LocationResolver implements KeyComponentValueResolver {
+
+	protected List<MeasurementVariable> conditions;
+	protected ObservationUnitRow observationUnitRow;
+	protected Map<String, String> locationIdNameMap;
+
+	private static final Logger LOG = LoggerFactory.getLogger(LocationResolver.class);
+
+	public LocationResolver(final List<MeasurementVariable> conditions, final ObservationUnitRow observationUnitRow,
+		final Map<String, String> locationIdNameMap) {
+
+		this.observationUnitRow = observationUnitRow;
+		this.conditions = conditions;
+		this.locationIdNameMap = locationIdNameMap;
+	}
+
+	@Override
+	public String resolve() {
+		String location = "";
+
+		ImmutableMap<Integer, MeasurementVariable> conditionsMap = null;
+		if (this.conditions != null) {
+			conditionsMap = Maps.uniqueIndex(this.conditions, new Function<MeasurementVariable, Integer>() {
+
+				@Override
+				public Integer apply(final MeasurementVariable measurementVariable) {
+					return measurementVariable.getTermId();
+				}
+			});
+		}
+
+		if (conditionsMap != null) {
+			// FIXME See IBP-2575
+			if (conditionsMap.containsKey(TermId.LOCATION_ABBR.getId())) {
+				location = conditionsMap.get(TermId.LOCATION_ABBR.getId()).getValue();
+			} else if (conditionsMap.containsKey(TermId.TRIAL_LOCATION.getId())) {
+				location = conditionsMap.get(TermId.TRIAL_LOCATION.getId()).getValue();
+			} else {
+				location = conditionsMap.get(TermId.TRIAL_INSTANCE_FACTOR.getId()).getValue();
+			}
+		}
+
+		if (this.observationUnitRow != null) {
+			final ImmutableMap<Integer, ObservationUnitData> dataListMap =
+					Maps.uniqueIndex(this.observationUnitRow.getVariables().values(), new Function<ObservationUnitData, Integer>() {
+
+						@Override
+						public Integer apply(final ObservationUnitData observationUnitData) {
+							return observationUnitData.getVariableId();
+						}
+					});
+
+			if (dataListMap.containsKey(TermId.LOCATION_ABBR.getId())) {
+				location = dataListMap.get(TermId.LOCATION_ABBR.getId()).getValue();
+			} else if (conditionsMap != null && conditionsMap.containsKey(TermId.LOCATION_ABBR.getId())) {
+				location = conditionsMap.get(TermId.LOCATION_ABBR.getId()).getValue();
+			} else if (dataListMap.containsKey(TermId.LOCATION_ID.getId())) {
+				final String locationId = dataListMap.get(TermId.LOCATION_ID.getId()).getValue();
+				location = this.locationIdNameMap.get(locationId);
+			}
+
+			if (StringUtils.isBlank(location)) {
+				location = dataListMap.get(TermId.TRIAL_INSTANCE_FACTOR.getId()).getValue();
+			}
+		}
+
+		if (StringUtils.isBlank(location)) {
+			LocationResolver.LOG.debug(
+					"No LOCATION_ABBR(8189), LOCATION_NAME(8180) or TRIAL_INSTANCE(8170) variable was found in the study. "
+						+ "Or it is present but no value is set. Resolving location value to be an empty string.");
+			return "";
+		}
+
+		return location;
+	}
+
+	@Override
+	public boolean isOptional() {
+		return false;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/resolver/ProjectPrefixResolver.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/resolver/ProjectPrefixResolver.java
@@ -1,0 +1,52 @@
+
+package org.generationcp.middleware.ruleengine.resolver;
+
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitData;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class ProjectPrefixResolver extends CategoricalKeyCodeResolverBase {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ProjectPrefixResolver.class);
+
+	public ProjectPrefixResolver(final OntologyVariableDataManager ontologyVariableDataManager,
+		final List<MeasurementVariable> conditions, final ObservationUnitRow observationUnitRow,
+		final Map<Integer, MeasurementVariable> measurementVariableByTermId) {
+
+		super(ontologyVariableDataManager, conditions, observationUnitRow, measurementVariableByTermId);
+	}
+
+	@Override
+	protected TermId getKeyCodeId() {
+		return TermId.PROJECT_PREFIX;
+	}
+
+	@Override
+	protected boolean isAbbreviationRequired() {
+		return true;
+	}
+
+	@Override
+	protected String getDefaultValue() {
+		ProjectPrefixResolver.LOG.debug("No Project_Prefix(3001) variable was found or it is present but no value is set."
+				+ "Resolving Program value to be an empty string.");
+		return "";
+	}
+
+	@Override
+	protected String getValueFromObservationUnitData(final ObservationUnitData observationUnitData) {
+		return observationUnitData.getValue();
+	}
+
+	@Override
+	protected String getValueFromTrialConditions(final MeasurementVariable trialCondition) {
+		return trialCondition.getValue();
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/resolver/SeasonResolver.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/resolver/SeasonResolver.java
@@ -1,0 +1,92 @@
+
+package org.generationcp.middleware.ruleengine.resolver;
+
+import com.google.common.base.Optional;
+import org.generationcp.middleware.domain.dms.ValueReference;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitData;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Revolves Season value for Nurseries and Trials.
+ */
+public class SeasonResolver extends CategoricalKeyCodeResolverBase {
+
+	private static final Logger LOG = LoggerFactory.getLogger(SeasonResolver.class);
+
+	public SeasonResolver(final OntologyVariableDataManager ontologyVariableDataManager,
+		final List<MeasurementVariable> conditions, final ObservationUnitRow observationUnitRow,
+		final Map<Integer, MeasurementVariable> environmentVariablesByTermId) {
+
+		super(ontologyVariableDataManager, conditions, observationUnitRow, environmentVariablesByTermId);
+	}
+
+	@Override
+	protected TermId getKeyCodeId() {
+		return TermId.SEASON_VAR;
+	}
+
+	@Override
+	protected boolean isAbbreviationRequired() {
+		return true;
+	}
+
+	@Override
+	protected String getDefaultValue() {
+		// Default the season to current year and month.
+		final SimpleDateFormat formatter = new SimpleDateFormat("YYYYMM");
+		final String currentYearAndMonth = formatter.format(new java.util.Date());
+		SeasonResolver.LOG.debug(
+				"No Crop_season_Code(8371) variable was found or it is present but no value is set. Defaulting [SEASON] with: {}.",
+				currentYearAndMonth);
+		return currentYearAndMonth;
+	}
+
+	@Override
+	protected String getValueFromObservationUnitData(final ObservationUnitData observationUnitData) {
+		return this.getValue(observationUnitData.getValue(),
+			this.environmentVariablesByTermId.get(observationUnitData.getVariableId()).getPossibleValues());
+	}
+
+	protected Optional<ValueReference> findValueReferenceByDescription(final String description,
+			final List<ValueReference> possibleValues) {
+
+		if (possibleValues != null) {
+			for (final ValueReference valueReference : possibleValues) {
+				if (valueReference.getDescription().equals(description)) {
+					return Optional.of(valueReference);
+				}
+			}
+		}
+
+		return Optional.absent();
+
+	}
+
+	@Override
+	protected String getValueFromTrialConditions(final MeasurementVariable variable) {
+		if (TermId.SEASON_VAR.getId() == variable.getTermId()) {
+			return this.getValue(variable.getValue(), variable.getPossibleValues());
+		}
+		return "";
+	}
+
+	private String getValue(final String value, final List<ValueReference> possibleValues) {
+		final Optional<ValueReference> valueReferenceOptional = this.findValueReferenceByDescription(value, possibleValues);
+
+		if (valueReferenceOptional.isPresent()) {
+			return valueReferenceOptional.get().getName();
+		} else {
+			return value;
+		}
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/service/GermplasmNamingProperties.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/service/GermplasmNamingProperties.java
@@ -1,0 +1,47 @@
+
+package org.generationcp.middleware.ruleengine.service;
+
+/**
+ * This bean is typically populated in Spring application context using values in crossing.properties file.
+ */
+public class GermplasmNamingProperties {
+
+	private String germplasmOriginStudiesDefault;
+	private String germplasmOriginStudiesWheat;
+	private String germplasmOriginStudiesMaize;
+
+	private String breedersCrossIDStudy;
+
+	public String getGermplasmOriginStudiesDefault() {
+		return this.germplasmOriginStudiesDefault;
+	}
+
+	public void setGermplasmOriginStudiesDefault(final String germplasmOriginStudiesDefault) {
+		this.germplasmOriginStudiesDefault = germplasmOriginStudiesDefault;
+	}
+
+	public String getGermplasmOriginStudiesWheat() {
+		return this.germplasmOriginStudiesWheat;
+	}
+
+	public void setGermplasmOriginStudiesWheat(final String germplasmOriginStudiesWheat) {
+		this.germplasmOriginStudiesWheat = germplasmOriginStudiesWheat;
+	}
+
+	public String getGermplasmOriginStudiesMaize() {
+		return this.germplasmOriginStudiesMaize;
+	}
+
+	public void setGermplasmOriginStudiesMaize(final String germplasmOriginStudiesMaize) {
+		this.germplasmOriginStudiesMaize = germplasmOriginStudiesMaize;
+	}
+
+	public String getBreedersCrossIDStudy(){
+		return this.breedersCrossIDStudy;
+	}
+
+	public void setBreedersCrossIDStudy(final String breedersCrossIDStudy){
+		this.breedersCrossIDStudy = breedersCrossIDStudy;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/service/KeyTemplateProvider.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/service/KeyTemplateProvider.java
@@ -1,0 +1,11 @@
+package org.generationcp.middleware.ruleengine.service;
+
+
+/**
+ * Interface to be implemented by classes that act as providers of the key code templates.
+ * 
+ */
+public interface KeyTemplateProvider {
+
+	String getKeyTemplate();
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/service/RulesService.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/service/RulesService.java
@@ -6,5 +6,5 @@ import org.generationcp.middleware.ruleengine.RuleExecutionContext;
 
 public interface RulesService {
 
-	public Object runRules(RuleExecutionContext context) throws RuleException;
+	Object runRules(RuleExecutionContext context) throws RuleException;
 }

--- a/src/main/java/org/generationcp/middleware/ruleengine/service/RulesService.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/service/RulesService.java
@@ -1,0 +1,10 @@
+
+package org.generationcp.middleware.ruleengine.service;
+
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.RuleExecutionContext;
+
+public interface RulesService {
+
+	public Object runRules(RuleExecutionContext context) throws RuleException;
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/settings/AdditionalDetailsSetting.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/settings/AdditionalDetailsSetting.java
@@ -1,0 +1,93 @@
+
+package org.generationcp.middleware.ruleengine.settings;
+
+import java.io.Serializable;
+import java.text.DateFormatSymbols;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlTransient;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+public class AdditionalDetailsSetting implements Serializable {
+
+	private static final long serialVersionUID = -5167579512310794528L;
+
+	private Integer harvestLocationId;
+	private String harvestDate;
+
+	public AdditionalDetailsSetting() {
+
+	}
+
+	public AdditionalDetailsSetting(Integer harvestLocationId, String harvestDate) {
+		super();
+		this.harvestLocationId = harvestLocationId;
+		this.harvestDate = harvestDate;
+	}
+
+	@XmlAttribute
+	public Integer getHarvestLocationId() {
+		return this.harvestLocationId;
+	}
+
+	public void setHarvestLocationId(Integer harvestLocationId) {
+		this.harvestLocationId = harvestLocationId;
+	}
+
+	@XmlTransient
+	public String getHarvestDate() {
+		return this.harvestDate;
+	}
+
+	public void setHarvestDate(String harvestDate) {
+		this.harvestDate = harvestDate;
+	}
+
+	public String getHarvestMonth() {
+		int month = Integer.valueOf(this.harvestDate.substring(4, 6));
+
+		if (month == 0) {
+			return "";
+		} else {
+			DateFormatSymbols dateFormat = new DateFormatSymbols();
+			String monthString = dateFormat.getMonths()[month - 1];
+			return monthString;
+		}
+	}
+
+	public String getHarvestYear() {
+		return this.harvestDate.substring(0, 4);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (this.harvestDate == null ? 0 : this.harvestDate.hashCode());
+		result = prime * result + (this.harvestLocationId == null ? 0 : this.harvestLocationId.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
+		if (obj == this) {
+			return true;
+		}
+		if (!(obj instanceof AdditionalDetailsSetting)) {
+			return false;
+		}
+
+		AdditionalDetailsSetting rhs = (AdditionalDetailsSetting) obj;
+		return new EqualsBuilder().append(this.harvestLocationId, rhs.harvestLocationId).isEquals();
+	}
+
+	@Override
+	public String toString() {
+		return "AdditionalDetailsSetting [harvestLocationId=" + this.harvestLocationId + ", harvestDate=" + this.harvestDate + "]";
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/settings/BreedingMethodSetting.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/settings/BreedingMethodSetting.java
@@ -1,0 +1,90 @@
+
+package org.generationcp.middleware.ruleengine.settings;
+
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlAttribute;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+public class BreedingMethodSetting implements Serializable {
+
+	private static final long serialVersionUID = -7580936794539379309L;
+
+	private Integer methodId;
+	private boolean isBasedOnStatusOfParentalLines;
+	private boolean basedOnImportFile;
+
+	public BreedingMethodSetting() {
+
+	}
+
+	public BreedingMethodSetting(Integer methodId, boolean isBasedOnStatusOfParentalLines, boolean basedOnImportFile) {
+		super();
+		this.methodId = methodId;
+		this.isBasedOnStatusOfParentalLines = isBasedOnStatusOfParentalLines;
+		this.basedOnImportFile = basedOnImportFile;
+	}
+
+	@XmlAttribute
+	public Integer getMethodId() {
+		return this.methodId;
+	}
+
+	public void setMethodId(Integer methodId) {
+		this.methodId = methodId;
+	}
+
+	@XmlAttribute
+	public boolean isBasedOnStatusOfParentalLines() {
+		return this.isBasedOnStatusOfParentalLines;
+	}
+
+	public void setBasedOnStatusOfParentalLines(boolean isBasedOnStatusOfParentalLines) {
+		this.isBasedOnStatusOfParentalLines = isBasedOnStatusOfParentalLines;
+	}
+
+	@XmlAttribute
+	public boolean isBasedOnImportFile() {
+	  return basedOnImportFile;
+	}
+
+	public void setBasedOnImportFile(final boolean basedOnImportFile) {
+	  this.basedOnImportFile = basedOnImportFile;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
+		if (obj == this) {
+			return true;
+		}
+		if (!(obj instanceof BreedingMethodSetting)) {
+			return false;
+		}
+
+		BreedingMethodSetting rhs = (BreedingMethodSetting) obj;
+		return new EqualsBuilder().append(this.methodId, rhs.methodId)
+				.append(this.isBasedOnStatusOfParentalLines, rhs.isBasedOnStatusOfParentalLines)
+				.append(this.basedOnImportFile, rhs.isBasedOnImportFile()).isEquals();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (this.isBasedOnStatusOfParentalLines ? 1231 : 1237);
+		result = prime * result + (this.basedOnImportFile ? 1231 : 1237);
+		result = prime * result + (this.methodId == null ? 0 : this.methodId.hashCode());
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "BreedingMethodSetting [methodId=" + this.methodId + ", isBasedOnStatusOfParentalLines="
+						+ this.isBasedOnStatusOfParentalLines + ", basedOnImportFile=" + this.basedOnImportFile + "]";
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/settings/CrossNameSetting.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/settings/CrossNameSetting.java
@@ -1,0 +1,168 @@
+
+package org.generationcp.middleware.ruleengine.settings;
+
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlAttribute;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+public class CrossNameSetting implements Serializable {
+
+	public static final String DEFAULT_SEPARATOR = "/";
+
+	private static final long serialVersionUID = 2944997653987903733L;
+
+	private String prefix;
+	private String suffix;
+	private boolean addSpaceBetweenPrefixAndCode;
+	private boolean addSpaceBetweenSuffixAndCode;
+	private Integer numOfDigits;
+	private String separator;
+	private boolean saveParentageDesignationAsAString;
+
+	private Integer startNumber; // "transient" attribute, not saved in DB
+
+	public CrossNameSetting() {
+
+	}
+
+	public CrossNameSetting(String prefix, String suffix, boolean addSpaceBetweenPrefixAndCode, boolean addSpaceBetweenSuffixAndCode,
+			Integer numOfDigits, String separator) {
+		super();
+		this.prefix = prefix;
+		this.suffix = suffix;
+		this.addSpaceBetweenPrefixAndCode = addSpaceBetweenPrefixAndCode;
+		this.addSpaceBetweenSuffixAndCode = addSpaceBetweenSuffixAndCode;
+		this.numOfDigits = numOfDigits;
+		this.separator = separator;
+	}
+
+	@XmlAttribute
+	public String getPrefix() {
+		return this.prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	@XmlAttribute
+	public String getSuffix() {
+		return this.suffix;
+	}
+
+	public void setSuffix(String suffix) {
+		this.suffix = suffix;
+	}
+
+	@XmlAttribute
+	public boolean isAddSpaceBetweenPrefixAndCode() {
+		return this.addSpaceBetweenPrefixAndCode;
+	}
+
+	public void setAddSpaceBetweenPrefixAndCode(boolean addSpaceBetweenPrefixAndCode) {
+		this.addSpaceBetweenPrefixAndCode = addSpaceBetweenPrefixAndCode;
+	}
+
+	@XmlAttribute
+	public boolean isAddSpaceBetweenSuffixAndCode() {
+		return this.addSpaceBetweenSuffixAndCode;
+	}
+
+	public void setAddSpaceBetweenSuffixAndCode(boolean addSpaceBetweenSuffixAndCode) {
+		this.addSpaceBetweenSuffixAndCode = addSpaceBetweenSuffixAndCode;
+	}
+
+	@XmlAttribute
+	public Integer getNumOfDigits() {
+		return this.numOfDigits;
+	}
+
+	public void setNumOfDigits(Integer numOfDigits) {
+		this.numOfDigits = numOfDigits;
+	}
+
+	public Integer getStartNumber() {
+		return this.startNumber;
+	}
+
+	public void setStartNumber(Integer startNumber) {
+		this.startNumber = startNumber;
+	}
+
+	@XmlAttribute
+	public String getSeparator() {
+		return this.separator;
+	}
+
+	public void setSeparator(String separator) {
+		this.separator = separator;
+	}
+
+	@XmlAttribute
+	public boolean isSaveParentageDesignationAsAString() {
+		return this.saveParentageDesignationAsAString;
+	}
+
+	public void setSaveParentageDesignationAsAString(boolean saveParentageDesignationAsAString) {
+		this.saveParentageDesignationAsAString = saveParentageDesignationAsAString;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (this.addSpaceBetweenPrefixAndCode ? 1231 : 1237);
+		result = prime * result + (this.addSpaceBetweenSuffixAndCode ? 1231 : 1237);
+		result = prime * result + (this.numOfDigits == null ? 0 : this.numOfDigits.hashCode());
+		result = prime * result + (this.prefix == null ? 0 : this.prefix.hashCode());
+		result = prime * result + (this.separator == null ? 0 : this.separator.hashCode());
+		result = prime * result + (this.startNumber == null ? 0 : this.startNumber.hashCode());
+		result = prime * result + (this.suffix == null ? 0 : this.suffix.hashCode());
+		result = prime * result + (this.saveParentageDesignationAsAString ? 1231 : 1237);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
+		if (obj == this) {
+			return true;
+		}
+		if (!(obj instanceof CrossNameSetting)) {
+			return false;
+		}
+
+		CrossNameSetting rhs = (CrossNameSetting) obj;
+		return new EqualsBuilder().append(this.prefix, rhs.prefix).append(this.suffix, rhs.suffix)
+				.append(this.addSpaceBetweenPrefixAndCode, rhs.addSpaceBetweenPrefixAndCode)
+				.append(this.addSpaceBetweenSuffixAndCode, rhs.addSpaceBetweenSuffixAndCode).append(this.numOfDigits, rhs.numOfDigits)
+				.append(this.saveParentageDesignationAsAString, rhs.saveParentageDesignationAsAString)
+				.append(this.separator, rhs.separator).isEquals();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("CrossNameSetting [prefix=");
+		builder.append(this.prefix);
+		builder.append(", suffix=");
+		builder.append(this.suffix);
+		builder.append(", addSpaceBetweenPrefixAndCode=");
+		builder.append(this.addSpaceBetweenPrefixAndCode);
+		builder.append(", addSpaceBetweenSuffixAndCode=");
+		builder.append(this.addSpaceBetweenSuffixAndCode);
+		builder.append(", saveParentageDesignationAsAString=");
+		builder.append(this.saveParentageDesignationAsAString);
+		builder.append(", numOfDigits=");
+		builder.append(this.numOfDigits);
+		builder.append(", separator=");
+		builder.append(this.separator);
+		builder.append("]");
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/settings/CrossSetting.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/settings/CrossSetting.java
@@ -1,0 +1,135 @@
+
+package org.generationcp.middleware.ruleengine.settings;
+
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+@XmlRootElement(name = "CrossingManagerSetting")
+public class CrossSetting implements Serializable, PresetSetting {
+
+	public static final String CROSSING_MANAGER_TOOL_NAME = "crossing_manager";
+
+	private static final long serialVersionUID = 905356968758567192L;
+
+	private String name;
+	private BreedingMethodSetting breedingMethodSetting;
+	private CrossNameSetting crossNameSetting;
+	private AdditionalDetailsSetting additionalDetailsSetting;
+	private boolean preservePlotDuplicates;
+	private boolean isUseManualSettingsForNaming;
+	private boolean applyNewGroupToPreviousCrosses;
+
+	public CrossSetting() {
+
+	}
+
+	public CrossSetting(String name, BreedingMethodSetting breedingMethodSetting, CrossNameSetting crossNameSetting,
+			AdditionalDetailsSetting additionalDetailsSetting) {
+		super();
+		this.name = name;
+		this.breedingMethodSetting = breedingMethodSetting;
+		this.crossNameSetting = crossNameSetting;
+		this.additionalDetailsSetting = additionalDetailsSetting;
+	}
+
+	@XmlAttribute
+	public String getName() {
+		return this.name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@XmlElement
+	public BreedingMethodSetting getBreedingMethodSetting() {
+		return this.breedingMethodSetting;
+	}
+
+	public void setBreedingMethodSetting(BreedingMethodSetting breedingMethodSetting) {
+		this.breedingMethodSetting = breedingMethodSetting;
+	}
+
+	@XmlElement
+	public CrossNameSetting getCrossNameSetting() {
+		return this.crossNameSetting;
+	}
+
+	public void setCrossNameSetting(CrossNameSetting crossNameSetting) {
+		this.crossNameSetting = crossNameSetting;
+	}
+
+	@XmlElement
+	public AdditionalDetailsSetting getAdditionalDetailsSetting() {
+		return this.additionalDetailsSetting;
+	}
+
+	public void setAdditionalDetailsSetting(AdditionalDetailsSetting additionalDetailsSetting) {
+		this.additionalDetailsSetting = additionalDetailsSetting;
+	}
+
+	public boolean isPreservePlotDuplicates() {
+		return this.preservePlotDuplicates;
+	}
+
+	public void setPreservePlotDuplicates(boolean preservePlotDuplicates) {
+		this.preservePlotDuplicates = preservePlotDuplicates;
+	}
+
+	public boolean isUseManualSettingsForNaming() {
+		return this.isUseManualSettingsForNaming;
+	}
+
+	public void setIsUseManualSettingsForNaming(boolean isUseManualSettingsForNaming) {
+		this.isUseManualSettingsForNaming = isUseManualSettingsForNaming;
+	}
+
+	public boolean isApplyNewGroupToPreviousCrosses() {
+		return applyNewGroupToPreviousCrosses;
+	}
+
+	public void setApplyNewGroupToPreviousCrosses(boolean applyNewGroupToPreviousCrosses) {
+		this.applyNewGroupToPreviousCrosses = applyNewGroupToPreviousCrosses;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
+		if (obj == this) {
+			return true;
+		}
+		if (!(obj instanceof CrossSetting)) {
+			return false;
+		}
+
+		CrossSetting rhs = (CrossSetting) obj;
+		return new EqualsBuilder().append(this.name, rhs.name).append(this.breedingMethodSetting, rhs.breedingMethodSetting)
+				.append(this.crossNameSetting, rhs.crossNameSetting).append(this.additionalDetailsSetting, rhs.additionalDetailsSetting)
+				.isEquals();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (this.additionalDetailsSetting == null ? 0 : this.additionalDetailsSetting.hashCode());
+		result = prime * result + (this.breedingMethodSetting == null ? 0 : this.breedingMethodSetting.hashCode());
+		result = prime * result + (this.crossNameSetting == null ? 0 : this.crossNameSetting.hashCode());
+		result = prime * result + (this.name == null ? 0 : this.name.hashCode());
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "CrossingManagerSetting [name=" + this.name + ", breedingMethodSetting=" + this.breedingMethodSetting
+				+ ", crossNameSetting=" + this.crossNameSetting + ", additionalDetailsSetting=" + this.additionalDetailsSetting + "]";
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/settings/PresetSetting.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/settings/PresetSetting.java
@@ -1,0 +1,10 @@
+
+package org.generationcp.middleware.ruleengine.settings;
+
+/**
+ * Created by IntelliJ IDEA. User: Daniel Villafuerte
+ *
+ * This serves as a marker interface for all classes used to store preset settings for the application that need to be persisted via XML
+ */
+public interface PresetSetting {
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/stockid/BreederIdentifierGenerationStrategy.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/stockid/BreederIdentifierGenerationStrategy.java
@@ -1,0 +1,11 @@
+
+package org.generationcp.middleware.ruleengine.stockid;
+
+/**
+ * This interface is used to represent possible implementations for generating breeder identifiers to be used in the generation of stock ID
+ * values
+ */
+public interface BreederIdentifierGenerationStrategy {
+
+	String generateBreederIdentifier();
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/stockid/BreederIdentifierRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/stockid/BreederIdentifierRule.java
@@ -1,0 +1,31 @@
+
+package org.generationcp.middleware.ruleengine.stockid;
+
+import org.generationcp.middleware.ruleengine.OrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.springframework.stereotype.Component;
+
+/**
+ * A rule implementation that defines the logic for processing breeder identifiers within the context of generation of stock IDs
+ */
+@Component
+public class BreederIdentifierRule extends OrderedRule<StockIDGenerationRuleExecutionContext> {
+
+	static final String KEY = "IDENTIFIER";
+
+	@Override
+	public Object runRule(final StockIDGenerationRuleExecutionContext context) throws RuleException {
+		if (context.getBreederIdentifier() == null) {
+			throw new IllegalStateException("User must have supplied breeder identifier at this point");
+		}
+
+		context.getStockIDGenerationBuilder().append(context.getBreederIdentifier());
+
+		return context.getBreederIdentifier();
+	}
+
+	@Override
+	public String getKey() {
+		return BreederIdentifierRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/stockid/StockIDGenerationRuleExecutionContext.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/stockid/StockIDGenerationRuleExecutionContext.java
@@ -1,0 +1,81 @@
+
+package org.generationcp.middleware.ruleengine.stockid;
+
+import java.util.List;
+
+import org.generationcp.middleware.ruleengine.OrderedRuleExecutionContext;
+import org.generationcp.middleware.service.api.inventory.LotService;
+
+/**
+ * An object that serves to provide a common context between rules that interact together for the purpose of stock ID generation. This
+ * allows the preservation / storage of state between rule executions.
+ */
+public class StockIDGenerationRuleExecutionContext extends OrderedRuleExecutionContext {
+
+	private LotService lotService;
+	private StringBuilder stockIDGenerationBuilder;
+	private String breederIdentifier;
+	private Integer notationNumber;
+	private String separator;
+	private Long sequenceNumber;
+
+	public StockIDGenerationRuleExecutionContext(final List<String> executionOrder) {
+		this(executionOrder, null);
+	}
+
+	public StockIDGenerationRuleExecutionContext(final List<String> executionOrder, final LotService lotService) {
+		super(executionOrder);
+		this.lotService = lotService;
+		this.stockIDGenerationBuilder = new StringBuilder();
+	}
+
+	@Override
+	public Object getRuleExecutionOutput() {
+		return this.stockIDGenerationBuilder.toString();
+	}
+
+	public StringBuilder getStockIDGenerationBuilder() {
+		return this.stockIDGenerationBuilder;
+	}
+
+	public void setStockIDGenerationBuilder(final StringBuilder stockIDGenerationBuilder) {
+		this.stockIDGenerationBuilder = stockIDGenerationBuilder;
+	}
+
+	public String getBreederIdentifier() {
+		return this.breederIdentifier;
+	}
+
+	public void setBreederIdentifier(final String breederIdentifier) {
+		this.breederIdentifier = breederIdentifier;
+	}
+
+	public Integer getNotationNumber() {
+		return this.notationNumber;
+	}
+
+	public void setNotationNumber(Integer notationNumber) {
+		this.notationNumber = notationNumber;
+	}
+
+	public String getSeparator() {
+		return this.separator;
+	}
+
+	public void setSeparator(String separator) {
+		this.separator = separator;
+	}
+
+	public Long getSequenceNumber() {
+		return this.sequenceNumber;
+	}
+
+	public void setSequenceNumber(Long sequenceNumber) {
+		this.sequenceNumber = sequenceNumber;
+	}
+
+	public LotService getLotService() {
+		return this.lotService;
+	}
+
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/stockid/StockIDSeparatorRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/stockid/StockIDSeparatorRule.java
@@ -1,0 +1,33 @@
+
+package org.generationcp.middleware.ruleengine.stockid;
+
+import org.apache.commons.lang3.StringUtils;
+import org.generationcp.middleware.ruleengine.OrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.springframework.stereotype.Component;
+
+/**
+ * A rule implementation that defines the logic for processing separators within the context of generation of stock IDs
+ */
+@Component
+public class StockIDSeparatorRule extends OrderedRule<StockIDGenerationRuleExecutionContext> {
+
+	static final String KEY = "SEPARATOR";
+	public static final String DEFAULT_SEPARATOR = "-";
+
+	@Override
+	public Object runRule(final StockIDGenerationRuleExecutionContext context) throws RuleException {
+		final String separator =
+				StringUtils.isEmpty(context.getSeparator()) ? StockIDSeparatorRule.DEFAULT_SEPARATOR : context.getSeparator();
+		context.setSeparator(separator);
+
+		context.getStockIDGenerationBuilder().append(separator);
+
+		return separator;
+	}
+
+	@Override
+	public String getKey() {
+		return StockIDSeparatorRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/stockid/StockNotationNumberRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/stockid/StockNotationNumberRule.java
@@ -1,0 +1,38 @@
+
+package org.generationcp.middleware.ruleengine.stockid;
+
+import org.generationcp.middleware.ruleengine.OrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.exceptions.MiddlewareQueryException;
+import org.springframework.stereotype.Component;
+
+/**
+ * A rule implementation that defines the logic for processing stock notation within the context of generation of stock IDs
+ */
+@Component
+public class StockNotationNumberRule extends OrderedRule<StockIDGenerationRuleExecutionContext> {
+
+	static final String KEY = "NOTATION";
+
+	@Override
+	public Object runRule(final StockIDGenerationRuleExecutionContext context) throws RuleException {
+
+		try {
+			final Integer notationNumber =
+					context.getLotService().getCurrentNotationNumberForBreederIdentifier(context.getBreederIdentifier()) + 1;
+			context.setNotationNumber(notationNumber);
+		} catch (MiddlewareQueryException e) {
+			throw new RuleException(e.getMessage(), e);
+		}
+
+		final Integer currentNotationNumber = context.getNotationNumber();
+		context.getStockIDGenerationBuilder().append(currentNotationNumber);
+
+		return currentNotationNumber;
+	}
+
+	@Override
+	public String getKey() {
+		return StockNotationNumberRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/stockid/StockSequenceRule.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/stockid/StockSequenceRule.java
@@ -1,0 +1,30 @@
+
+package org.generationcp.middleware.ruleengine.stockid;
+
+import org.generationcp.middleware.ruleengine.OrderedRule;
+import org.generationcp.middleware.ruleengine.RuleException;
+
+/**
+ * A rule implementation that defines the logic for processing sequence numbers within the context of generation of stock IDs
+ */
+public class StockSequenceRule extends OrderedRule<StockIDGenerationRuleExecutionContext> {
+
+	static final String KEY = "SEQUENCE";
+
+	@Override
+	public Object runRule(final StockIDGenerationRuleExecutionContext context) throws RuleException {
+		final Long currentSequenceNumber = context.getSequenceNumber() == null ? 0L : context.getSequenceNumber();
+
+		final Long nextSequenceNumber = currentSequenceNumber + 1;
+
+		context.setSequenceNumber(nextSequenceNumber);
+		context.getStockIDGenerationBuilder().append(nextSequenceNumber);
+
+		return nextSequenceNumber;
+	}
+
+	@Override
+	public String getKey() {
+		return StockSequenceRule.KEY;
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/stockid/UserSpecifiedBreederIdentifierGenerationStrategy.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/stockid/UserSpecifiedBreederIdentifierGenerationStrategy.java
@@ -1,0 +1,22 @@
+
+package org.generationcp.middleware.ruleengine.stockid;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * This class serves as an implementation of the BreederIdentifierGenerationStrategy that assumes that the value of the breeder identifier
+ * is supplied by the user prior to the execution of the stock ID generation process instead of a system generated value.
+ * 
+ * The IllegalStateException thrown by the class enforces this assumption; at this point, the rule execution context should already have a
+ * value for breeder identifier and hence does not need to call the implementation.
+ */
+
+@Component
+public class UserSpecifiedBreederIdentifierGenerationStrategy implements BreederIdentifierGenerationStrategy {
+
+	@Override
+	public String generateBreederIdentifier() {
+		throw new IllegalStateException("User specified breeder identifiers should be set into the RuleExecutionContext "
+				+ "programatically before executing this rule");
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/util/ExpressionHelper.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/util/ExpressionHelper.java
@@ -1,0 +1,30 @@
+
+package org.generationcp.middleware.ruleengine.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Created by IntelliJ IDEA. User: Daniel Villafuerte
+ */
+public class ExpressionHelper {
+
+	public static final String PROCESS_CODE_PATTERN = "\\[([^\\]]*)]";
+
+	private ExpressionHelper() {
+
+	}
+
+	public static void evaluateExpression(String input, String sequence, ExpressionHelperCallback callback) {
+		Pattern pattern = Pattern.compile(sequence);
+		Matcher matcher = pattern.matcher(input);
+
+		while (matcher.find()) {
+			String text = matcher.group();
+			int start = matcher.start();
+			int end = matcher.end();
+
+			callback.evaluateCapturedExpression(text, input, start, end);
+		}
+	}
+}

--- a/src/main/java/org/generationcp/middleware/ruleengine/util/ExpressionHelperCallback.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/util/ExpressionHelperCallback.java
@@ -6,5 +6,5 @@ package org.generationcp.middleware.ruleengine.util;
  */
 public interface ExpressionHelperCallback {
 
-	public void evaluateCapturedExpression(String capturedText, String originalInput, int start, int end);
+	void evaluateCapturedExpression(String capturedText, String originalInput, int start, int end);
 }

--- a/src/main/java/org/generationcp/middleware/ruleengine/util/ExpressionHelperCallback.java
+++ b/src/main/java/org/generationcp/middleware/ruleengine/util/ExpressionHelperCallback.java
@@ -1,0 +1,10 @@
+
+package org.generationcp.middleware.ruleengine.util;
+
+/**
+ * Created by IntelliJ IDEA. User: Daniel Villafuerte
+ */
+public interface ExpressionHelperCallback {
+
+	public void evaluateCapturedExpression(String capturedText, String originalInput, int start, int end);
+}

--- a/src/main/java/org/generationcp/middleware/spring/util/ComponentFactory.java
+++ b/src/main/java/org/generationcp/middleware/spring/util/ComponentFactory.java
@@ -1,0 +1,5 @@
+package org.generationcp.middleware.spring.util;
+
+public interface ComponentFactory<Component> {
+    void addComponent(Component component);
+}

--- a/src/main/java/org/generationcp/middleware/spring/util/ComponentPostProcessorFactory.java
+++ b/src/main/java/org/generationcp/middleware/spring/util/ComponentPostProcessorFactory.java
@@ -1,0 +1,31 @@
+package org.generationcp.middleware.spring.util;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+public class ComponentPostProcessorFactory{
+
+    public <T> BeanPostProcessor generatePostProcessorFactory(final Class<T> componentClass, final ComponentFactory<T> factoryInstance)  {
+        BeanPostProcessor postProcessor = new BeanPostProcessor() {
+
+            private ComponentFactory<T> factory = factoryInstance;
+
+            @Override
+            public Object postProcessAfterInitialization(Object o, String s) throws BeansException {
+                if (componentClass.isInstance(o)) {
+                    factory.addComponent((T) o);
+                }
+
+                return o;
+            }
+
+            @Override
+            public Object postProcessBeforeInitialization(Object o, String s) throws BeansException {
+                return o;
+            }
+
+        };
+
+        return postProcessor;
+    }
+}

--- a/src/main/resources/crossing.properties
+++ b/src/main/resources/crossing.properties
@@ -1,0 +1,57 @@
+# We have two options default and cimmyt. The cimmyt profile results in activating
+# the cimmyt specific wheat pedigree string generation algorightm
+pedigree.profile=${pedigree.profile}
+
+#Generation Level would be depending on the pedigree profile and crop type, wheat level would be use for a custom pedigree profile
+wheat.generation.level=${wheat.generation.level}
+
+# The number of generation we should expand our pedigree string. Please note derivative/maintenance
+# breeding methods do not count as generations.
+default.generation.level=${default.generation.level}
+
+# Name types in priority order to stop at while traversing ancestry tree in order to generate pedigree strings
+maize.nametype.order=${maize.nametype.order}
+
+# Name types in priority order to stop at while traversing ancestry tree in order to generate pedigree strings.
+# Please make sure names types specified are defined in the UDFLDS (User Defined Fields) table.
+maize.generation.level=${maize.generation.level}
+
+# Customize the brackcross notation used. By default this is a * on both the male and female side
+maize.backcross.notation.female=${maize.backcross.notation.female}
+maize.backcross.notation.male=${maize.backcross.notation.male}
+
+naming.rules=RootNameGenerator,Separator,Prefix,Count,Suffix
+stockid.rules=IDENTIFIER,NOTATION,SEPARATOR
+
+# Comma separated list of breeding method ids (mid in methods table) that are considered Hybrid methods.
+hybrid.breeding.methods=${hybrid.breeding.methods}
+
+# Formats for the germplasm origin (also interchangeably called seed source or plot code) strings for newly created germplasm e.g. when
+# advancing or crossing studies.
+#
+#     [NAME] replaced by the name of the study.
+# [LOCATION] replaced by the value of LOCATION_ABBR (cvterm id = 8189)
+#            variable or LOCATION_NAME(cvterm id = 8180) variable
+#            if they are present in study settings/environments.
+#            Defaulted to TRIAL_INSTANCE(cvterm id = 8170) if it's present
+#            or empty string otherwise.
+#   [SEASON] replaced by the value of SEASON_VAR (cvterm id = 8371) variable if it is present in study settings and has a non empty value. Defaulted to current year and month in YYYYMM format otherwise.
+#   [PLOTNO] replaced by the value of PLOT_NO (cvterm id = 8200) assigned to the germplasm
+# [SELECTION_NUMBER] replaced by a dash ("-") + the selection number (ear/plant number) IF advancing method results in selection of multiple plants/ears per plot. Nothing is applied if all plots are selected.
+#
+# All other characters in the format string are kept as is.
+
+# **PLEASE NOTE**: If the \ character (backslash) is expected to be used as separator in between the place holder components, two of those characters must be used for a single one to appear in final output.
+# e.g. [LOCATION]\\[PLOTNO] when a single backslash character is expected to be generated between location and plot number.
+# This is because a single \ character is a special programming construct to mean escaping for Strings in Java programming language.
+# Trials for all crops except wheat and maize (see below) will use the following default formats:
+germplasm.origin.studies.default=${germplasm.origin.studies.default}
+
+# Format strings for Maize studies. These are usually customized at CIMMYT. Kept the same as defaults elsewhere.
+germplasm.origin.studies.wheat=${germplasm.origin.studies.wheat}
+
+# Format strings for Wheat studies. These are usually customized at CIMMYT. Kept the same as defaults elsewhere.
+germplasm.origin.studies.maize=${germplasm.origin.studies.maize}
+
+# Format strings for breeders cross id trail
+breeders.cross.id.study=${breeders.cross.id.study}

--- a/src/test/java/org/generationcp/middleware/ruleengine/ExpressionUtilsTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/ExpressionUtilsTest.java
@@ -1,0 +1,72 @@
+package org.generationcp.middleware.ruleengine;
+
+import org.generationcp.middleware.ruleengine.naming.expression.Expression;
+import org.generationcp.middleware.ruleengine.naming.expression.FirstExpression;
+import org.generationcp.middleware.ruleengine.naming.expression.PaddedSequenceExpression;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+public class ExpressionUtilsTest {
+
+	private final Expression unitUnderTest = new FirstExpression();
+
+	@Test
+	public void testReplaceProcessCodeWithValue() {
+		final String key = this.unitUnderTest.getExpressionKey();
+		final StringBuilder builder = new StringBuilder("ABC" + key);
+
+		ExpressionUtils.replaceExpressionWithValue(key, builder, "D");
+
+		Assert.assertEquals("BaseExpression unable to replace the process code with the new value", "ABCD", builder.toString());
+	}
+
+	@Test
+	public void testReplaceProcessCodeWithNullValue() {
+		final String key = this.unitUnderTest.getExpressionKey();
+		final StringBuilder builder = new StringBuilder("ABC" + key);
+
+		final String nullVariable = null;
+		ExpressionUtils.replaceExpressionWithValue(key, builder, nullVariable);
+
+		Assert.assertEquals("BaseExpression unable to replace the process code with the new value", "ABC", builder.toString());
+	}
+
+	@Test
+	public void testReplaceRegularExpressionProcessCodeWithNullValue() {
+		final PaddedSequenceExpression expression = new PaddedSequenceExpression();
+		final StringBuilder builder = new StringBuilder("ABC" + "[PADSEQ.3]");
+
+		final String nullVariable = null;
+		ExpressionUtils.replaceRegularExpressionKeyWithValue(Pattern.compile(expression.getExpressionKey()), builder, nullVariable);
+
+		Assert.assertEquals("BaseExpression unable to replace the process code with the new value", "ABC", builder.toString());
+	}
+
+	@Test
+	public void testReplaceRegularExpressionProcessCodeWithValue() {
+		final PaddedSequenceExpression expression = new PaddedSequenceExpression();
+		final StringBuilder builder = new StringBuilder("ABC" + "[PADSEQ.3]");
+
+		final String value = "023";
+		ExpressionUtils.replaceRegularExpressionKeyWithValue(Pattern.compile(expression.getExpressionKey()), builder, value);
+
+		Assert.assertEquals("BaseExpression unable to replace the process code with the new value", "ABC" + value, builder.toString());
+	}
+
+	@Test
+	public void testGetNumberOfDigitsFromKey() {
+		final PaddedSequenceExpression expression = new PaddedSequenceExpression();
+		final Pattern pattern = Pattern.compile(expression.getExpressionKey());
+		// When no digit is specified
+		Assert.assertEquals(ExpressionUtils.DEFAULT_LENGTH, ExpressionUtils.getNumberOfDigitsFromKey(pattern,  new StringBuilder("ABC" + "[PADSEQ]XYZ")));
+		// Check that regex matching is case-insensitive
+		Assert.assertEquals(ExpressionUtils.DEFAULT_LENGTH, ExpressionUtils.getNumberOfDigitsFromKey(pattern,  new StringBuilder("ABC" + "[padseq]XYZ")));
+		// With digit specified
+		Assert.assertEquals(7, ExpressionUtils.getNumberOfDigitsFromKey(pattern,  new StringBuilder("ABC" + "[PADSEQ.7]XYZ")).intValue());
+		// Regex not matched
+		Assert.assertEquals(0, ExpressionUtils.getNumberOfDigitsFromKey(pattern,  new StringBuilder("ABC" + "[SEQUENCE]")).intValue());
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/RuleFactoryIntegrationTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/RuleFactoryIntegrationTest.java
@@ -1,0 +1,35 @@
+
+package org.generationcp.middleware.ruleengine;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.annotation.Resource;
+import java.util.Collection;
+
+/**
+ * Created by IntelliJ IDEA. User: Daniel Villafuerte Date: 2/16/2015 Time: 2:05 PM
+ */
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:BaseNamingRuleTest-context.xml", "classpath:testContext.xml"})
+public class RuleFactoryIntegrationTest {
+
+	@Resource
+	private RuleFactory factory;
+
+	@Test
+	public void testSuccessfulRuleRegistration() {
+		Assert.assertTrue("Rules not successfully registered to factory", this.factory.getAvailableRuleCount() > 0);
+	}
+
+	@Test
+	public void testRuleConfiguration() {
+		Collection<String> configuredNamespaces = this.factory.getAvailableConfiguredNamespaces();
+		Assert.assertNotNull(configuredNamespaces);
+		Assert.assertFalse(configuredNamespaces.isEmpty());
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/coding/CountRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/coding/CountRuleTest.java
@@ -1,0 +1,44 @@
+package org.generationcp.middleware.ruleengine.coding;
+
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.coding.expression.CodingExpressionResolver;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CountRuleTest {
+
+	@Mock
+	private CodingExpressionResolver codingExpressionResolver;
+
+	@InjectMocks
+	private CountRule countRule;
+
+	@Test
+	public void testRunRule() throws RuleException {
+
+		final List<String> sequenceOrder = new ArrayList<>();
+		final NamingConfiguration namingConfiguration = new NamingConfiguration();
+		namingConfiguration.setCount("[SEQUENCE]");
+		final CodingRuleExecutionContext context = new CodingRuleExecutionContext(sequenceOrder, namingConfiguration);
+		context.setCurrentData("CML");
+
+		final String resolvedValue = "CML1";
+		Mockito.when(codingExpressionResolver.resolve(context.getCurrentData(), namingConfiguration.getCount(), namingConfiguration))
+				.thenReturn(Arrays.asList(resolvedValue));
+
+		assertEquals(resolvedValue, this.countRule.runRule(context));
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/coding/PrefixRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/coding/PrefixRuleTest.java
@@ -1,0 +1,46 @@
+package org.generationcp.middleware.ruleengine.coding;
+
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.coding.expression.CodingExpressionResolver;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PrefixRuleTest {
+
+	@Mock
+	private CodingExpressionResolver codingExpressionResolver;
+
+	@InjectMocks
+	private PrefixRule prefixRule;
+
+	@Test
+	public void testRunRule() throws RuleException {
+
+		final String prefix = "CML";
+
+		final List<String> sequenceOrder = new ArrayList<>();
+		final NamingConfiguration namingConfiguration = new NamingConfiguration();
+
+		namingConfiguration.setPrefix(prefix);
+		final CodingRuleExecutionContext context = new CodingRuleExecutionContext(sequenceOrder, namingConfiguration);
+		context.setCurrentData("");
+
+		Mockito.when(codingExpressionResolver.resolve(context.getCurrentData(), namingConfiguration.getPrefix(), namingConfiguration))
+				.thenReturn(Arrays.asList(prefix));
+
+		assertEquals(prefix, this.prefixRule.runRule(context));
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/coding/SuffixRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/coding/SuffixRuleTest.java
@@ -1,0 +1,46 @@
+package org.generationcp.middleware.ruleengine.coding;
+
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.coding.expression.CodingExpressionResolver;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SuffixRuleTest {
+
+	@Mock
+	private CodingExpressionResolver codingExpressionResolver;
+
+	@InjectMocks
+	private SuffixRule suffixRule;
+
+	@Test
+	public void testRunRule() throws RuleException {
+
+		final String suffix = "XYZ";
+
+		final List<String> sequenceOrder = new ArrayList<>();
+		final NamingConfiguration namingConfiguration = new NamingConfiguration();
+
+		namingConfiguration.setSuffix(suffix);
+		final CodingRuleExecutionContext context = new CodingRuleExecutionContext(sequenceOrder, namingConfiguration);
+		context.setCurrentData("");
+
+		Mockito.when(codingExpressionResolver.resolve(context.getCurrentData(), namingConfiguration.getSuffix(), namingConfiguration))
+				.thenReturn(Arrays.asList(suffix));
+
+		assertEquals(suffix, this.suffixRule.runRule(context));
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/coding/expression/BaseCodingExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/coding/expression/BaseCodingExpressionTest.java
@@ -1,0 +1,29 @@
+package org.generationcp.middleware.ruleengine.coding.expression;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BaseCodingExpressionTest {
+	private static final String SEQUENCE_CODE = "[SEQUENCE]";
+
+	private final SequenceExpression expression = new SequenceExpression();
+
+	@Test
+	public void testReplaceProcessCodeWithValue() {
+		final StringBuilder builder = new StringBuilder("ABC" + SEQUENCE_CODE);
+
+		this.expression.replaceRegularExpressionKeyWithValue(builder, "D");
+
+		Assert.assertEquals("BaseCodingExpression unable to replace the process code with the new value", "ABCD", builder.toString());
+	}
+
+	@Test
+	public void testReplaceProcessCodeWithNullVariable() {
+		final StringBuilder builder = new StringBuilder("ABC" + SEQUENCE_CODE);
+
+		final String nullVariable = null;
+		this.expression.replaceRegularExpressionKeyWithValue(builder, nullVariable);
+
+		Assert.assertEquals("BaseCodingExpression unable to replace the process code with the new value", "ABC", builder.toString());
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/coding/expression/CodingExpressionFactoryTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/coding/expression/CodingExpressionFactoryTest.java
@@ -1,0 +1,27 @@
+package org.generationcp.middleware.ruleengine.coding.expression;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CodingExpressionFactoryTest {
+
+	private static final String KEY = "[SEQUENCE]";
+
+	private final CodingExpressionFactory factory = new CodingExpressionFactory();
+
+	@Before
+	public void init() {
+
+		this.factory.init();
+		this.factory.addExpression(new SequenceExpression());
+	}
+
+	@Test
+	public void testLookup() {
+		Assert.assertNotNull(this.factory.lookup(CodingExpressionFactoryTest.KEY));
+		Assert.assertNull(this.factory.lookup(""));
+
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/coding/expression/CodingExpressionPostProcessorTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/coding/expression/CodingExpressionPostProcessorTest.java
@@ -1,0 +1,32 @@
+package org.generationcp.middleware.ruleengine.coding.expression;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CodingExpressionPostProcessorTest {
+
+	private CodingExpressionPostProcessor codingExpressionPostProcessor = new CodingExpressionPostProcessor();
+
+	@Mock
+	private CodingExpressionFactory codingExpressionFactory;
+
+	@Before
+	public void init() {
+		codingExpressionPostProcessor.setCodingExpressionFactory(codingExpressionFactory);
+	}
+
+	@Test
+	public void testPostProcessAfterInitialization() {
+		BaseCodingExpression expression = new SequenceExpression();
+		codingExpressionPostProcessor.postProcessAfterInitialization(expression, null);
+		verify(codingExpressionFactory).addExpression(expression);
+
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/coding/expression/CodingExpressionResolverTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/coding/expression/CodingExpressionResolverTest.java
@@ -1,0 +1,49 @@
+package org.generationcp.middleware.ruleengine.coding.expression;
+
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+import org.generationcp.middleware.ruleengine.naming.service.GermplasmNamingService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CodingExpressionResolverTest {
+
+	private static final String SEQUENCE_CODE = "[SEQUENCE]";
+
+	@Mock
+	private CodingExpressionFactory factory;
+
+	@Mock
+	private GermplasmNamingService germplasmNamingService;
+
+	@InjectMocks
+	private final CodingExpressionResolver codingExpressionResolver = new CodingExpressionResolver();
+
+	@Test
+	public void testResolve() {
+
+		final int startingSequenceNumber = 11;
+		final NamingConfiguration namingConfiguration = new NamingConfiguration();
+		final String prefix = "IBC";
+		namingConfiguration.setPrefix(prefix);
+		final String currentInput = "CML";
+
+		final SequenceExpression sequenceExpression = new SequenceExpression();
+		sequenceExpression.setGermplasmNamingService(this.germplasmNamingService);
+		Mockito.when(this.factory.lookup(SEQUENCE_CODE)).thenReturn(sequenceExpression);
+		Mockito.when(this.germplasmNamingService.getNextNumberAndIncrementSequence(prefix)).thenReturn(startingSequenceNumber);
+		Mockito.when(this.germplasmNamingService.getNumberWithLeadingZeroesAsString(startingSequenceNumber, 1)).thenReturn(String.valueOf(startingSequenceNumber));
+
+		final List<String> result = this.codingExpressionResolver.resolve(currentInput, SEQUENCE_CODE, namingConfiguration);
+		assertEquals(currentInput + startingSequenceNumber, result.get(0));
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/coding/expression/PaddedSequenceExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/coding/expression/PaddedSequenceExpressionTest.java
@@ -1,0 +1,103 @@
+package org.generationcp.middleware.ruleengine.coding.expression;
+
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+import org.generationcp.middleware.ruleengine.ExpressionUtils;
+import org.generationcp.middleware.ruleengine.naming.service.GermplasmNamingService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class PaddedSequenceExpressionTest {
+
+	private static final Integer NEXT_NUMBER_FROM_DB = 43;
+	private static final String PREFIX = "ABC";
+	private static final String SUFFIX = "XYZ";
+	private static final String PADSEQ = "[PADSEQ]";
+	private static final String PADSEQ_WITH_NUMBER = "[PADSEQ.%s]";
+	private final PaddedSequenceExpression padSeqExpression = new PaddedSequenceExpression();
+	private final NamingConfiguration namingConfiguration = new NamingConfiguration();
+
+	@Mock
+	private GermplasmNamingService germplasmNamingService;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.padSeqExpression.setGermplasmNamingService(this.germplasmNamingService);
+
+		this.namingConfiguration.setPrefix(PREFIX);
+		this.namingConfiguration.setCount(PADSEQ);
+		this.namingConfiguration.setSuffix(SUFFIX);
+		Mockito.doReturn(NEXT_NUMBER_FROM_DB, NEXT_NUMBER_FROM_DB + 1, NEXT_NUMBER_FROM_DB + 2).when(this.germplasmNamingService)
+			.getNextNumberAndIncrementSequence(PREFIX);
+		Mockito.doReturn("0" + NEXT_NUMBER_FROM_DB, "0" + (NEXT_NUMBER_FROM_DB + 1), "0" + (NEXT_NUMBER_FROM_DB + 2))
+			.when(this.germplasmNamingService).getNumberWithLeadingZeroesAsString(
+			ArgumentMatchers.anyInt(), ArgumentMatchers.eq(ExpressionUtils.DEFAULT_LENGTH));
+	}
+
+	@Test
+	public void testExpressionRegex() {
+		Assert.assertTrue(PaddedSequenceExpressionTest.PADSEQ.matches(this.padSeqExpression.getExpressionKey()));
+		Assert.assertTrue("[PADSEQ.2]".matches(this.padSeqExpression.getExpressionKey()));
+		Assert.assertTrue("[PADSEQ.23]".matches(this.padSeqExpression.getExpressionKey()));
+		Assert.assertFalse("[PADSEQ.AB2]".matches(this.padSeqExpression.getExpressionKey()));
+		Assert.assertFalse("[PADSEQ.ab2]".matches(this.padSeqExpression.getExpressionKey()));
+	}
+
+	@Test
+	public void testApplyNoNumberOfDigitsSpecified() {
+		final Integer count = 3;
+		final List<StringBuilder> values = this.createInitialValues(this.namingConfiguration, count);
+
+		this.padSeqExpression.apply(values, "", this.namingConfiguration);
+		assertEquals(count.intValue(), values.size());
+		assertEquals(PREFIX + "0" + NEXT_NUMBER_FROM_DB + SUFFIX, values.get(0).toString());
+		assertEquals(PREFIX + "0" + (NEXT_NUMBER_FROM_DB + 1) + SUFFIX, values.get(1).toString());
+		assertEquals(PREFIX + "0" + (NEXT_NUMBER_FROM_DB + 2) + SUFFIX, values.get(2).toString());
+	}
+
+	@Test
+	public void testApplyWithNumberOfDigitsSpecified() {
+		final Integer numberofDigits = 5;
+		this.namingConfiguration.setCount(String.format(PaddedSequenceExpressionTest.PADSEQ_WITH_NUMBER, numberofDigits));
+		final Integer count = 3;
+		final List<StringBuilder> values = this.createInitialValues(this.namingConfiguration, count);
+		Mockito.doReturn("000" + NEXT_NUMBER_FROM_DB, "000" + (NEXT_NUMBER_FROM_DB + 1), "000" + (NEXT_NUMBER_FROM_DB + 2))
+			.when(this.germplasmNamingService).getNumberWithLeadingZeroesAsString(
+			ArgumentMatchers.anyInt(), ArgumentMatchers.eq(numberofDigits));
+
+		this.padSeqExpression.apply(values, "", this.namingConfiguration);
+		assertEquals(count.intValue(), values.size());
+		assertEquals(PREFIX + "000" + NEXT_NUMBER_FROM_DB + SUFFIX, values.get(0).toString());
+		assertEquals(PREFIX + "000" + (NEXT_NUMBER_FROM_DB + 1) + SUFFIX, values.get(1).toString());
+		assertEquals(PREFIX + "000" + (NEXT_NUMBER_FROM_DB + 2) + SUFFIX, values.get(2).toString());
+	}
+
+	private List<StringBuilder> createInitialValues(final NamingConfiguration config, final Integer count) {
+		final List<StringBuilder> builders = new ArrayList<>();
+
+		for (int i = 0; i < count; i++) {
+			final StringBuilder builder = new StringBuilder();
+			builder.append(this.getNonNullValue(config.getPrefix()))
+				.append(this.getNonNullValue(config.getCount()))
+				.append(this.getNonNullValue(config.getSuffix()));
+			builders.add(builder);
+		}
+
+		return builders;
+	}
+
+	private String getNonNullValue(final String value) {
+		return value != null ? value : "";
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/coding/expression/SequenceExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/coding/expression/SequenceExpressionTest.java
@@ -1,0 +1,85 @@
+package org.generationcp.middleware.ruleengine.coding.expression;
+
+import org.generationcp.middleware.pojos.naming.NamingConfiguration;
+import org.generationcp.middleware.ruleengine.naming.service.GermplasmNamingService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SequenceExpressionTest {
+
+	private static final Integer NEXT_NUMBER_FROM_DB = 22;
+	private static final String PREFIX = "XYZ";
+	private static final String SEQUENCE = "[SEQUENCE]";
+	private static final String SUFFIX = "T";
+	private final SequenceExpression sequenceExpression = new SequenceExpression();
+	private final NamingConfiguration namingConfiguration = new NamingConfiguration();
+
+	@Mock
+	private GermplasmNamingService germplasmNamingService;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.sequenceExpression.setGermplasmNamingService(this.germplasmNamingService);
+
+		this.namingConfiguration.setPrefix(PREFIX);
+		this.namingConfiguration.setCount(SEQUENCE);
+		this.namingConfiguration.setSuffix(SUFFIX);
+		Mockito.doReturn(NEXT_NUMBER_FROM_DB, NEXT_NUMBER_FROM_DB + 1, NEXT_NUMBER_FROM_DB + 2).when(this.germplasmNamingService)
+			.getNextNumberAndIncrementSequence(PREFIX);
+		Mockito
+			.doReturn(String.valueOf(NEXT_NUMBER_FROM_DB), String.valueOf(NEXT_NUMBER_FROM_DB + 1), String.valueOf(NEXT_NUMBER_FROM_DB + 2))
+			.when(this.germplasmNamingService).getNumberWithLeadingZeroesAsString(
+			ArgumentMatchers.anyInt(), ArgumentMatchers.eq(1));
+	}
+
+	@Test
+	public void testApplySingleValue() {
+		final Integer count = 1;
+		final List<StringBuilder> values = this.createInitialValues(this.namingConfiguration, count);
+
+		this.sequenceExpression.apply(values, "", this.namingConfiguration);
+		assertEquals(count.intValue(), values.size());
+		assertEquals(PREFIX + NEXT_NUMBER_FROM_DB + SUFFIX, values.get(0).toString());
+	}
+
+	@Test
+	public void testApplyMultipleValues() {
+		final Integer count = 3;
+		final List<StringBuilder> values = this.createInitialValues(this.namingConfiguration, count);
+
+		this.sequenceExpression.apply(values, "", this.namingConfiguration);
+		assertEquals(count.intValue(), values.size());
+		assertEquals(PREFIX + NEXT_NUMBER_FROM_DB + SUFFIX, values.get(0).toString());
+		assertEquals(PREFIX + (NEXT_NUMBER_FROM_DB + 1) + SUFFIX, values.get(1).toString());
+		assertEquals(PREFIX + (NEXT_NUMBER_FROM_DB + 2) + SUFFIX, values.get(2).toString());
+	}
+
+	private List<StringBuilder> createInitialValues(final NamingConfiguration config, final Integer count) {
+		final List<StringBuilder> builders = new ArrayList<>();
+
+		for (int i = 0; i < count; i++) {
+			final StringBuilder builder = new StringBuilder();
+			builder.append(this.getNonNullValue(config.getPrefix()))
+				.append(this.getNonNullValue(config.getCount()))
+				.append(this.getNonNullValue(config.getSuffix()));
+			builders.add(builder);
+		}
+
+		return builders;
+	}
+
+	private String getNonNullValue(final String value) {
+		return value != null ? value : "";
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/cross/BackCrossSuffixRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/cross/BackCrossSuffixRuleTest.java
@@ -1,0 +1,78 @@
+
+package org.generationcp.middleware.ruleengine.cross;
+
+import org.generationcp.middleware.exceptions.MiddlewareQueryException;
+import org.generationcp.middleware.manager.PedigreeDataManagerImpl;
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.manager.api.PedigreeDataManager;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.settings.CrossSetting;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class BackCrossSuffixRuleTest {
+
+	private static final String TEST_BASE_CROSS_NAME = "Cross";
+	private static final int MALE_GID = 100;
+	private static final int FEMALE_GID = 101;
+
+	private BackCrossSuffixRule unitUnderTest;
+	private PedigreeDataManager pedigreeDataManager;
+	private CrossSetting crossSetting;
+	private GermplasmDataManager germplasmDataManager;
+	private CrossingRuleExecutionContext ruleContext;
+
+	@Before
+	public void setUp() throws Exception {
+		unitUnderTest = new BackCrossSuffixRule();
+
+		pedigreeDataManager = Mockito.mock(PedigreeDataManager.class);
+		crossSetting = Mockito.mock(CrossSetting.class);
+		germplasmDataManager = Mockito.mock(GermplasmDataManager.class);
+		ruleContext = new CrossingRuleExecutionContext(null);
+		ruleContext.setPedigreeDataManager(pedigreeDataManager);
+		ruleContext.setCurrentCrossName(TEST_BASE_CROSS_NAME);
+		ruleContext.setCrossSetting(crossSetting);
+		ruleContext.setGermplasmDataManager(germplasmDataManager);
+		ruleContext.setMaleGid(MALE_GID);
+		ruleContext.setFemaleGid(FEMALE_GID);
+	}
+
+	@Test
+	public void testRunRuleMaleRecurrent() throws RuleException, MiddlewareQueryException {
+		Mockito.when(pedigreeDataManager.calculateRecurrentParent(MALE_GID, FEMALE_GID)).thenReturn(PedigreeDataManagerImpl.MALE_RECURRENT);
+
+		String output = (String) unitUnderTest.runRule(ruleContext);
+		Assert.assertEquals("Unable to add proper suffix for items with recurrent male parent", TEST_BASE_CROSS_NAME
+				+ BackCrossSuffixRule.MALE_RECURRENT_SUFFIX, output);
+	}
+
+	@Test
+	public void testRunRuleFemaleRecurrent() throws RuleException, MiddlewareQueryException {
+		Mockito.when(pedigreeDataManager.calculateRecurrentParent(MALE_GID, FEMALE_GID)).thenReturn(PedigreeDataManagerImpl.FEMALE_RECURRENT);
+
+		String output = (String) unitUnderTest.runRule(ruleContext);
+		Assert.assertEquals("Unable to add proper suffix for items with recurrent female parent", TEST_BASE_CROSS_NAME
+				+ BackCrossSuffixRule.FEMALE_RECURRENT_SUFFIX, output);
+	}
+
+	@Test
+	public void testRunRuleNonRecurrent() throws RuleException, MiddlewareQueryException {
+		Mockito.when(pedigreeDataManager.calculateRecurrentParent(MALE_GID, FEMALE_GID)).thenReturn(PedigreeDataManagerImpl.NONE);
+
+		String output = (String) unitUnderTest.runRule(ruleContext);
+		Assert.assertEquals("Wrong output for items with no recurrent parent", TEST_BASE_CROSS_NAME, output);
+	}
+
+	@Test
+	public void testGetKey() {
+		Assert.assertEquals(BackCrossSuffixRule.KEY, unitUnderTest.getKey());
+	}
+
+	@Test
+	public void testGetProcessCode() {
+		Assert.assertEquals(BackCrossSuffixRule.PROCESS_CODE, unitUnderTest.getProcessCode());
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/generator/BreedersCrossIDGeneratorTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/generator/BreedersCrossIDGeneratorTest.java
@@ -1,0 +1,186 @@
+package org.generationcp.middleware.ruleengine.generator;
+
+import com.google.common.collect.Lists;
+import org.generationcp.middleware.domain.etl.MeasurementData;
+import org.generationcp.middleware.domain.etl.MeasurementRow;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.etl.StudyDetails;
+import org.generationcp.middleware.domain.etl.Workbook;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.domain.oms.TermSummary;
+import org.generationcp.middleware.domain.ontology.Scale;
+import org.generationcp.middleware.domain.ontology.Variable;
+import org.generationcp.middleware.domain.study.StudyTypeDto;
+import org.generationcp.middleware.manager.api.StudyDataManager;
+import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.pojos.workbench.CropType;
+import org.generationcp.middleware.pojos.workbench.Project;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.ruleengine.service.GermplasmNamingProperties;
+import org.generationcp.middleware.service.api.dataset.DatasetService;
+import org.generationcp.middleware.service.api.study.StudyInstanceService;
+import org.generationcp.middleware.service.impl.study.StudyInstance;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.generationcp.middleware.service.api.dataset.ObservationUnitUtils.fromMeasurementRow;
+import static org.mockito.ArgumentMatchers.anyInt;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BreedersCrossIDGeneratorTest {
+
+	@Mock
+	private OntologyVariableDataManager ontologyVariableDataManager;
+
+	@Mock
+	private StudyDataManager studyDataManager;
+
+	@Mock
+	private StudyInstanceService studyInstanceService;
+
+	@Mock
+	private DatasetService datasetService;
+
+	private static final Integer PROJECT_PREFIX_CATEGORY_ID = 3001;
+	private static final String PROJECT_PREFIX_CATEGORY_VALUE = "Project_Prefix";
+
+	private static final Integer HABITAT_DESIGNATION_CATEGORY_ID = 3002;
+	private static final String HABITAT_DESIGNATION_CATEGORY_VALUE = "Habitat_Designation";
+
+	private static final Integer SEASON_CATEGORY_ID = 10290;
+	private static final String SEASON_CATEGORY_VALUE = "Dry Season";
+
+	@InjectMocks
+	private BreedersCrossIDGenerator breedersCrossIDGenerator;
+
+	private List<StudyInstance> studyInstances;
+
+	@Before
+	public void setUp() {
+
+		final GermplasmNamingProperties germplasmNamingProperties = new GermplasmNamingProperties();
+		germplasmNamingProperties.setBreedersCrossIDStudy("[PROJECT_PREFIX]-[HABITAT_DESIGNATION]-[SEASON]-[LOCATION]");
+		germplasmNamingProperties.setBreedersCrossIDStudy("[PROJECT_PREFIX]-[HABITAT_DESIGNATION]-[SEASON]-[LOCATION]");
+		breedersCrossIDGenerator.setGermplasmNamingProperties(germplasmNamingProperties);
+
+		final Project testProject = new Project();
+		testProject.setUniqueID("e8e4be0a-5d63-452f-8fde-b1c794ec7b1a");
+		testProject.setCropType(new CropType("maize"));
+
+		final Variable projectPrefixVariable = new Variable();
+		final Scale projectPrefixScale = new Scale();
+		final TermSummary projectPrefixCategory = new TermSummary(PROJECT_PREFIX_CATEGORY_ID, PROJECT_PREFIX_CATEGORY_VALUE,
+				PROJECT_PREFIX_CATEGORY_VALUE);
+		projectPrefixScale.addCategory(projectPrefixCategory);
+		projectPrefixVariable.setScale(projectPrefixScale);
+
+		final Variable habitatDesignationVariable = new Variable();
+		final Scale habitatDesignationScale = new Scale();
+		final TermSummary habitatDesignationCategory = new TermSummary(HABITAT_DESIGNATION_CATEGORY_ID, HABITAT_DESIGNATION_CATEGORY_VALUE,
+				HABITAT_DESIGNATION_CATEGORY_VALUE);
+		habitatDesignationScale.addCategory(habitatDesignationCategory);
+		habitatDesignationVariable.setScale(habitatDesignationScale);
+
+		final Variable seasonVariable = new Variable();
+		final Scale seasonScale = new Scale();
+		final TermSummary seasonCategory = new TermSummary(SEASON_CATEGORY_ID, SEASON_CATEGORY_VALUE, SEASON_CATEGORY_VALUE);
+		seasonScale.addCategory(seasonCategory);
+		seasonVariable.setScale(seasonScale);
+
+		final StudyInstance studyInstance = new StudyInstance();
+		studyInstance.setInstanceNumber(1);
+		studyInstance.setLocationAbbreviation("ABBR");
+		studyInstances = new ArrayList<>();
+		studyInstances.add(studyInstance);
+
+	}
+
+	@Test
+	public void testGenerateBreedersCrossIDStudy() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyName("TestStudy");
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		studyDetails.setId(1);
+		workbook.setStudyDetails(studyDetails);
+
+		final AdvancingSource source = new AdvancingSource();
+		source.setEnvironmentDatasetId(12);
+
+		final MeasurementVariable instance1LocationAbbrMV = new MeasurementVariable();
+		instance1LocationAbbrMV.setTermId(TermId.LOCATION_ABBR.getId());
+		instance1LocationAbbrMV.setName(TermId.LOCATION_ABBR.name());
+		final MeasurementData instance1LocationAbbrMD = new MeasurementData();
+		instance1LocationAbbrMD.setValue("IND");
+		instance1LocationAbbrMD.setMeasurementVariable(instance1LocationAbbrMV);
+
+		final MeasurementVariable instance1ProjectPrefix = new MeasurementVariable();
+		instance1ProjectPrefix.setTermId(TermId.PROJECT_PREFIX.getId());
+		instance1ProjectPrefix.setName(TermId.PROJECT_PREFIX.name());
+		final MeasurementData instance1ProjectPrefixMD = new MeasurementData();
+		instance1ProjectPrefixMD.setValue(PROJECT_PREFIX_CATEGORY_VALUE);
+		instance1ProjectPrefixMD.setMeasurementVariable(instance1ProjectPrefix);
+
+		final MeasurementVariable instance1HabitatDesignationMV = new MeasurementVariable();
+		instance1HabitatDesignationMV.setTermId(TermId.HABITAT_DESIGNATION.getId());
+		instance1HabitatDesignationMV.setName(TermId.HABITAT_DESIGNATION.name());
+		final MeasurementData instance1HabitatDesignationMD = new MeasurementData();
+		instance1HabitatDesignationMD.setValue(HABITAT_DESIGNATION_CATEGORY_VALUE);
+		instance1HabitatDesignationMD.setMeasurementVariable(instance1HabitatDesignationMV);
+
+		final MeasurementVariable instance1SeasonMV = new MeasurementVariable();
+		instance1SeasonMV.setTermId(TermId.SEASON_VAR.getId());
+		instance1SeasonMV.setName(TermId.SEASON_VAR.name());
+		final MeasurementData instance1SeasonMD = new MeasurementData();
+		instance1SeasonMD.setValue(SEASON_CATEGORY_VALUE);
+		instance1SeasonMD.setMeasurementVariable(instance1SeasonMV);
+
+		final MeasurementVariable instance1InstanceNumberMV = new MeasurementVariable();
+		instance1InstanceNumberMV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		instance1InstanceNumberMV.setName(TermId.TRIAL_INSTANCE_FACTOR.name());
+		final MeasurementData instance1InstanceNumberMD = new MeasurementData();
+		instance1InstanceNumberMD.setValue("1");
+		instance1InstanceNumberMD.setMeasurementVariable(instance1InstanceNumberMV);
+
+		final MeasurementRow instance1Measurements = new MeasurementRow();
+		instance1Measurements.setDataList(Lists.newArrayList(instance1InstanceNumberMD, instance1LocationAbbrMD,
+				instance1ProjectPrefixMD, instance1HabitatDesignationMD, instance1SeasonMD));
+
+		final Method breedingMethod = new Method();
+		breedingMethod.setMname("Single cross");
+		breedingMethod.setSnametype(5);
+		breedingMethod.setPrefix("pre");
+		breedingMethod.setSeparator("-");
+		breedingMethod.setCount("[CIMCRS]");
+		breedingMethod.setSuffix("suff");
+
+		workbook.setTrialObservations(Lists.newArrayList(instance1Measurements));
+
+		final String expectedBreedersCrossId = PROJECT_PREFIX_CATEGORY_VALUE + "-" + HABITAT_DESIGNATION_CATEGORY_VALUE + "-"
+				+ SEASON_CATEGORY_VALUE + "-" + instance1LocationAbbrMD.getValue();
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+
+		Mockito.doReturn(instance1Measurements.getMeasurementVariables())
+			.when(this.datasetService).getObservationSetVariables(anyInt(), ArgumentMatchers.<Integer>anyList());
+
+		Mockito.doReturn(studyInstances).when(this.studyInstanceService).getStudyInstances(1);
+
+		final String actualBreedersCrossId = this.breedersCrossIDGenerator.generateBreedersCrossID(workbook.getStudyDetails().getId(),
+			source.getEnvironmentDatasetId(), conditions, fromMeasurementRow(instance1Measurements));
+
+		Assert.assertEquals(expectedBreedersCrossId, actualBreedersCrossId);
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/generator/BreedersCrossIDTemplateProviderTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/generator/BreedersCrossIDTemplateProviderTest.java
@@ -1,0 +1,25 @@
+package org.generationcp.middleware.ruleengine.generator;
+
+import org.generationcp.middleware.ruleengine.service.GermplasmNamingProperties;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BreedersCrossIDTemplateProviderTest {
+
+	@Test
+	public void testGetKeyTemplate() {
+
+		final GermplasmNamingProperties germplasmNamingProperties = new GermplasmNamingProperties();
+
+		germplasmNamingProperties.setBreedersCrossIDStudy("[PROJECT_PREFIX][HABITAT_DESIGNATION]-[SEASON]-[LOCATION]");
+		germplasmNamingProperties.setBreedersCrossIDStudy("[PROJECT_PREFIX][HABITAT_DESIGNATION]-[SEASON]:[LOCATION]");
+
+		// Study
+		Assert.assertEquals(germplasmNamingProperties.getBreedersCrossIDStudy(),
+				new BreedersCrossIDTemplateProvider(germplasmNamingProperties).getKeyTemplate());
+
+		// Study
+		Assert.assertEquals(germplasmNamingProperties.getBreedersCrossIDStudy(),
+				new BreedersCrossIDTemplateProvider(germplasmNamingProperties).getKeyTemplate());
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/generator/KeyCodeGenerationsServiceImplTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/generator/KeyCodeGenerationsServiceImplTest.java
@@ -1,0 +1,142 @@
+
+package org.generationcp.middleware.ruleengine.generator;
+
+import org.generationcp.middleware.ruleengine.resolver.KeyComponentValueResolver;
+import org.generationcp.middleware.ruleengine.service.KeyTemplateProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class KeyCodeGenerationsServiceImplTest {
+
+	// Template with one optional component ([SELECTION_NUMBER])
+	final KeyTemplateProvider oneOptionalComponentTemplateProvider = new KeyTemplateProvider() {
+
+		@Override
+		public String getKeyTemplate() {
+			return "[LOCATION]-[PLOTNO][SELECTION_NUMBER]";
+		}
+	};
+
+	// Template with all required components
+	final KeyTemplateProvider allRequiredComponentTemplateProvider = new KeyTemplateProvider() {
+
+		@Override
+		public String getKeyTemplate() {
+			return "[LOCATION]-[PLOTNO]-[SEASON]";
+		}
+	};
+
+	final KeyComponentValueResolver locationValueResolver = new KeyComponentValueResolver() {
+
+		@Override
+		public String resolve() {
+			return "INDIA";
+		}
+
+		@Override
+		public boolean isOptional() {
+			return false;
+		}
+	};
+
+	final KeyComponentValueResolver plotNumberResolver = new KeyComponentValueResolver() {
+
+		@Override
+		public String resolve() {
+			return "123";
+		}
+
+		@Override
+		public boolean isOptional() {
+			return false;
+		}
+	};
+
+	final KeyComponentValueResolver seasonResolver = new KeyComponentValueResolver() {
+
+		@Override
+		public String resolve() {
+			return "DrySeason";
+		}
+
+		@Override
+		public boolean isOptional() {
+			return false;
+		}
+	};
+
+	final KeyComponentValueResolver optionalSelectionNumberWithValueResolver = new KeyComponentValueResolver() {
+
+		@Override
+		public String resolve() {
+			return "Plant1";
+		}
+
+		@Override
+		public boolean isOptional() {
+			return true;
+		}
+	};
+
+	final KeyComponentValueResolver optionalSelectionNumberWithoutValueResolver = new KeyComponentValueResolver() {
+
+		@Override
+		public String resolve() {
+			return null;
+		}
+
+		@Override
+		public boolean isOptional() {
+			return true;
+		}
+	};
+
+	@Test
+	public void testGenerateKeyAllRequiredComponents() {
+
+		KeyCodeGenerationService service = new KeyCodeGenerationServiceImpl();
+
+		Map<KeyComponent, KeyComponentValueResolver> keyComponentValueResolvers = new HashMap<>();
+		keyComponentValueResolvers.put(KeyComponent.LOCATION, this.locationValueResolver);
+		keyComponentValueResolvers.put(KeyComponent.PLOTNO, this.plotNumberResolver);
+		keyComponentValueResolvers.put(KeyComponent.SEASON, this.seasonResolver);
+
+		String keyCode = service.generateKey(this.allRequiredComponentTemplateProvider, keyComponentValueResolvers);
+
+		Assert.assertEquals("INDIA-123-DrySeason", keyCode);
+	}
+
+	@Test
+	public void testGenerateKeyOneOptionalComponentWithValue() {
+
+		KeyCodeGenerationService service = new KeyCodeGenerationServiceImpl();
+
+		Map<KeyComponent, KeyComponentValueResolver> keyComponentValueResolvers = new HashMap<>();
+		keyComponentValueResolvers.put(KeyComponent.LOCATION, this.locationValueResolver);
+		keyComponentValueResolvers.put(KeyComponent.PLOTNO, this.plotNumberResolver);
+		keyComponentValueResolvers.put(KeyComponent.SELECTION_NUMBER, this.optionalSelectionNumberWithValueResolver);
+
+		String keyCode = service.generateKey(this.oneOptionalComponentTemplateProvider, keyComponentValueResolvers);
+
+		Assert.assertEquals("INDIA-123-Plant1", keyCode);
+	}
+
+	@Test
+	public void testGenerateKeyOneOptionalComponentWithoutValue() {
+
+		KeyCodeGenerationService service = new KeyCodeGenerationServiceImpl();
+
+		Map<KeyComponent, KeyComponentValueResolver> keyComponentValueResolvers = new HashMap<>();
+		keyComponentValueResolvers.put(KeyComponent.LOCATION, this.locationValueResolver);
+		keyComponentValueResolvers.put(KeyComponent.PLOTNO, this.plotNumberResolver);
+		keyComponentValueResolvers.put(KeyComponent.SELECTION_NUMBER, this.optionalSelectionNumberWithoutValueResolver);
+
+		String keyCode = service.generateKey(this.oneOptionalComponentTemplateProvider, keyComponentValueResolvers);
+
+		Assert.assertEquals("INDIA-123", keyCode);
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/generator/SeedSourceGeneratorTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/generator/SeedSourceGeneratorTest.java
@@ -1,0 +1,282 @@
+
+package org.generationcp.middleware.ruleengine.generator;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.generationcp.middleware.ContextHolder;
+import org.generationcp.middleware.data.initializer.MeasurementVariableTestDataInitializer;
+import org.generationcp.middleware.domain.etl.MeasurementData;
+import org.generationcp.middleware.domain.etl.MeasurementRow;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.etl.StudyDetails;
+import org.generationcp.middleware.domain.etl.Workbook;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.domain.oms.TermSummary;
+import org.generationcp.middleware.domain.ontology.Scale;
+import org.generationcp.middleware.domain.ontology.Variable;
+import org.generationcp.middleware.domain.study.StudyTypeDto;
+import org.generationcp.middleware.manager.Season;
+import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
+import org.generationcp.middleware.pojos.Name;
+import org.generationcp.middleware.ruleengine.pojo.ImportedCross;
+import org.generationcp.middleware.ruleengine.pojo.ImportedGermplasmParent;
+import org.generationcp.middleware.ruleengine.service.GermplasmNamingProperties;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitRow;
+import org.generationcp.middleware.service.api.dataset.ObservationUnitUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * This is more of an integration test (not a pure unit test) of all key code generation pieces for the seed source use case.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SeedSourceGeneratorTest {
+
+	private static final String PROGRAM_UUID = UUID.randomUUID().toString();
+
+	@Mock
+	private OntologyVariableDataManager ontologyVariableDataManager;
+
+	@InjectMocks
+	private SeedSourceGenerator seedSourceGenerator;
+
+	@Before
+	public void setUp() {
+
+		final GermplasmNamingProperties germplasmNamingProperties = new GermplasmNamingProperties();
+		germplasmNamingProperties.setGermplasmOriginStudiesMaize("[LOCATION][SEASON]-[NAME]-[PLOTNO][SELECTION_NUMBER]");
+		germplasmNamingProperties.setGermplasmOriginStudiesWheat("[LOCATION]\\[SEASON]\\[NAME]\\[PLOTNO]");
+		germplasmNamingProperties.setGermplasmOriginStudiesDefault("[NAME]:[LOCATION]:[SEASON]:[PLOTNO]:[PLANT_NO]");
+
+		seedSourceGenerator.setGermplasmNamingProperties(germplasmNamingProperties);
+
+	}
+
+	private void setCurrentCrop(final String crop) {
+		ContextHolder.setCurrentCrop(crop);
+		ContextHolder.setCurrentProgram(PROGRAM_UUID);
+
+		final Variable seasonVariable = new Variable();
+		final Scale seasonScale = new Scale();
+		final TermSummary seasonCategory = new TermSummary(TermId.SEASON_DRY.getId(), Season.DRY.getDefinition(), Season.DRY.getDefinition());
+		seasonScale.addCategory(seasonCategory);
+		seasonVariable.setScale(seasonScale);
+		Mockito.when(this.ontologyVariableDataManager.getVariable(ArgumentMatchers.eq(PROGRAM_UUID),
+			ArgumentMatchers.eq(TermId.SEASON_VAR.getId()), ArgumentMatchers.eq(true))).thenReturn(seasonVariable);
+	}
+
+	@Test
+	public void testGenerateSeedSourceStudy() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyName("TestStudy");
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		final int studyId = 1;
+		studyDetails.setId(studyId);
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1LocationAbbrMV = new MeasurementVariable();
+		instance1LocationAbbrMV.setTermId(TermId.LOCATION_ABBR.getId());
+		instance1LocationAbbrMV.setName(TermId.LOCATION_ABBR.name());
+		final MeasurementData instance1LocationAbbrMD = new MeasurementData();
+		instance1LocationAbbrMD.setValue("IND");
+		instance1LocationAbbrMD.setMeasurementVariable(instance1LocationAbbrMV);
+
+		final MeasurementVariable instance1SeasonMV = new MeasurementVariable();
+		instance1SeasonMV.setTermId(TermId.SEASON_VAR.getId());
+		instance1SeasonMV.setName(TermId.SEASON_VAR.name());
+		final MeasurementData instance1SeasonMD = new MeasurementData();
+		instance1SeasonMD.setValue(Season.DRY.getDefinition());
+		instance1SeasonMD.setMeasurementVariable(instance1SeasonMV);
+
+		final MeasurementVariable instance1InstanceNumberMV = new MeasurementVariable();
+		instance1InstanceNumberMV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		instance1InstanceNumberMV.setName(TermId.TRIAL_INSTANCE_FACTOR.name());
+		final MeasurementData instance1InstanceNumberMD = new MeasurementData();
+		instance1InstanceNumberMD.setValue("1");
+		instance1InstanceNumberMD.setMeasurementVariable(instance1InstanceNumberMV);
+
+		final MeasurementRow instance1Measurements = new MeasurementRow();
+		instance1Measurements.setDataList(Lists.newArrayList(instance1InstanceNumberMD, instance1LocationAbbrMD, instance1SeasonMD));
+
+		workbook.setTrialObservations(Lists.newArrayList(instance1Measurements));
+
+		setCurrentCrop("rice");
+		String seedSource = this.seedSourceGenerator
+			.generateSeedSource(ObservationUnitUtils.fromMeasurementRow(workbook.getTrialObservationByTrialInstanceNo(1)), null, "2", "3",
+				studyDetails.getStudyName(), null, null, null, instance1Measurements.getMeasurementVariables());
+		Assert.assertEquals("TestStudy:IND:Dry season:3:", seedSource);
+
+		// with Plant Number
+		seedSource = this.seedSourceGenerator.generateSeedSource(ObservationUnitUtils.fromMeasurementRow(workbook.getTrialObservationByTrialInstanceNo(1)), null, "2", "3",
+			studyDetails.getStudyName(), "4", null, null, instance1Measurements.getMeasurementVariables());
+		Assert.assertEquals("TestStudy:IND:Dry season:3:4", seedSource);
+
+		setCurrentCrop("wheat");
+		seedSource = this.seedSourceGenerator.generateSeedSource(ObservationUnitUtils.fromMeasurementRow(workbook.getTrialObservationByTrialInstanceNo(1)), null, "2", "3",
+			studyDetails.getStudyName(), null, null, null, instance1Measurements.getMeasurementVariables());
+		Assert.assertEquals("IND\\Dry season\\TestStudy\\3", seedSource);
+
+		setCurrentCrop("maize");
+		// with selection number
+		seedSource = this.seedSourceGenerator.generateSeedSource(ObservationUnitUtils.fromMeasurementRow(workbook.getTrialObservationByTrialInstanceNo(1)), null, "2", "3",
+			studyDetails.getStudyName(), null, null, null, instance1Measurements.getMeasurementVariables());
+		Assert.assertEquals("INDDry season-TestStudy-3-2", seedSource);
+		// without selection number
+		seedSource = this.seedSourceGenerator.generateSeedSource(ObservationUnitUtils.fromMeasurementRow(workbook.getTrialObservationByTrialInstanceNo(1)), null, null, "3",
+			studyDetails.getStudyName(), null, null, null, instance1Measurements.getMeasurementVariables());
+		Assert.assertEquals("INDDry season-TestStudy-3", seedSource);
+	}
+	
+	@Test
+	public void testGenerateSeedSourceForUnknownPlot() {
+		Assert.assertEquals(Name.UNKNOWN, this.seedSourceGenerator.generateSeedSource(new ObservationUnitRow(),
+			null, RandomStringUtils.randomNumeric(2), "0", RandomStringUtils.randomAlphabetic(20), RandomStringUtils.randomNumeric(2), null,
+			null, null));
+	}
+
+	@Test
+	public void testGenerateSeedSourceForCross() {
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyName("StudyName");
+		studyDetails.setStudyType(StudyTypeDto.getNurseryDto());
+		studyDetails.setId(1);
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable locationMV = MeasurementVariableTestDataInitializer.createMeasurementVariable(TermId.LOCATION_ABBR.getId(), "IND");
+		final MeasurementVariable seasonMV = MeasurementVariableTestDataInitializer.createMeasurementVariable(TermId.SEASON_VAR.getId(), Season.DRY.getDefinition());
+		workbook.setConditions(Lists.newArrayList(locationMV, seasonMV));
+
+		setCurrentCrop("maize");
+		final List<String> malePlotNos = Arrays.asList("1", "3", "4");
+		String generatedSeedSources =
+			this.seedSourceGenerator.generateSeedSourceForCross(
+				Pair.of(ObservationUnitUtils.fromMeasurementRow(workbook.getTrialObservationByTrialInstanceNo(1)), ObservationUnitUtils.fromMeasurementRow(workbook.getTrialObservationByTrialInstanceNo(1))), Pair.of(workbook.getConditions(), workbook.getConditions()),
+				Pair.of(Collections.emptyMap(), Collections.emptyMap()), Pair.of(Collections.emptyMap(), Collections.emptyMap()),
+				Pair.of(Collections.emptyList(), Collections.emptyList()), this.getCross(malePlotNos, "2", "StudyName", "StudyName"));
+		List<String> expectedResultsString = new ArrayList<>();
+		for(final String malePlotNo: malePlotNos) {
+			expectedResultsString.add("INDDry season-StudyName-" + malePlotNo);
+		}
+		String expectedString = "INDDry season-StudyName-2/[" + StringUtils.join(expectedResultsString, ", ") + "]";
+		Assert.assertEquals(expectedString, generatedSeedSources);
+
+		setCurrentCrop("rice");
+		generatedSeedSources =
+			this.seedSourceGenerator.generateSeedSourceForCross(
+				Pair.of(ObservationUnitUtils.fromMeasurementRow(workbook.getTrialObservationByTrialInstanceNo(1)), ObservationUnitUtils.fromMeasurementRow(workbook.getTrialObservationByTrialInstanceNo(1))), Pair.of(workbook.getConditions(), workbook.getConditions()),
+				Pair.of(Collections.emptyMap(), Collections.emptyMap()), Pair.of(Collections.emptyMap(), Collections.emptyMap()),
+				Pair.of(Collections.emptyList(), Collections.emptyList()), this.getCross(malePlotNos, "2", "StudyName", "StudyName"));
+		expectedResultsString = new ArrayList<>();
+		for(final String malePlotNo: malePlotNos) {
+			expectedResultsString.add("StudyName:IND:Dry season:"+malePlotNo+":");
+		}
+		expectedString = "StudyName:IND:Dry season:2:/[" + StringUtils.join(expectedResultsString, ", ") + "]";
+		Assert.assertEquals(expectedString, generatedSeedSources);
+
+		//For scenario where there's only one male plot number
+		generatedSeedSources =
+			this.seedSourceGenerator.generateSeedSourceForCross(
+				Pair.of(ObservationUnitUtils.fromMeasurementRow(workbook.getTrialObservationByTrialInstanceNo(1)), ObservationUnitUtils.fromMeasurementRow(workbook.getTrialObservationByTrialInstanceNo(1))), Pair.of(workbook.getConditions(), workbook.getConditions()),
+				Pair.of(Collections.emptyMap(), Collections.emptyMap()), Pair.of(Collections.emptyMap(), Collections.emptyMap()),
+				Pair.of(Collections.emptyList(), Collections.emptyList()), this.getCross(Collections.singletonList("1"), "2", "StudyName", "StudyName"));
+		Assert.assertEquals("StudyName:IND:Dry season:2:/StudyName:IND:Dry season:1:", generatedSeedSources);
+	}
+
+	@Test
+	public void testGenerateSeedSourceForCrossWhereMaleAndFemaleStudyAreDifferent() {
+		final Workbook femaleStudyWorkbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyName("femaleStudyName");
+		studyDetails.setStudyType(StudyTypeDto.getNurseryDto());
+		studyDetails.setId(1);
+		femaleStudyWorkbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable locationMV = MeasurementVariableTestDataInitializer.createMeasurementVariable(TermId.LOCATION_ABBR.getId(), "IND");
+		final MeasurementVariable seasonMV = MeasurementVariableTestDataInitializer.createMeasurementVariable(TermId.SEASON_VAR.getId(), Season.DRY.getDefinition());
+		femaleStudyWorkbook.setConditions(Lists.newArrayList(locationMV, seasonMV));
+
+		final Workbook maleStudyWorkbook = new Workbook();
+		final StudyDetails maleStudyDetails = new StudyDetails();
+		maleStudyDetails.setStudyName("maleStudyName");
+		maleStudyDetails.setStudyType(StudyTypeDto.getNurseryDto());
+		maleStudyDetails.setId(1);
+		maleStudyWorkbook.setStudyDetails(maleStudyDetails);
+
+		final MeasurementVariable malelocationMV = MeasurementVariableTestDataInitializer.createMeasurementVariable(TermId.LOCATION_ABBR.getId(), "CIMMYT");
+		final MeasurementVariable maleSeasonMv = MeasurementVariableTestDataInitializer.createMeasurementVariable(TermId.SEASON_VAR.getId(), Season.WET.getDefinition());
+		maleStudyWorkbook.setConditions(Lists.newArrayList(malelocationMV, maleSeasonMv));
+
+		setCurrentCrop("maize");
+		final List<String> malePlotNos = Arrays.asList("1", "3", "4");
+		String generatedSeedSources =
+			this.seedSourceGenerator.generateSeedSourceForCross(
+				Pair.of(ObservationUnitUtils.fromMeasurementRow(femaleStudyWorkbook.getTrialObservationByTrialInstanceNo(1)), ObservationUnitUtils.fromMeasurementRow(maleStudyWorkbook.getTrialObservationByTrialInstanceNo(1))), Pair.of(femaleStudyWorkbook.getConditions(), maleStudyWorkbook.getConditions()),
+				Pair.of(Collections.emptyMap(), Collections.emptyMap()), Pair.of(Collections.emptyMap(), Collections.emptyMap()),
+				Pair.of(Collections.emptyList(), Collections.emptyList()),
+				this.getCross(malePlotNos, "2", "maleStudyName", "femaleStudyName"));
+		List<String> expectedResultsString = new ArrayList<>();
+		for(final String malePlotNo: malePlotNos) {
+			expectedResultsString.add("CIMMYTWet season-maleStudyName-"+malePlotNo);
+		}
+		String expectedString = "INDDry season-femaleStudyName-2/[" + StringUtils.join(expectedResultsString, ", ") + "]";
+		Assert.assertEquals(expectedString, generatedSeedSources);
+
+		setCurrentCrop("rice");
+		generatedSeedSources =
+			this.seedSourceGenerator.generateSeedSourceForCross(
+				Pair.of(ObservationUnitUtils.fromMeasurementRow(femaleStudyWorkbook.getTrialObservationByTrialInstanceNo(1)), ObservationUnitUtils.fromMeasurementRow(maleStudyWorkbook.getTrialObservationByTrialInstanceNo(1))), Pair.of(femaleStudyWorkbook.getConditions(), maleStudyWorkbook.getConditions()),
+				Pair.of(Collections.emptyMap(), Collections.emptyMap()), Pair.of(Collections.emptyMap(), Collections.emptyMap()),
+				Pair.of(Collections.emptyList(), Collections.emptyList()),
+				this.getCross(malePlotNos, "2", "maleStudyName", "femaleStudyName"));
+		expectedResultsString = new ArrayList<>();
+		for(final String malePlotNo: malePlotNos) {
+			expectedResultsString.add("maleStudyName:CIMMYT:Wet season:"+malePlotNo+":");
+		}
+		expectedString = "femaleStudyName:IND:Dry season:2:/[" + StringUtils.join(expectedResultsString, ", ") + "]";
+		Assert.assertEquals(expectedString, generatedSeedSources);
+
+		//For scenario where there's only one male plot number
+		generatedSeedSources =
+			this.seedSourceGenerator.generateSeedSourceForCross(
+				Pair.of(ObservationUnitUtils.fromMeasurementRow(femaleStudyWorkbook.getTrialObservationByTrialInstanceNo(1)), ObservationUnitUtils.fromMeasurementRow(maleStudyWorkbook.getTrialObservationByTrialInstanceNo(1))), Pair.of(femaleStudyWorkbook.getConditions(), maleStudyWorkbook.getConditions()),
+				Pair.of(Collections.emptyMap(), Collections.emptyMap()), Pair.of(Collections.emptyMap(), Collections.emptyMap()),
+				Pair.of(Collections.emptyList(), Collections.emptyList()),
+				this.getCross(Collections.singletonList("1"), "2", "maleStudyName", "femaleStudyName"));
+		Assert.assertEquals("femaleStudyName:IND:Dry season:2:/maleStudyName:CIMMYT:Wet season:1:", generatedSeedSources);
+	}
+
+	private ImportedCross getCross(final List<String> malePlotNos, final String femalePlotNo, final String maleStudyName, final String femaleStudyName) {
+		final ImportedCross crossInfo = new ImportedCross();
+		crossInfo.setFemaleParent(
+			new ImportedGermplasmParent(null, null, StringUtils.isEmpty(femalePlotNo) ? null : Integer.valueOf(femalePlotNo),
+				femaleStudyName));
+
+		final List<ImportedGermplasmParent> crossMaleParents = new ArrayList<>();
+		for (final String malePlotNo : malePlotNos) {
+			crossMaleParents.add(
+				new ImportedGermplasmParent(null, null, StringUtils.isEmpty(malePlotNo) ? null : Integer.valueOf(malePlotNo),
+					maleStudyName));
+		}
+		crossInfo.setMaleParents(crossMaleParents);
+		return crossInfo;
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/generator/SeedSourceTemplateProviderTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/generator/SeedSourceTemplateProviderTest.java
@@ -1,0 +1,41 @@
+package org.generationcp.middleware.ruleengine.generator;
+
+import org.generationcp.middleware.ruleengine.service.GermplasmNamingProperties;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SeedSourceTemplateProviderTest {
+
+	@Test
+	public void testGetKeyTemplate() {
+
+		final GermplasmNamingProperties germplasmNamingProperties = new GermplasmNamingProperties();
+		germplasmNamingProperties.setGermplasmOriginStudiesDefault("[NAME]:[PLOTNO]");
+		germplasmNamingProperties.setGermplasmOriginStudiesMaize("[LOCATION][SEASON]-[NAME]-[PLOTNO][SELECTION_NUMBER]");
+		germplasmNamingProperties.setGermplasmOriginStudiesWheat("[LOCATION]\\[SEASON]\\[NAME]\\[PLOTNO]");
+
+		germplasmNamingProperties.setGermplasmOriginStudiesDefault("[NAME]:[LOCATION]:[SEASON]:[PLOTNO]");
+		germplasmNamingProperties.setGermplasmOriginStudiesMaize("[LOCATION]\\[SEASON]\\[NAME]\\[PLOTNO]");
+		germplasmNamingProperties.setGermplasmOriginStudiesWheat("[LOCATION][SEASON]-[NAME]-[PLOTNO]");
+
+		// Studies
+		Assert.assertEquals(germplasmNamingProperties.getGermplasmOriginStudiesDefault(),
+				new SeedSourceTemplateProvider(germplasmNamingProperties, "rice").getKeyTemplate());
+
+		Assert.assertEquals(germplasmNamingProperties.getGermplasmOriginStudiesMaize(),
+				new SeedSourceTemplateProvider(germplasmNamingProperties, "maize").getKeyTemplate());
+
+		Assert.assertEquals(germplasmNamingProperties.getGermplasmOriginStudiesWheat(),
+				new SeedSourceTemplateProvider(germplasmNamingProperties, "wheat").getKeyTemplate());
+
+		// Studies
+		Assert.assertEquals(germplasmNamingProperties.getGermplasmOriginStudiesDefault(),
+				new SeedSourceTemplateProvider(germplasmNamingProperties, "rice").getKeyTemplate());
+
+		Assert.assertEquals(germplasmNamingProperties.getGermplasmOriginStudiesMaize(),
+				new SeedSourceTemplateProvider(germplasmNamingProperties, "maize").getKeyTemplate());
+
+		Assert.assertEquals(germplasmNamingProperties.getGermplasmOriginStudiesWheat(),
+				new SeedSourceTemplateProvider(germplasmNamingProperties, "wheat").getKeyTemplate());
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeFemaleParentExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeFemaleParentExpressionTest.java
@@ -1,0 +1,208 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.pojos.Germplasm;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.ruleengine.pojo.ImportedGermplasm;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AttributeFemaleParentExpressionTest extends TestExpression {
+
+	@Mock
+	private GermplasmDataManager germplasmDataManager;
+
+	@InjectMocks
+	AttributeFemaleParentExpression expression = new AttributeFemaleParentExpression();
+
+	private static final Integer VARIABLE_ID = 2000;
+
+	private static final String PREFIX = "[ATTRFP.2000]";
+
+	private static final String COUNT = "[SEQUENCE]";
+
+	@Test
+	public void testAttributeAsPrefixDerivativeMethod() throws Exception {
+
+		final Germplasm groupSource = new Germplasm();
+		final int femaleParentGidOfGroupSource = 103;
+		groupSource.setGpid1(femaleParentGidOfGroupSource);
+
+		Mockito.when(germplasmDataManager.getAttributeValue(femaleParentGidOfGroupSource, VARIABLE_ID)).thenReturn("Mexico");
+		Mockito.when(germplasmDataManager.getGermplasmByGID(104)).thenReturn(groupSource);
+
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 104, 105, -1, derivativeMethod.getMid());
+		final AdvancingSource source =
+				this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-Mexico[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixWithoutAttributeValueDerivativeMethod() throws Exception {
+
+		final Germplasm groupSource = new Germplasm();
+		final int femaleParentGidOfGroupSource = 103;
+		groupSource.setGpid1(femaleParentGidOfGroupSource);
+
+		Mockito.when(germplasmDataManager.getAttributeValue(femaleParentGidOfGroupSource, VARIABLE_ID)).thenReturn("");
+		Mockito.when(germplasmDataManager.getGermplasmByGID(104)).thenReturn(groupSource);
+
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 104, 105, -1, derivativeMethod.getMid());
+		final AdvancingSource source =
+				this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixGpid1IsUnknownDerivativeMethod() throws Exception {
+
+		Mockito.when(germplasmDataManager.getAttributeValue(null, VARIABLE_ID)).thenReturn("");
+		Mockito.when(germplasmDataManager.getGermplasmByGID(0)).thenReturn(null);
+
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm = this.createImportedGermplasm(1, "(AA/ABC)", "0", 0, 0, -1, derivativeMethod.getMid());
+		AdvancingSource source = this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixFemaleParentOfGroupSourceIsUnknownDerivativeMethod() throws Exception {
+
+		final Germplasm groupSource = new Germplasm();
+		final int femaleParentGidOfGroupSource = 0;
+		groupSource.setGpid1(femaleParentGidOfGroupSource);
+
+		Mockito.when(germplasmDataManager.getAttributeValue(null, VARIABLE_ID)).thenReturn("");
+
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm = this.createImportedGermplasm(1, "(AA/ABC)", "0", 0, 0, -1, derivativeMethod.getMid());
+		AdvancingSource source = this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixDerivativeMethodWithUnknownSourceGpid1andGpid2() throws Exception {
+
+		final Germplasm groupSource = new Germplasm();
+		groupSource.setGpid1(0);
+		groupSource.setGpid2(0);
+
+		Mockito.when(germplasmDataManager.getAttributeValue(groupSource.getGpid1(), VARIABLE_ID)).thenReturn("");
+		Mockito.when(germplasmDataManager.getGermplasmByGID(1000)).thenReturn(groupSource);
+
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 0, 0, -1, derivativeMethod.getMid());
+		AdvancingSource source = this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixDerivativeMethodWithSourceGermplasmIsGenerative() throws Exception {
+
+		final Germplasm groupSource = new Germplasm();
+		groupSource.setGpid1(1002);
+		groupSource.setGpid2(1003);
+
+		Mockito.when(germplasmDataManager.getAttributeValue(groupSource.getGpid1(), VARIABLE_ID)).thenReturn("Mexico");
+		Mockito.when(germplasmDataManager.getGermplasmByGID(1000)).thenReturn(groupSource);
+
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 0, 0, -1, derivativeMethod.getMid());
+		AdvancingSource source = this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		source.setSourceMethod(this.createGenerativeMethod(PREFIX, COUNT, null, "-", true));
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-Mexico[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixGenerativeMethod() throws Exception {
+
+		Mockito.when(germplasmDataManager.getAttributeValue(104, VARIABLE_ID)).thenReturn("Mexico");
+
+		final Method generativeMethod = this.createGenerativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 104, 105, -1, generativeMethod.getMid());
+		final AdvancingSource source =
+				this.createAdvancingSourceTestData(generativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+
+		source.setFemaleGid(104);
+
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-Mexico[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixWithoutAttributeValueGenerativeMethod() throws Exception {
+		Mockito.when(germplasmDataManager.getAttributeValue(104, VARIABLE_ID)).thenReturn("");
+		final Method generativeMethod = this.createGenerativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 104, 105, -1, generativeMethod.getMid());
+		final AdvancingSource source =
+				this.createAdvancingSourceTestData(generativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+
+		source.setFemaleGid(104);
+
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixGpid1UnknownGenerativeMethod() throws Exception {
+
+		Mockito.when(germplasmDataManager.getAttributeValue(0, VARIABLE_ID)).thenReturn("");
+		final Method generativeMethod = this.createGenerativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 0, 0, -1, generativeMethod.getMid());
+		AdvancingSource source = this.createAdvancingSourceTestData(generativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeMaleParentExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeMaleParentExpressionTest.java
@@ -1,0 +1,211 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.pojos.Germplasm;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.ruleengine.pojo.ImportedGermplasm;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AttributeMaleParentExpressionTest extends TestExpression {
+
+	@Mock
+	private GermplasmDataManager germplasmDataManager;
+
+	@InjectMocks
+	AttributeMaleParentExpression expression = new AttributeMaleParentExpression();
+
+	private static final Integer VARIABLE_ID = 2000;
+
+	private static final String PREFIX = "[ATTRMP.2000]";
+
+	private static final String COUNT = "[SEQUENCE]";
+
+	@Test
+	public void testAttributeAsPrefixDerivativeMethod() throws Exception {
+
+		final Germplasm groupSource = new Germplasm();
+		final int maleParentGidOfGroupSource = 103;
+		groupSource.setGpid2(maleParentGidOfGroupSource);
+
+		Mockito.when(germplasmDataManager.getAttributeValue(maleParentGidOfGroupSource, VARIABLE_ID)).thenReturn("Mexico");
+		Mockito.when(germplasmDataManager.getGermplasmByGID(104)).thenReturn(groupSource);
+
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 104, 105, -1, derivativeMethod.getMid());
+		final AdvancingSource source =
+				this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-Mexico[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixWithoutAttributeValueDerivativeMethod() throws Exception {
+
+		final Germplasm groupSource = new Germplasm();
+		final int maleParentGidOfGroupSource = 103;
+		groupSource.setGpid2(maleParentGidOfGroupSource);
+
+		Mockito.when(germplasmDataManager.getAttributeValue(maleParentGidOfGroupSource, VARIABLE_ID)).thenReturn("");
+		Mockito.when(germplasmDataManager.getGermplasmByGID(104)).thenReturn(groupSource);
+
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 104, 105, -1, derivativeMethod.getMid());
+		final AdvancingSource source =
+				this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixGpid2UnknownDerivativeMethod() throws Exception {
+
+		final Germplasm groupSource = new Germplasm();
+		final int maleParentGidOfGroupSource = 103;
+		groupSource.setGpid2(maleParentGidOfGroupSource);
+
+		Mockito.when(germplasmDataManager.getAttributeValue(null, VARIABLE_ID)).thenReturn("");
+		Mockito.when(germplasmDataManager.getGermplasmByGID(0)).thenReturn(null);
+
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm = this.createImportedGermplasm(1, "(AA/ABC)", "0", 0, 0, -1, derivativeMethod.getMid());
+		AdvancingSource source = this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixMaleParentOfGroupSourceIsUnknownDerivativeMethod() throws Exception {
+
+		final Germplasm groupSource = new Germplasm();
+		final int maleParentGidOfGroupSource = 0;
+		groupSource.setGpid2(maleParentGidOfGroupSource);
+
+		Mockito.when(germplasmDataManager.getAttributeValue(null, VARIABLE_ID)).thenReturn("");
+
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm = this.createImportedGermplasm(1, "(AA/ABC)", "0", 0, 0, -1, derivativeMethod.getMid());
+		AdvancingSource source = this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixDerivativeMethodWithUnknownSourceGpid1andGpid2() throws Exception {
+
+		final Germplasm groupSource = new Germplasm();
+		groupSource.setGpid1(0);
+		groupSource.setGpid2(0);
+
+		Mockito.when(germplasmDataManager.getAttributeValue(groupSource.getGpid2(), VARIABLE_ID)).thenReturn("");
+		Mockito.when(germplasmDataManager.getGermplasmByGID(1000)).thenReturn(groupSource);
+
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 0, 0, -1, derivativeMethod.getMid());
+		AdvancingSource source = this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixDerivativeMethodWithSourceGermplasmIsGenerative() throws Exception {
+
+		final Germplasm groupSource = new Germplasm();
+		groupSource.setGpid1(1002);
+		groupSource.setGpid2(1003);
+
+		Mockito.when(germplasmDataManager.getAttributeValue(groupSource.getGpid2(), VARIABLE_ID)).thenReturn("Mexico");
+		Mockito.when(germplasmDataManager.getGermplasmByGID(1000)).thenReturn(groupSource);
+
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 0, 0, -1, derivativeMethod.getMid());
+		AdvancingSource source = this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		source.setSourceMethod(this.createGenerativeMethod(PREFIX, COUNT, null, "-", true));
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-Mexico[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixGenerativeMethod() throws Exception {
+		Mockito.when(germplasmDataManager.getAttributeValue(105, VARIABLE_ID)).thenReturn("Mexico");
+		final Method generativeMethod = this.createGenerativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 104, 105, -1, generativeMethod.getMid());
+		final AdvancingSource source =
+				this.createAdvancingSourceTestData(generativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+
+		source.setMaleGid(105);
+
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-Mexico[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixWithoutAttributeValueGenerativeMethod() throws Exception {
+		Mockito.when(germplasmDataManager.getAttributeValue(105, VARIABLE_ID)).thenReturn("");
+		final Method generativeMethod = this.createGenerativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 104, 105, -1, generativeMethod.getMid());
+		final AdvancingSource source =
+				this.createAdvancingSourceTestData(generativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+
+		source.setMaleGid(105);
+
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixUnknownMaleParentGenerativeMethod() throws Exception {
+
+		Mockito.when(germplasmDataManager.getAttributeValue(0, VARIABLE_ID)).thenReturn("");
+		final Method generativeMethod = this.createGenerativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+				this.createImportedGermplasm(1, "(AA/ABC)", "1000", 0, 0, -1, generativeMethod.getMid());
+		AdvancingSource source = this.createAdvancingSourceTestData(generativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+
+		source.setMaleGid(0);
+
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeSourceExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/AttributeSourceExpressionTest.java
@@ -1,0 +1,105 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.ruleengine.pojo.ImportedGermplasm;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AttributeSourceExpressionTest extends TestExpression {
+
+	@Mock
+	private GermplasmDataManager germplasmDataManager;
+
+	@InjectMocks
+	AttributeSourceExpression expression = new AttributeSourceExpression();
+
+	private static final Integer VARIABLE_ID = 2000;
+
+	private static final String PREFIX = "[ATTRSC.2000]";
+
+	private static final String COUNT = "[SEQUENCE]";
+
+
+	@Test
+	public void testAttributeAsPrefix() throws Exception {
+		Mockito.when(germplasmDataManager.getAttributeValue(1000, VARIABLE_ID)).thenReturn("AA");
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+			this.createImportedGermplasm(1, "(AA/ABC)", "1000", 104, 104, -1, derivativeMethod.getMid());
+		final AdvancingSource source =
+			this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		final List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+		this.printResult(values, source);
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-AA[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixMultipleCopies() throws Exception {
+		Mockito.when(germplasmDataManager.getAttributeValue(1000, VARIABLE_ID)).thenReturn("AA");
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX + PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+			this.createImportedGermplasm(1, "(AA/ABC)", "1000", 104, 104, -1, derivativeMethod.getMid());
+		final AdvancingSource source =
+			this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		final List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+		this.printResult(values, source);
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-AAAA[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixWithOutAttributeValue() throws Exception {
+		Mockito.when(germplasmDataManager.getAttributeValue(1000, VARIABLE_ID)).thenReturn("");
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+			this.createImportedGermplasm(1, "(AA/ABC)", "1000", 104, 104, -1, derivativeMethod.getMid());
+		final AdvancingSource source =
+			this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		final List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+		this.printResult(values, source);
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixGpid2Unknown() throws Exception {
+
+		Mockito.when(germplasmDataManager.getAttributeValue(1000, VARIABLE_ID)).thenReturn("AA");
+		final Method derivativeMethod = this.createDerivativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+			this.createImportedGermplasm(1, "(AA/ABC)", "1000", 0, 0, -1, derivativeMethod.getMid());
+		AdvancingSource source = this.createAdvancingSourceTestData(derivativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+		this.printResult(values, source);
+		assertThat(values.get(0).toString(), is(equalTo("(AA/ABC)-AA[SEQUENCE]")));
+	}
+
+	@Test
+	public void testAttributeAsPrefixInvalidBreedingMethod() throws Exception {
+
+		final Method generativeMethod = this.createGenerativeMethod(PREFIX, COUNT, null, "-", true);
+		final ImportedGermplasm importedGermplasm =
+			this.createImportedGermplasm(1, "(AA/ABC)", "1000", 104, 104, -1, generativeMethod.getMid());
+		AdvancingSource source =
+			this.createAdvancingSourceTestData(generativeMethod, importedGermplasm, "(AA/ABC)", "Dry", "NurseryTest");
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, PREFIX);
+		this.printResult(values, source);
+		assertThat(values.get(0).toString(),is(equalTo("(AA/ABC)-[SEQUENCE]")));
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/BackcrossExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/BackcrossExpressionTest.java
@@ -1,0 +1,105 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import junit.framework.Assert;
+import org.generationcp.middleware.manager.PedigreeDataManagerImpl;
+import org.generationcp.middleware.manager.api.PedigreeDataManager;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BackcrossExpressionTest extends TestExpression {
+
+	@Mock
+	private PedigreeDataManager pedigreeDataManager;
+
+	@InjectMocks
+	private BackcrossExpression expression = new BackcrossExpression();
+
+	@Test
+	public void testResolveBackcrossParentFemale() {
+
+		int maleParentGid = 1;
+		int femaleParentGid = 2;
+
+		Mockito.when(pedigreeDataManager.calculateRecurrentParent(maleParentGid, femaleParentGid))
+				.thenReturn(PedigreeDataManagerImpl.FEMALE_RECURRENT);
+
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", "-", null, "[BC]", null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		source.setFemaleGid(femaleParentGid);
+		source.setMaleGid(maleParentGid);
+
+		expression.apply(values, source, null);
+
+		Assert.assertEquals("GERMPLASM_TEST-F", values.get(0).toString());
+
+	}
+
+	@Test
+	public void testResolveBackcrossParentMale() {
+
+		int maleParentGid = 1;
+		int femaleParentGid = 2;
+
+		Mockito.when(pedigreeDataManager.calculateRecurrentParent(maleParentGid, femaleParentGid))
+				.thenReturn(PedigreeDataManagerImpl.MALE_RECURRENT);
+
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", "-", null, "[BC]", null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		source.setFemaleGid(femaleParentGid);
+		source.setMaleGid(maleParentGid);
+
+		expression.apply(values, source, null);
+
+		Assert.assertEquals("GERMPLASM_TEST-M", values.get(0).toString());
+
+	}
+
+	@Test
+	public void testResolveBackcrossParentMaleWithLiteralStringBeforeAndAfterTheProcessCode() {
+
+		int maleParentGid = 1;
+		int femaleParentGid = 2;
+
+		Mockito.when(pedigreeDataManager.calculateRecurrentParent(maleParentGid, femaleParentGid))
+				.thenReturn(PedigreeDataManagerImpl.MALE_RECURRENT);
+
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", "-", null, "AA[BC]CC", null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		source.setFemaleGid(femaleParentGid);
+		source.setMaleGid(maleParentGid);
+
+		expression.apply(values, source, null);
+
+		Assert.assertEquals("GERMPLASM_TEST-AAMCC", values.get(0).toString());
+
+	}
+
+	@Test
+	public void testResolveBackcrossParentWithNoRecurringParent() {
+
+		int maleParentGid = 1;
+		int femaleParentGid = 2;
+
+		Mockito.when(pedigreeDataManager.calculateRecurrentParent(maleParentGid, femaleParentGid)).thenReturn(PedigreeDataManagerImpl.NONE);
+
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", "-", null, "[BC]", null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		source.setFemaleGid(femaleParentGid);
+		source.setMaleGid(maleParentGid);
+
+		expression.apply(values, source, null);
+
+		Assert.assertEquals("GERMPLASM_TEST-", values.get(0).toString());
+
+	}
+
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/BaseExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/BaseExpressionTest.java
@@ -1,0 +1,27 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import junit.framework.Assert;
+import org.junit.Test;
+
+public class BaseExpressionTest {
+    private BaseExpression unitUnderTest = new FirstExpression();
+
+    @Test
+    public void testReplaceProcessCodeWithValue() {
+        StringBuilder builder = new StringBuilder("ABC" + unitUnderTest.getExpressionKey());
+
+        unitUnderTest.replaceExpressionWithValue(builder, "D");
+
+        Assert.assertEquals("BaseExpression unable to replace the process code with the new value", "ABCD", builder.toString());
+    }
+
+    @Test
+    public void testReplaceProcessCodeWithNullVariable() {
+        StringBuilder builder = new StringBuilder("ABC" + unitUnderTest.getExpressionKey());
+
+        String nullVariable = null;
+        unitUnderTest.replaceExpressionWithValue(builder, nullVariable);
+
+        Assert.assertEquals("BaseExpression unable to replace the process code with the new value", "ABC", builder.toString());
+    }
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/BracketsExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/BracketsExpressionTest.java
@@ -1,0 +1,44 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.manager.GermplasmNameType;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BracketsExpressionTest extends TestExpression {
+
+	BracketsExpression dut = new BracketsExpression();
+
+	@Test
+	public void testBracketsNonCross() {
+		String testRootName = "CMLI452";
+		AdvancingSource source = this.createAdvancingSourceTestData(testRootName, "-", null, null, null, false);
+		source.setRootName(testRootName);
+		List<StringBuilder> builders = new ArrayList<>();
+		builders.add(new StringBuilder(source.getRootName() + BracketsExpression.KEY));
+
+		this.dut.apply(builders, source, null);
+
+		Assert.assertEquals(testRootName, builders.get(0).toString());
+	}
+
+	@Test
+	public void testBracketsCross() {
+		String testRootName = "CMLI452 X POSI105";
+		AdvancingSource source = this.createAdvancingSourceTestData(testRootName, "-", null, null, null, false);
+		source.setRootName(testRootName);
+		source.setRootNameType(GermplasmNameType.CROSS_NAME.getUserDefinedFieldID());
+
+		List<StringBuilder> builders = new ArrayList<>();
+		builders.add(new StringBuilder(source.getRootName() + BracketsExpression.KEY));
+
+		this.dut.apply(builders, source, null);
+
+		Assert.assertEquals("(" + testRootName + ")", builders.get(0).toString());
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/BulkCountExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/BulkCountExpressionTest.java
@@ -1,0 +1,65 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Test;
+
+import java.util.List;
+
+public class BulkCountExpressionTest extends TestExpression {
+
+	@Test
+	public void testNonBulkingSource() throws Exception {
+		BulkCountExpression expression = new BulkCountExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", "[BCOUNT]", null, null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testBulkSourceAt1() throws Exception {
+		BulkCountExpression expression = new BulkCountExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST-B", "[BCOUNT]", null, null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testBulkSourceAt2() throws Exception {
+		BulkCountExpression expression = new BulkCountExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST-2B", "[BCOUNT]", null, null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testBulkSourceAtInvalidNumber() throws Exception {
+		BulkCountExpression expression = new BulkCountExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST-11a22B", "[BCOUNT]", null, null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testBulkSourceAtMultipleAdvanced() throws Exception {
+		BulkCountExpression expression = new BulkCountExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST-B-4B-3B", "[BCOUNT]", null, null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testCaseSensitive() throws Exception {
+		BulkCountExpression expression = new BulkCountExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST-B-4B-3B", "[bcount]", null, null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		System.out.println("process code in lower case");
+		this.printResult(values, source);
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/ChangeLocationExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/ChangeLocationExpressionTest.java
@@ -1,0 +1,82 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.exceptions.MiddlewareException;
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.pojos.Germplasm;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.ruleengine.pojo.ImportedGermplasm;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by Daniel Villafuerte on 6/16/2015.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ChangeLocationExpressionTest {
+
+    public static final int ORIGINAL_LOCATION_ID = 2;
+    public static final int TEST_GID = 3;
+    public static final String NEW_LOCATION_ABBR = "ABC";
+
+    @Mock
+    private GermplasmDataManager germplasmDataManager;
+
+    @InjectMocks
+    private ChangeLocationExpression dut;
+
+    @Test
+    public void testChangeLocationExpressionNoChange() throws MiddlewareException {
+        Germplasm germplasm = mock(Germplasm.class);
+        when(germplasmDataManager.getGermplasmByGID(anyInt())).thenReturn(germplasm);
+
+        when(germplasm.getLocationId()).thenReturn(ORIGINAL_LOCATION_ID);
+        List<StringBuilder> input = constructExpressionInput();
+
+        AdvancingSource source = new AdvancingSource();
+        source.setHarvestLocationId(ORIGINAL_LOCATION_ID);
+        ImportedGermplasm importedGermplasm = mock(ImportedGermplasm.class);
+        when(importedGermplasm.getGid()).thenReturn(Integer.toString(TEST_GID));
+        source.setGermplasm(importedGermplasm);
+
+        dut.apply(input, source, null);
+        assertEquals("", input.get(0).toString());
+    }
+
+    @Test
+    public void testChangeLocationExpressionChanged() throws MiddlewareException {
+        Germplasm germplasm = mock(Germplasm.class);
+        when(germplasmDataManager.getGermplasmByGID(anyInt())).thenReturn(germplasm);
+
+        when(germplasm.getLocationId()).thenReturn(ORIGINAL_LOCATION_ID);
+        List<StringBuilder> input = constructExpressionInput();
+
+        AdvancingSource source = new AdvancingSource();
+        source.setHarvestLocationId(ORIGINAL_LOCATION_ID + 1);
+        ImportedGermplasm importedGermplasm = mock(ImportedGermplasm.class);
+        when(importedGermplasm.getGid()).thenReturn(Integer.toString(TEST_GID));
+        source.setGermplasm(importedGermplasm);
+        source.setLocationAbbreviation(NEW_LOCATION_ABBR);
+
+        dut.apply(input, source, null);
+        assertEquals(NEW_LOCATION_ABBR, input.get(0).toString());
+    }
+
+    protected List<StringBuilder> constructExpressionInput() {
+        List<StringBuilder> list = new ArrayList<>();
+        list.add(new StringBuilder(ChangeLocationExpression.KEY));
+
+        return list;
+    }
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/ComponentPostProcessorTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/ComponentPostProcessorTest.java
@@ -1,0 +1,48 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.RuleFactory;
+import org.generationcp.middleware.ruleengine.naming.impl.ProcessCodeFactory;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Created by Daniel Villafuerte on 6/16/2015.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ComponentPostProcessorTest {
+
+    @Mock
+    private RuleFactory ruleFactory;
+
+    @Mock
+    private ProcessCodeFactory processCodeFactory;
+
+    @InjectMocks
+    private ComponentPostProcessor dut;
+
+    @Test
+    public void testProcessCodeAdd() {
+        Expression testExpression = new Expression() {
+            @Override
+            public void apply(List<StringBuilder> values, AdvancingSource source, final String capturedText) {
+                // do nothing
+            }
+
+            @Override
+            public String getExpressionKey() {
+                return "TEST";
+            }
+        };
+
+        dut.postProcessAfterInitialization(testExpression, testExpression.getExpressionKey());
+        verify(processCodeFactory).addExpression(testExpression);
+    }
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/CrossTypeExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/CrossTypeExpressionTest.java
@@ -1,0 +1,87 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import junit.framework.Assert;
+import org.generationcp.middleware.ContextHolder;
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.operation.builder.WorkbookBuilderTest;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.pojos.workbench.CropType;
+import org.generationcp.middleware.pojos.workbench.Project;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.ruleengine.pojo.ImportedGermplasm;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CrossTypeExpressionTest {
+
+	private static final String CRSTYP = "[CRSTYP]";
+	private static final String PROGRAM_UUID = UUID.randomUUID().toString();
+
+	@Mock
+	private GermplasmDataManager germplasmDataManager;
+
+	@InjectMocks
+	private CrossTypeExpression crossTypeExpression;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+
+		final Project testProject = new Project();
+		testProject.setUniqueID("e8e4be0a-5d63-452f-8fde-b1c794ec7b1a");
+		testProject.setCropType(new CropType("maize"));
+
+		ContextHolder.setCurrentCrop("maize");
+		ContextHolder.setCurrentProgram(PROGRAM_UUID);
+	}
+
+	@Test
+	public void testResolveForNurseryWithSingleCrossBreedingMethod(){
+		final AdvancingSource source = new AdvancingSource();
+		final Method breedingMethod = this.generateBreedingMethod("Single cross");
+		final ImportedGermplasm importedGermplasm = new ImportedGermplasm();
+		source.setBreedingMethod(breedingMethod);
+		source.setGermplasm(importedGermplasm);
+
+		final List<StringBuilder> values = new ArrayList<>();
+		values.add(new StringBuilder(CRSTYP));
+
+		this.crossTypeExpression.apply(values, source, null);
+
+		Assert.assertEquals("S", values.get(0).toString());
+	}
+
+
+	public void testResolveForNurseryWithDoubleCrossBreedingMethod() {
+		final AdvancingSource source = new AdvancingSource();
+		final Method breedingMethod = this.generateBreedingMethod("Double cross");
+		final ImportedGermplasm importedGermplasm = new ImportedGermplasm();
+		source.setBreedingMethod(breedingMethod);
+		source.setGermplasm(importedGermplasm);
+
+		final List<StringBuilder> values = new ArrayList<>();
+		values.add(new StringBuilder(CRSTYP));
+
+		this.crossTypeExpression.apply(values, source, null);
+
+		Assert.assertEquals("D", values.get(0).toString());
+	}
+
+	private Method generateBreedingMethod(final String methodName){
+		final Method breedingMethod = new Method();
+		breedingMethod.setMname(methodName);
+		return breedingMethod;
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/DoubleHaploidSourceExpressionIntegrationTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/DoubleHaploidSourceExpressionIntegrationTest.java
@@ -1,0 +1,69 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.IntegrationTestBase;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.service.api.KeySequenceRegisterService;
+import org.generationcp.middleware.service.impl.KeySequenceRegisterServiceImpl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class DoubleHaploidSourceExpressionIntegrationTest extends IntegrationTestBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DoubleHaploidSourceExpressionIntegrationTest.class);
+
+    @Test
+    public void testDoubleHaploidApplyRuleWithMultipleThreads() throws ExecutionException, InterruptedException {
+
+        final AdvancingSource source = new AdvancingSource();
+
+        final int threads = 10;
+        final List<Future<String>> resultingDesignations = new ArrayList<>();
+
+        final ExecutorService threadPool = Executors.newFixedThreadPool(threads);
+
+        final KeySequenceRegisterService keySequenceRegisterService =
+                new KeySequenceRegisterServiceImpl(this.sessionProvder);
+
+        for (int i = 1; i <= threads; i++) {
+            final Future<String> result = threadPool.submit(new Callable<String>() {
+                @Override
+                public String call() {
+                    final List<StringBuilder> values = new ArrayList<>();
+                    values.add(new StringBuilder("WM14AST0001L@0[DHSOURCE]"));
+                    final DoubleHaploidSourceExpression doubleHaploidSourceExpression = new DoubleHaploidSourceExpression();
+                    doubleHaploidSourceExpression.setKeySequenceRegisterService(keySequenceRegisterService);
+
+                    doubleHaploidSourceExpression.apply(values, source, null);
+                    return values.get(0).toString();
+                }
+            });
+            resultingDesignations.add(result);
+        }
+
+        threadPool.shutdown();
+        while (!threadPool.isTerminated()) {
+        }
+
+        final Set<String> uniqueDesignationSet = new HashSet<>();
+        for (final Future<String> future : resultingDesignations) {
+            final String generatedDesignation = future.get();
+            uniqueDesignationSet.add(generatedDesignation);
+            LOG.info("Designation returned: {}.", generatedDesignation);
+        }
+
+        Assert.assertEquals("Each thread must return a unique designation.", threads, uniqueDesignationSet.size());
+    }
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/DoubleHaploidSourceExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/DoubleHaploidSourceExpressionTest.java
@@ -1,0 +1,58 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import junit.framework.Assert;
+import org.generationcp.middleware.exceptions.MiddlewareException;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.service.api.KeySequenceRegisterService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DoubleHaploidSourceExpressionTest extends TestExpression {
+
+	@Mock
+	private KeySequenceRegisterService keySequenceRegisterService;
+
+	@InjectMocks
+	private DoubleHaploidSourceExpression doubleHaploidSourceExpression;
+
+	/**
+	 * Test to check whether designation value is suffixed with '@' + [sequence number] for Double Haploid Method
+	 * @throws MiddlewareException
+	 */
+    @Test
+    public void testDesignationValueWithLastUsedSequenceNumberForDoubleHaploid() throws MiddlewareException {
+		AdvancingSource source = this.createAdvancingSourceTestData("(CML454 X CML451)-B-3-1-1@0", null, null, null, "[DHSOURCE]", false);
+
+		List<StringBuilder> values = this.createInitialValues(source);
+
+		Mockito.when(this.keySequenceRegisterService.incrementAndGetNextSequence("(CML454 X CML451)-B-3-1-1@")).thenReturn(25);
+
+		doubleHaploidSourceExpression.apply(values, source, null);
+
+		Assert.assertEquals("Error in Designation value for Double Haploid Source Method", "(CML454 X CML451)-B-3-1-1@25", values.get(0).toString());
+	}
+
+	/**
+	 * Test to check whether designation value is not suffixed if value does not contain '@0' for Double Haploid Method
+	 * @throws MiddlewareException
+	 */
+	@Test
+	public void testDesignationValueWithoutLastUsedSequenceNumberForDoubleHaploid() throws MiddlewareException {
+		AdvancingSource source = this.createAdvancingSourceTestData("(CML454 X CML451)-B-3-1-1", "-", "DH", null, "[DHSOURCE]", false);
+
+		List<StringBuilder> values = this.createInitialValues(source);
+
+		doubleHaploidSourceExpression.apply(values, source, null);
+
+		Assert.assertEquals("Error in Designation value for Double Haploid Source Method", "(CML454 X CML451)-B-3-1-1-DH", values.get(0).toString());
+	}
+
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/FirstExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/FirstExpressionTest.java
@@ -1,0 +1,39 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Test;
+
+import java.util.List;
+
+public class FirstExpressionTest extends TestExpression {
+
+	@Test
+	public void testFirst() throws Exception {
+		FirstExpression expression = new FirstExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST-12B:13C-14D:15E", "[FIRST]:", "12C", null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testFirst2() throws Exception {
+		FirstExpression expression = new FirstExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", "[FIRST]:", "12C", null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testCaseSensitive() throws Exception {
+		FirstExpression expression = new FirstExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST-12B:13C-14D:15E", "[first]:", "12C", null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		System.out.println("process is in lower case");
+		this.printResult(values, source);
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/GroupCountExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/GroupCountExpressionTest.java
@@ -1,0 +1,46 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by IntelliJ IDEA. User: Daniel Villafuerte
+ */
+public class GroupCountExpressionTest extends TestExpression {
+
+	GroupCountExpression dut = new GroupCountExpression();
+
+    @Test
+    public void verifyTestScenarios() {
+        testCountExpression("CML451 / ABC1234-B*3-B-B", "B*[COUNT]", "CML451 / ABC1234-B*3-B-B*2");
+        testCountExpression("CML451 / ABC1234-B*5-B*2", "B*[COUNT]", "CML451 / ABC1234-B*5-B*3");
+        testCountExpression("CML451 / ABC1234-B*3-4-B", "B*[COUNT]", "CML451 / ABC1234-B*3-4-B*2");
+        testCountExpression("TEST-BBB", "B*[COUNT]", "TEST-BBB*2");
+        testCountExpression("TEST-B-B-B", "B*[COUNT]", "TEST-B-B-B*2");
+        testCountExpression("CML451 / ABC1234", "B*[COUNT]", "CML451 / ABC1234-B");
+        testCountExpression("TEST-B-2-B-3-B", "B*[COUNT]", "TEST-B-2-B-3-B*2");
+        testCountExpression("TEST-1-B-2-B*3-B", "B*[COUNT]", "TEST-1-B-2-B*3-B*2");
+        testCountExpression("TEST-B-1-B*4-B*3", "B*[COUNT]", "TEST-B-1-B*4-B*4");
+        testCountExpression("TEST-B-B*3-B", "B*[COUNT]", "TEST-B-B*3-B*2");
+        testCountExpression("TEST-B-1B-2B-B", "B*[COUNT]", "TEST-B-1B-2B-B*2");
+        testCountExpression("TEST-B-1B-2BBB", "B*[COUNT]", "TEST-B-1B-2BBB*2");
+        testCountExpression("TEST-B-1B-2B", "B*[COUNT]", "TEST-B-1B-2B*2");
+
+
+    }
+
+    protected void testCountExpression(final String sourceName, final String countExpression, final String expectedValue) {
+        final AdvancingSource source = this.createAdvancingSourceTestData(sourceName, "-", null, null, null, true);
+        final List<StringBuilder> values = new ArrayList<>();
+        values.add(new StringBuilder(source.getRootName() + countExpression));
+
+        this.dut.apply(values, source, null);
+        final String value = values.get(0).toString();
+
+        Assert.assertEquals(expectedValue, value);
+    }
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/LocationAbbreviationExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/LocationAbbreviationExpressionTest.java
@@ -1,0 +1,49 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Test;
+
+import java.util.List;
+
+public class LocationAbbreviationExpressionTest extends TestExpression {
+
+	@Test
+	public void testLabbrAsPrefix() throws Exception {
+		LocationAbbreviationExpression expression = new LocationAbbreviationExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", null, "[LABBR]", null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testLabbrAsSuffix() throws Exception {
+		LocationAbbreviationExpression expression = new LocationAbbreviationExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", ":", null, null, "[LABBR]", true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testNoLabbr() throws Exception {
+		LocationAbbreviationExpression expression = new LocationAbbreviationExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", null, null, null, "[LABBR]", true);
+		source.setLocationAbbreviation(null);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testCaseSensitive() throws Exception {
+		LocationAbbreviationExpression expression = new LocationAbbreviationExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", null, "[labbr]", null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		System.out.println("process code is in lower case");
+		this.printResult(values, source);
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/NumberExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/NumberExpressionTest.java
@@ -1,0 +1,67 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class NumberExpressionTest extends TestExpression {
+
+	private static final String ROOT_NAME = "GERMPLASM_TEST";
+	private static final String SEPARATOR = "-";
+	private static final String PREFIX = "IBX";
+	private static final String SUFFIX = "RS";
+	private static final String NUMBER = "[NUMBER]";
+
+	private AdvancingSource source;
+	private NumberExpression expression;
+
+	@Before
+	public void setup() {
+		this.expression = new NumberExpression();
+		this.source = this.createAdvancingSourceTestData(ROOT_NAME, SEPARATOR, PREFIX, NUMBER, SUFFIX, true);
+	}
+
+	@Test
+	public void testNumber() {
+		final int plantsSelected = 2;
+		this.source.setPlantsSelected(plantsSelected);
+		List<StringBuilder> values = this.createInitialValues(this.source);
+
+		this.expression.apply(values, this.source, null);
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + plantsSelected + SUFFIX, values.get(0).toString());
+	}
+
+
+	@Test
+	public void testNegativeNumber() {
+		this.source.setPlantsSelected(-2);
+		List<StringBuilder> values = this.createInitialValues(this.source);
+		this.expression.apply(values, this.source, null);
+		// The NUMBER expression will be replaced with blank string
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + SUFFIX, values.get(0).toString());
+	}
+
+	@Test
+	public void testNumberEqualToOne() {
+		this.source.setPlantsSelected(1);
+		List<StringBuilder> values = this.createInitialValues(this.source);
+		this.expression.apply(values, this.source, null);
+		// The NUMBER expression will be replaced with blank string
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + SUFFIX, values.get(0).toString());
+	}
+
+	@Test
+	public void testCaseSensitive() {
+		final int plantsSelected = 3;
+		this.source.setPlantsSelected(plantsSelected);
+		List<StringBuilder> values = this.createInitialValues(this.source);
+		this.expression.apply(values, this.source, null);
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + plantsSelected + SUFFIX, values.get(0).toString());
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/PaddedSequenceExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/PaddedSequenceExpressionTest.java
@@ -1,0 +1,153 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.ExpressionUtils;
+import org.generationcp.middleware.ruleengine.naming.service.GermplasmNamingService;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class PaddedSequenceExpressionTest extends TestExpression {
+
+	private static final String ROOT_NAME = "TESTING";
+	private static final String SEPARATOR = "-";
+	private static final String PREFIX = "ABC";
+	private static final String SUFFIX = "XYZ";
+	private static final String PADSEQ = "[PADSEQ]";
+	private static final String PADSEQ_WITH_NUMBER = "[PADSEQ.%s]";
+	private static final Integer PLANTS_SELECTED = 5;
+	private static final Integer NEXT_NUMBER_FROM_DB = 22;
+
+	private PaddedSequenceExpression expression;
+
+	@Mock
+	private GermplasmNamingService germplasmNamingService;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.expression = new PaddedSequenceExpression();
+		this.expression.setGermplasmNamingService(this.germplasmNamingService);
+
+		Mockito.doReturn(NEXT_NUMBER_FROM_DB, NEXT_NUMBER_FROM_DB + 1, NEXT_NUMBER_FROM_DB + 2, NEXT_NUMBER_FROM_DB + 3,
+			NEXT_NUMBER_FROM_DB + 4).when(this.germplasmNamingService).getNextNumberAndIncrementSequence(
+			ArgumentMatchers.anyString());
+		Mockito
+			.doReturn("0" + NEXT_NUMBER_FROM_DB, "0" + (NEXT_NUMBER_FROM_DB + 1), "0" + (NEXT_NUMBER_FROM_DB + 2),
+				"0" + (NEXT_NUMBER_FROM_DB + 3), "0" + (NEXT_NUMBER_FROM_DB + 4)).when(this.germplasmNamingService)
+			.getNumberWithLeadingZeroesAsString(
+				ArgumentMatchers.anyInt(), ArgumentMatchers.eq(ExpressionUtils.DEFAULT_LENGTH));
+	}
+
+	@Test
+	public void testExpressionRegex() {
+		Assert.assertTrue(PaddedSequenceExpressionTest.PADSEQ.matches(this.expression.getExpressionKey()));
+		Assert.assertTrue("[PADSEQ.2]".matches(this.expression.getExpressionKey()));
+		Assert.assertTrue("[PADSEQ.23]".matches(this.expression.getExpressionKey()));
+		Assert.assertFalse("[PADSEQ.AB2]".matches(this.expression.getExpressionKey()));
+		Assert.assertFalse("[PADSEQ.ab2]".matches(this.expression.getExpressionKey()));
+	}
+
+	@Test
+	public void testWithNegativeNumberPlantsSelected() {
+		final AdvancingSource source = this.createAdvancingSourceTestData(ROOT_NAME, SEPARATOR, PREFIX, PADSEQ, SUFFIX, true);
+		source.setPlantsSelected(-2);
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		this.expression.apply(values, source, null);
+		// The expression will be replaced with blank string
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + SUFFIX, values.get(0).toString());
+		Mockito.verifyZeroInteractions(this.germplasmNamingService);
+	}
+
+	@Test
+	public void testCaseSensitiveKey() {
+		final AdvancingSource source = this.createAdvancingSourceTestData(ROOT_NAME, SEPARATOR, PREFIX, PADSEQ.toLowerCase(), SUFFIX, true);
+		source.setPlantsSelected(PLANTS_SELECTED);
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		this.expression.apply(values, source, null);
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + "0" + NEXT_NUMBER_FROM_DB + SUFFIX, values.get(0).toString());
+	}
+
+	@Test
+	public void testWithNullPlantsSelected() {
+		// final false refers to nonBulking
+		final AdvancingSource source =
+			this.createAdvancingSourceTestData(ROOT_NAME, SEPARATOR, PREFIX, PADSEQ.toLowerCase(), SUFFIX, false);
+		source.setPlantsSelected(null);
+		final int currentMaxSequence = 10;
+		source.setCurrentMaxSequence(currentMaxSequence);
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		this.expression.apply(values, source, null);
+		Mockito.verifyZeroInteractions(this.germplasmNamingService);
+		assertEquals(1, values.size());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + SUFFIX, values.get(0).toString());
+	}
+
+	@Test
+	public void testBulkingWithPlantsSelected() {
+		final AdvancingSource source = this.createAdvancingSourceTestData(ROOT_NAME, SEPARATOR, PREFIX, PADSEQ, SUFFIX, true);
+		source.setPlantsSelected(PLANTS_SELECTED);
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		this.expression.apply(values, source, null);
+		// Expecting only one iteration for bulking method
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + "0" + NEXT_NUMBER_FROM_DB + SUFFIX, values.get(0).toString());
+	}
+
+	@Test
+	public void testNonBulkingWithPlantsSelected() {
+		// final false refers to nonBulking
+		final AdvancingSource source = this.createAdvancingSourceTestData(ROOT_NAME, SEPARATOR, PREFIX, PADSEQ, SUFFIX, false);
+		source.setPlantsSelected(PLANTS_SELECTED);
+		final int currentMaxSequence = 13;
+		source.setCurrentMaxSequence(currentMaxSequence);
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		this.expression.apply(values, source, null);
+		assertEquals(PLANTS_SELECTED.intValue(), values.size());
+		Mockito.verify(this.germplasmNamingService, Mockito.times(PLANTS_SELECTED))
+			.getNextNumberAndIncrementSequence(ROOT_NAME + SEPARATOR + PREFIX);
+		Mockito.verify(this.germplasmNamingService, Mockito.times(PLANTS_SELECTED))
+			.getNumberWithLeadingZeroesAsString(ArgumentMatchers.anyInt(), ArgumentMatchers.eq(ExpressionUtils.DEFAULT_LENGTH));
+
+		// If non-bulking, name is generated for each plant selected
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + "0" + (NEXT_NUMBER_FROM_DB) + SUFFIX, values.get(0).toString());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + "0" + (NEXT_NUMBER_FROM_DB + 1) + SUFFIX, values.get(1).toString());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + "0" + (NEXT_NUMBER_FROM_DB + 2) + SUFFIX, values.get(2).toString());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + "0" + (NEXT_NUMBER_FROM_DB + 3) + SUFFIX, values.get(3).toString());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + "0" + (NEXT_NUMBER_FROM_DB + 4) + SUFFIX, values.get(4).toString());
+	}
+
+	@Test
+	public void testApplyWithNumberOfDigitsSpecified() {
+		final Integer numberofDigits = 5;
+		final String processCode = String.format(PaddedSequenceExpressionTest.PADSEQ_WITH_NUMBER, numberofDigits);
+		final AdvancingSource source = this.createAdvancingSourceTestData(ROOT_NAME, SEPARATOR, PREFIX, processCode, SUFFIX, false);
+		source.setPlantsSelected(PLANTS_SELECTED);
+
+		final List<StringBuilder> values = this.createInitialValues(source);
+		Mockito.doReturn("000" + NEXT_NUMBER_FROM_DB, "000" + (NEXT_NUMBER_FROM_DB + 1), "000" + (NEXT_NUMBER_FROM_DB + 2),
+			"000" + (NEXT_NUMBER_FROM_DB + 3), "000" + (NEXT_NUMBER_FROM_DB + 4))
+			.when(this.germplasmNamingService).getNumberWithLeadingZeroesAsString(
+			ArgumentMatchers.anyInt(), ArgumentMatchers.eq(numberofDigits));
+
+		this.expression.apply(values, source, null);
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + "000" + (NEXT_NUMBER_FROM_DB) + SUFFIX, values.get(0).toString());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + "000" + (NEXT_NUMBER_FROM_DB + 1) + SUFFIX, values.get(1).toString());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + "000" + (NEXT_NUMBER_FROM_DB + 2) + SUFFIX, values.get(2).toString());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + "000" + (NEXT_NUMBER_FROM_DB + 3) + SUFFIX, values.get(3).toString());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + "000" + (NEXT_NUMBER_FROM_DB + 4) + SUFFIX, values.get(4).toString());
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/RootNameExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/RootNameExpressionTest.java
@@ -1,0 +1,117 @@
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import junit.framework.Assert;
+import org.generationcp.middleware.manager.GermplasmNameType;
+import org.generationcp.middleware.pojos.Name;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RootNameExpressionTest extends TestExpression {
+
+	private RootNameExpression rootNameExpression;
+
+	@Before
+	public void init() {
+
+		this.rootNameExpression = new RootNameExpression();
+
+	}
+
+	@Test
+	public void testCrossNameEnclosing() throws Exception {
+		final List<String> input = Arrays.asList("a(b/c)d", "a/bc", "/abc", "(ab)/(de)", "(abc)a/e", "((a/b))", "b/e(a/b)", "(b/e)/(a/b)",
+				"(CML146/CLQ-6203)/CML147", "(CLQ-6203/CML150)/CML144", "(L-133/LSA-297)/PA-1", "((P 47/MPSWCB 4) 11//(MPSWCB", "(a//b)",
+				"(a/b/c/d)");
+
+		final List<String> expectedOutput =
+				Arrays.asList("a(b/c)d", "(a/bc)", "(/abc)", "((ab)/(de))", "((abc)a/e)", "((a/b))", "(b/e(a/b))", "((b/e)/(a/b))",
+						"((CML146/CLQ-6203)/CML147)", "((CLQ-6203/CML150)/CML144)", "((L-133/LSA-297)/PA-1)",
+						"(((P 47/MPSWCB 4) 11//(MPSWCB)", "(a//b)", "(a/b/c/d)");
+
+		final AdvancingSource source = this.createAdvancingSourceTestData("Germplasm", null, null, null, null, true);
+		int i = 0;
+		final Name name = new Name();
+		name.setTypeId(10);
+		source.getNames().add(name);
+		source.getBreedingMethod().setSnametype(10);
+		for (final String nameString : input) {
+			System.out.println("INPUT = " + nameString);
+			final List<StringBuilder> builders = new ArrayList<StringBuilder>();
+			builders.add(new StringBuilder());
+			name.setNval(nameString);
+			this.rootNameExpression.apply(builders, source, null);
+			final String output = builders.get(0).toString();
+			Assert.assertEquals(expectedOutput.get(i), output);
+			i++;
+		}
+	}
+
+	@Test
+	public void testIfThereIsNoMatchingName() throws Exception {
+		final List<String> input = Arrays.asList("a(b/c)d", "a/bc", "/abc", "(ab)/(de)", "(abc)a/e", "((a/b))", "b/e(a/b)", "(b/e)/(a/b)",
+				"(CML146/CLQ-6203)/CML147", "(CLQ-6203/CML150)/CML144", "(L-133/LSA-297)/PA-1", "((P 47/MPSWCB 4) 11//(MPSWCB", "(a//b)",
+				"(a/b/c/d)");
+
+		final AdvancingSource source = this.createAdvancingSourceTestData("Germplasm", null, null, null, null, true);
+		final Name name = new Name();
+		name.setTypeId(11);
+		name.setNstat(2);
+		final List<Name> names = new ArrayList<Name>();
+		names.add(name);
+		source.setNames(names);
+		source.getBreedingMethod().setSnametype(10);
+		for (final String nameString : input) {
+			final List<StringBuilder> builders = new ArrayList<StringBuilder>();
+			builders.add(new StringBuilder());
+			name.setNval(nameString);
+			this.rootNameExpression.apply(builders, source, null);
+			final String output = builders.get(0).toString();
+			Assert.assertEquals("", output);
+		}
+	}
+
+	@Test
+	public void testSnametypeIsNull() {
+
+		final String lineNameValue = "DESIGNATION1";
+		final String derivativeNameValue = "DERIVATIVE NAME1";
+
+		final AdvancingSource source = this.createAdvancingSourceTestData("Germplasm", null, null, null, null, true);
+
+		// Create lineName Name and set is as preferred
+		final Name lineName = new Name();
+		lineName.setTypeId(GermplasmNameType.LINE_NAME.getUserDefinedFieldID());
+		lineName.setNval(lineNameValue);
+		lineName.setNstat(1);
+
+		// Create derivative name
+		final Name derivativeName = new Name();
+		derivativeName.setTypeId(GermplasmNameType.DERIVATIVE_NAME.getUserDefinedFieldID());
+		derivativeName.setNval(derivativeNameValue);
+		derivativeName.setNstat(2);
+
+		final List<Name> names = new ArrayList<Name>();
+		names.add(lineName);
+		names.add(derivativeName);
+
+		source.setNames(names);
+
+		// Set the snametype to null
+		source.getBreedingMethod().setSnametype(null);
+
+		final List<StringBuilder> builders = new ArrayList<StringBuilder>();
+		builders.add(new StringBuilder());
+
+		this.rootNameExpression.apply(builders, source, null);
+
+		final String output = builders.get(0).toString();
+		Assert.assertEquals("If snametype of the breeding method is null, then the preferred name should be used as a root name.",
+				lineNameValue, output);
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/SeasonExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/SeasonExpressionTest.java
@@ -1,0 +1,65 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import junit.framework.Assert;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+public class SeasonExpressionTest extends TestExpression {
+
+	public static final Logger LOG = LoggerFactory.getLogger(SeasonExpressionTest.class);
+
+	@Test
+	public void testSeasonAsPrefix() throws Exception {
+		LOG.debug("Testing Season As Prefix");
+		SeasonExpression expression = new SeasonExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", null, "[SEASON]", null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+		Assert.assertEquals("GERMPLASM_TESTDry", this.buildResult(values));
+	}
+
+	@Test
+	public void testSeasonAsSuffix() throws Exception {
+		LOG.debug("Testing Season As Suffix");
+		SeasonExpression expression = new SeasonExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", ":", null, null, "[SEASON]", true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+		Assert.assertEquals("GERMPLASM_TEST:Dry", this.buildResult(values));
+	}
+
+	@Test
+	public void testNoSeason() throws Exception {
+		SimpleDateFormat f = new SimpleDateFormat("YYYYMM");
+		String defSeason = f.format(new Date());
+		LOG.debug("Testing No Season");
+		SeasonExpression expression = new SeasonExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", "-", null, null, "[SEASON]", true);
+		source.setSeason(null);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+		Assert.assertEquals("GERMPLASM_TEST-" + defSeason, this.buildResult(values));
+	}
+
+	@Test
+	public void testCaseSensitive() throws Exception {
+		SeasonExpression expression = new SeasonExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", null, "[seasOn]", null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		LOG.debug("Testing process code is in lower case");
+		this.printResult(values, source);
+		Assert.assertEquals("GERMPLASM_TESTDry", this.buildResult(values));
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/SequenceExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/SequenceExpressionTest.java
@@ -1,0 +1,118 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.naming.service.GermplasmNamingService;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SequenceExpressionTest extends TestExpression {
+
+	private static final String ROOT_NAME = "GERMPLASM_TEST";
+	private static final String SEPARATOR = "-";
+	private static final String PREFIX = "IBX";
+	private static final String SUFFIX = "P";
+	private static final String SEQUENCE = "[SEQUENCE]";
+	private static final Integer PLANTS_SELECTED = 5;
+	private static final Integer NEXT_NUMBER_FROM_DB = 22;
+
+	private SequenceExpression expression;
+
+	@Mock
+	private GermplasmNamingService germplasmNamingService;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.expression = new SequenceExpression();
+		this.expression.setGermplasmNamingService(this.germplasmNamingService);
+
+		Mockito.doReturn(NEXT_NUMBER_FROM_DB, NEXT_NUMBER_FROM_DB + 1, NEXT_NUMBER_FROM_DB + 2, NEXT_NUMBER_FROM_DB + 3,
+			NEXT_NUMBER_FROM_DB + 4).when(this.germplasmNamingService).getNextNumberAndIncrementSequence(
+			ArgumentMatchers.anyString());
+		Mockito
+			.doReturn(String.valueOf(NEXT_NUMBER_FROM_DB), String.valueOf(NEXT_NUMBER_FROM_DB + 1), String.valueOf(NEXT_NUMBER_FROM_DB + 2),
+				String.valueOf(NEXT_NUMBER_FROM_DB + 3), String.valueOf(NEXT_NUMBER_FROM_DB + 4)).when(this.germplasmNamingService)
+			.getNumberWithLeadingZeroesAsString(
+				ArgumentMatchers.anyInt(), ArgumentMatchers.eq(1));
+	}
+
+	@Test
+	public void testWithNegativeNumberPlantsSelected() {
+		final AdvancingSource source = this.createAdvancingSourceTestData(ROOT_NAME, SEPARATOR, PREFIX, SEQUENCE, SUFFIX, true);
+		source.setPlantsSelected(-2);
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		this.expression.apply(values, source, null);
+		// The SEQUENCE expression will be replaced with blank string
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + SUFFIX, values.get(0).toString());
+		Mockito.verifyZeroInteractions(this.germplasmNamingService);
+	}
+
+	@Test
+	public void testCaseSensitiveSequence() {
+		final AdvancingSource source =
+			this.createAdvancingSourceTestData(ROOT_NAME, SEPARATOR, PREFIX, SEQUENCE.toLowerCase(), SUFFIX, true);
+		source.setPlantsSelected(PLANTS_SELECTED);
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		this.expression.apply(values, source, null);
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + NEXT_NUMBER_FROM_DB + SUFFIX, values.get(0).toString());
+	}
+
+	@Test
+	public void testWithNullPlantsSelected() {
+		// final false refers to nonBulking
+		final AdvancingSource source =
+			this.createAdvancingSourceTestData(ROOT_NAME, SEPARATOR, PREFIX, SEQUENCE.toLowerCase(), SUFFIX, false);
+		source.setPlantsSelected(null);
+		final int currentMaxSequence = 10;
+		source.setCurrentMaxSequence(currentMaxSequence);
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		this.expression.apply(values, source, null);
+		Mockito.verifyZeroInteractions(this.germplasmNamingService);
+		assertEquals(1, values.size());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + SUFFIX, values.get(0).toString());
+	}
+
+	@Test
+	public void testBulkingWithPlantsSelected() {
+		final AdvancingSource source = this.createAdvancingSourceTestData(ROOT_NAME, SEPARATOR, PREFIX, SEQUENCE, SUFFIX, true);
+		source.setPlantsSelected(PLANTS_SELECTED);
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		this.expression.apply(values, source, null);
+		// Expecting only one iteration for bulking method
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + NEXT_NUMBER_FROM_DB + SUFFIX, values.get(0).toString());
+	}
+
+	@Test
+	public void testNonBulkingWithPlantsSelected() {
+		// final false refers to nonBulking
+		final AdvancingSource source = this.createAdvancingSourceTestData(ROOT_NAME, SEPARATOR, PREFIX, SEQUENCE, SUFFIX, false);
+		source.setPlantsSelected(PLANTS_SELECTED);
+		final int currentMaxSequence = 13;
+		source.setCurrentMaxSequence(currentMaxSequence);
+		final List<StringBuilder> values = this.createInitialValues(source);
+
+		this.expression.apply(values, source, null);
+		assertEquals(PLANTS_SELECTED.intValue(), values.size());
+		Mockito.verify(this.germplasmNamingService, Mockito.times(PLANTS_SELECTED))
+			.getNextNumberAndIncrementSequence(ROOT_NAME + SEPARATOR + PREFIX);
+		// If non-bulking, name is generated for each plant selected
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + (NEXT_NUMBER_FROM_DB) + SUFFIX, values.get(0).toString());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + (NEXT_NUMBER_FROM_DB + 1) + SUFFIX, values.get(1).toString());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + (NEXT_NUMBER_FROM_DB + 2) + SUFFIX, values.get(2).toString());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + (NEXT_NUMBER_FROM_DB + 3) + SUFFIX, values.get(3).toString());
+		assertEquals(ROOT_NAME + SEPARATOR + PREFIX + (NEXT_NUMBER_FROM_DB + 4) + SUFFIX, values.get(4).toString());
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/TestExpression.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/TestExpression.java
@@ -1,0 +1,139 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.pojos.Germplasm;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.pojos.Name;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.generationcp.middleware.ruleengine.pojo.ImportedGermplasm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestExpression {
+
+	public static final Logger LOG = LoggerFactory.getLogger(TestExpression.class);
+
+	public void printResult(List<StringBuilder> values, AdvancingSource source) {
+		LOG.debug("DESIG = " + source.getGermplasm().getDesig());
+		LOG.debug("RESULTS=");
+		for (StringBuilder value : values) {
+			LOG.debug("\t" + value);
+		}
+	}
+
+	public String buildResult(List<StringBuilder> values) {
+		String result = "";
+		for (StringBuilder value : values) {
+			result = result + value;
+		}
+		return result;
+	}
+
+	public AdvancingSource createAdvancingSourceTestData(final Method method,final ImportedGermplasm germplasm, final String name, final String season,
+		final String studyName) {
+		final List<Name> names = new ArrayList<>();
+		names.add(new Name(1, new Germplasm(1), 3, 0, name + "_three", 0, 0, 0));
+		names.add(new Name(1, new Germplasm(1), 5, 0, name + "_five", 0, 0, 0));
+		names.add(new Name(1, new Germplasm(1), 2, 1, name + "_two", 0, 0, 0));
+
+		final AdvancingSource source = new AdvancingSource(germplasm, names, 2, method, false, studyName, "1");
+		source.setRootName(name);
+		source.setSeason(season);
+		return source;
+
+	}
+
+	public AdvancingSource createAdvancingSourceTestData(String name, String separator, String prefix, String count, String suffix,
+			boolean isBulking) {
+
+		final Method method = new Method();
+		method.setSeparator(separator);
+		method.setPrefix(prefix);
+		method.setCount(count);
+		method.setSuffix(suffix);
+		if (isBulking) {
+			method.setGeneq(TermId.BULKING_BREEDING_METHOD_CLASS.getId());
+		} else {
+			method.setGeneq(TermId.NON_BULKING_BREEDING_METHOD_CLASS.getId());
+		}
+
+		final ImportedGermplasm germplasm = new ImportedGermplasm();
+		germplasm.setDesig(name);
+		final List<Name> names = new ArrayList<Name>();
+		names.add(new Name(1, new Germplasm(1), 3, 0, name + "_three", 0, 0, 0));
+		names.add(new Name(1, new Germplasm(1), 5, 0, name + "_five", 0, 0, 0));
+		names.add(new Name(1, new Germplasm(1), 2, 1, name + "_two", 0, 0, 0));
+
+		final AdvancingSource source = new AdvancingSource(germplasm, names, 2, method, false, "MNL", "1");
+		source.setRootName(name);
+		source.setSeason("Dry");
+		source.setStudyName("NurseryTest");
+		return source;
+	}
+
+	public List<StringBuilder> createInitialValues(AdvancingSource source) {
+		final List<StringBuilder> builders = new ArrayList<>();
+
+		final StringBuilder builder = new StringBuilder();
+		builder.append(source.getGermplasm().getDesig()).append(this.getNonNullValue(source.getBreedingMethod().getSeparator()))
+		.append(this.getNonNullValue(source.getBreedingMethod().getPrefix()))
+		.append(this.getNonNullValue(source.getBreedingMethod().getCount()))
+		.append(this.getNonNullValue(source.getBreedingMethod().getSuffix()));
+		builders.add(builder);
+
+		return builders;
+	}
+
+	public ImportedGermplasm createImportedGermplasm(final Integer entryNumber, final String designation, final String gid, final Integer gpid1, final Integer gpid2,
+													 final Integer gnpgs, final Integer mid) {
+		final ImportedGermplasm germplasm = new ImportedGermplasm();
+		germplasm.setEntryNumber(entryNumber);
+		germplasm.setDesig(designation);
+		germplasm.setGid(gid);
+		germplasm.setGpid1(gpid1);
+		germplasm.setGpid2(gpid2);
+		germplasm.setGnpgs(gnpgs);
+		germplasm.setBreedingMethodId(mid);
+		return germplasm;
+	}
+
+	public Method createDerivativeMethod(final String prefix, final String count, final String suffix, final String separator, final boolean isBulking) {
+		return createBreedingMethod(prefix, count, suffix, "DER", 323, "G", "UDM", "Unknown derivative method",
+			"Unknown derivative method in self fertilising species: for storing historic pedigrees", separator, isBulking);
+	}
+
+	public Method createGenerativeMethod(final String prefix, final String count, final String suffix, final String separator, final boolean isBulking) {
+		return createBreedingMethod(prefix, count, suffix, "GEN", 1, "G", "UGM", "Unknown generative method",
+			"Unknown generative method for storing historic pedigrees for self fertilizing species.", separator, isBulking);
+	}
+
+	public Method createBreedingMethod(final String prefix, final String count, final String suffix, final String mType, final Integer mid,
+		final String mgrp, final String mcode, final String mname, final String mdesc, final String separator, final boolean isBulking) {
+		final Method method = new Method();
+		method.setMid(mid);
+		method.setPrefix(prefix);
+		method.setCount(count);
+		method.setSuffix(suffix);
+		method.setMtype(mType);
+		method.setMid(mid);
+		method.setMgrp(mgrp);
+		method.setMcode(mcode);
+		method.setMname(mname);
+		method.setMdesc(mdesc);
+		method.setSeparator(separator);
+		if (isBulking) {
+			method.setGeneq(TermId.BULKING_BREEDING_METHOD_CLASS.getId());
+		} else {
+			method.setGeneq(TermId.NON_BULKING_BREEDING_METHOD_CLASS.getId());
+		}
+		return method;
+	}
+
+	public String getNonNullValue(String value) {
+		return value != null ? value : "";
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/TopLocationAbbreviationExpressionTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/expression/TopLocationAbbreviationExpressionTest.java
@@ -1,0 +1,49 @@
+
+package org.generationcp.middleware.ruleengine.naming.expression;
+
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Test;
+
+import java.util.List;
+
+public class TopLocationAbbreviationExpressionTest extends TestExpression {
+
+	@Test
+	public void testLabbrAsPrefix() throws Exception {
+		TopLocationAbbreviationExpression expression = new TopLocationAbbreviationExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", null, "[TLABBR]", null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testLabbrAsSuffix() throws Exception {
+		TopLocationAbbreviationExpression expression = new TopLocationAbbreviationExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", ":", null, null, "[TLABBR]", true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testNoLabbr() throws Exception {
+		TopLocationAbbreviationExpression expression = new TopLocationAbbreviationExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", null, null, null, "[TLABBR]", true);
+		source.setLocationAbbreviation(null);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		this.printResult(values, source);
+	}
+
+	@Test
+	public void testCaseSensitive() throws Exception {
+		TopLocationAbbreviationExpression expression = new TopLocationAbbreviationExpression();
+		AdvancingSource source = this.createAdvancingSourceTestData("GERMPLASM_TEST", null, "[tLabbr]", null, null, true);
+		List<StringBuilder> values = this.createInitialValues(source);
+		expression.apply(values, source, null);
+		System.out.println("process code is in lower case");
+		this.printResult(values, source);
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/impl/GermplasmNamingServiceImplTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/impl/GermplasmNamingServiceImplTest.java
@@ -1,0 +1,222 @@
+package org.generationcp.middleware.ruleengine.naming.impl;
+
+import org.generationcp.middleware.exceptions.InvalidGermplasmNameSettingException;
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.pojos.germplasm.GermplasmNameSetting;
+import org.generationcp.middleware.service.api.KeySequenceRegisterService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class GermplasmNamingServiceImplTest {
+
+	private static final String PREFIX = "ABH";
+	private static final String SUFFIX = "CDE";
+	private static final Integer NEXT_NUMBER = 31;
+
+	@Mock
+	private KeySequenceRegisterService keySequenceRegisterService;
+
+	@Mock
+	private GermplasmDataManager germplasmDataManager;
+
+	@InjectMocks
+	private GermplasmNamingServiceImpl germplasmNamingService;
+
+	private GermplasmNameSetting germplasmNameSetting;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.germplasmNameSetting = this.createGermplasmNameSetting();
+		Mockito.doReturn(NEXT_NUMBER).when(this.keySequenceRegisterService).getNextSequence(PREFIX);
+	}
+
+	@Test
+	public void testBuildDesignationNameInSequenceDefaultSetting() {
+		final GermplasmNameSetting defaultSetting = new GermplasmNameSetting();
+		defaultSetting.setPrefix(GermplasmNamingServiceImplTest.PREFIX);
+		defaultSetting.setSuffix(GermplasmNamingServiceImplTest.SUFFIX);
+		defaultSetting.setAddSpaceBetweenPrefixAndCode(false);
+		defaultSetting.setAddSpaceBetweenSuffixAndCode(false);
+
+		final int nextNumber = 10;
+		final String designationName = this.germplasmNamingService.buildDesignationNameInSequence(nextNumber, defaultSetting);
+		Assert.assertEquals(PREFIX + nextNumber + SUFFIX, designationName);
+	}
+
+	@Test
+	public void testBuildDesignationNameInSequenceWithSpacesInPrefixSuffix() {
+		final int nextNumber = 10;
+		final String designationName =
+			this.germplasmNamingService.buildDesignationNameInSequence(nextNumber, this.germplasmNameSetting);
+		Assert.assertEquals(PREFIX + " 00000" + nextNumber + " " + SUFFIX, designationName);
+	}
+
+	@Test
+	public void testBuildPrefixStringDefault() {
+		final GermplasmNameSetting setting = new GermplasmNameSetting();
+		setting.setPrefix(" A  ");
+		final String prefix = this.germplasmNamingService.buildPrefixString(setting);
+		Assert.assertEquals("A", prefix);
+	}
+
+	@Test
+	public void testBuildPrefixStringWithSpace() {
+		final GermplasmNameSetting setting = new GermplasmNameSetting();
+		setting.setPrefix("   A");
+		setting.setAddSpaceBetweenPrefixAndCode(true);
+		final String prefix = this.germplasmNamingService.buildPrefixString(setting);
+		Assert.assertEquals("A ", prefix);
+	}
+
+	@Test
+	public void testBuildSuffixStringDefault() {
+		final GermplasmNameSetting setting = new GermplasmNameSetting();
+		setting.setSuffix("  B   ");
+		final String suffix = this.germplasmNamingService.buildSuffixString(setting);
+		Assert.assertEquals("B", suffix);
+	}
+
+	@Test
+	public void testBuildSuffixStringWithSpace() {
+		final GermplasmNameSetting setting = new GermplasmNameSetting();
+		setting.setSuffix("   B   ");
+		setting.setAddSpaceBetweenSuffixAndCode(true);
+		final String suffix = this.germplasmNamingService.buildSuffixString(setting);
+		Assert.assertEquals(" B", suffix);
+	}
+
+	@Test
+	public void testGetNextSequence() {
+		final int nextNumber = this.germplasmNamingService.getNextSequence(PREFIX);
+		Assert.assertEquals(GermplasmNamingServiceImplTest.NEXT_NUMBER.intValue(), nextNumber);
+		Mockito.verify(this.keySequenceRegisterService).getNextSequence(PREFIX);
+		Mockito.verify(this.germplasmDataManager, Mockito.never()).getNextSequenceNumberAsString(ArgumentMatchers.anyString());
+	}
+
+	@Test
+	public void testGetNextSequenceWhenPrefixIsEmpty() {
+		final int nextNumber = this.germplasmNamingService.getNextSequence("");
+		Assert.assertEquals(1, nextNumber);
+		Mockito.verify(this.keySequenceRegisterService, Mockito.never()).getNextSequence(ArgumentMatchers.anyString());
+		Mockito.verify(this.germplasmDataManager, Mockito.never()).getNextSequenceNumberAsString(ArgumentMatchers.anyString());
+	}
+
+	@Test
+	public void testGetNextSequenceFromNames() {
+		Mockito.doReturn(1).when(this.keySequenceRegisterService).getNextSequence(ArgumentMatchers.anyString());
+		final Integer nextNumberFromNames = 101;
+		Mockito.doReturn(String.valueOf(nextNumberFromNames)).when(this.germplasmDataManager).getNextSequenceNumberAsString(PREFIX);
+		Assert.assertEquals(nextNumberFromNames.intValue(), this.germplasmNamingService.getNextSequence(PREFIX));
+
+	}
+
+	@Test
+	public void testGetNumberWithLeadingZeroesAsStringDefault() {
+		String formattedString = this.germplasmNamingService.getNumberWithLeadingZeroesAsString(1, 0);
+		Assert.assertEquals("1", formattedString);
+
+		formattedString = this.germplasmNamingService.getNumberWithLeadingZeroesAsString(1, null);
+		Assert.assertEquals("1", formattedString);
+	}
+
+	@Test
+	public void testGetNumberWithLeadingZeroesAsStringWithNumOfDigitsSpecified() {
+		final String formattedString = this.germplasmNamingService.getNumberWithLeadingZeroesAsString(123, 8);
+		Assert.assertEquals("00000123", formattedString);
+	}
+
+	@Test
+	public void testGetNumberWithLeadingZeroesAsStringNumberGreaterThanhNumOfDigitsSpecified() {
+		final String formattedString = this.germplasmNamingService.getNumberWithLeadingZeroesAsString(123, 2);
+		Assert.assertEquals("123", formattedString);
+	}
+
+	@Test
+	public void testGetNextNameInSequenceWithNullStartNumber() {
+		String nextNameInSequence = "";
+		try {
+			nextNameInSequence = this.germplasmNamingService.getNextNameInSequence(this.germplasmNameSetting);
+		} catch (final InvalidGermplasmNameSettingException e) {
+			Assert.fail("Not expecting InvalidGermplasmNameSettingException to be thrown but was thrown.");
+		}
+		Assert.assertEquals(this.buildExpectedNextName(), nextNameInSequence);
+	}
+
+	@Test
+	public void testGetNextNameInSequenceWithZeroStartNumber() {
+		final GermplasmNameSetting setting = this.createGermplasmNameSetting();
+		setting.setStartNumber(0);
+		String nextNameInSequence = "";
+		try {
+			nextNameInSequence = this.germplasmNamingService.getNextNameInSequence(setting);
+		} catch (final InvalidGermplasmNameSettingException e) {
+			Assert.fail("Not expecting InvalidGermplasmNameSettingException to be thrown but was thrown.");
+		}
+		Assert.assertEquals(this.buildExpectedNextName(), nextNameInSequence);
+	}
+
+	private String buildExpectedNextName() {
+		return GermplasmNamingServiceImplTest.PREFIX + " 00000" + NEXT_NUMBER + " "
+			+ GermplasmNamingServiceImplTest.SUFFIX;
+	}
+
+	@Test
+	public void testGetNextNameInSequenceWhenSpecifiedSequenceStartingNumberIsGreater() {
+		final GermplasmNameSetting setting = this.createGermplasmNameSetting();
+		final int startNumber = 1000;
+		setting.setStartNumber(startNumber);
+		String nextNameInSequence = "";
+		try {
+			nextNameInSequence = this.germplasmNamingService.getNextNameInSequence(setting);
+		} catch (final InvalidGermplasmNameSettingException e) {
+			Assert.fail("Not expecting InvalidGermplasmNameSettingException to be thrown but was thrown.");
+		}
+		Assert.assertEquals("The specified starting sequence number will be used since it's larger.",
+			GermplasmNamingServiceImplTest.PREFIX + " 000" + startNumber + " " + GermplasmNamingServiceImplTest.SUFFIX,
+			nextNameInSequence);
+	}
+
+	@Test
+	public void testGetNextNameInSequenceWhenSpecifiedSequenceStartingNumberIsLower() {
+		final GermplasmNameSetting setting = this.createGermplasmNameSetting();
+		final int startNumber = GermplasmNamingServiceImplTest.NEXT_NUMBER - 1;
+		setting.setStartNumber(startNumber);
+		try {
+			this.germplasmNamingService.getNextNameInSequence(setting);
+			Assert.fail("Expecting InvalidGermplasmNameSettingException to be thrown but was not.");
+		} catch (final InvalidGermplasmNameSettingException e) {
+			Assert.assertEquals(
+				"Starting sequence number should be higher than or equal to next name in the sequence: " + this.buildExpectedNextName()
+					+ ".", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testGetNextNumberAndIncrementSequence() {
+		final int nextNumber = this.germplasmNamingService.getNextNumberAndIncrementSequence(PREFIX);
+		Assert.assertEquals(GermplasmNamingServiceImplTest.NEXT_NUMBER.intValue(), nextNumber);
+		Mockito.verify(this.keySequenceRegisterService).getNextSequence(PREFIX);
+		Mockito.verify(this.keySequenceRegisterService).saveLastSequenceUsed(PREFIX, nextNumber);
+		Mockito.verifyZeroInteractions(this.germplasmDataManager);
+	}
+
+	private GermplasmNameSetting createGermplasmNameSetting() {
+		final GermplasmNameSetting setting = new GermplasmNameSetting();
+
+		setting.setPrefix(GermplasmNamingServiceImplTest.PREFIX);
+		setting.setSuffix(GermplasmNamingServiceImplTest.SUFFIX);
+		setting.setAddSpaceBetweenPrefixAndCode(true);
+		setting.setAddSpaceBetweenSuffixAndCode(true);
+		setting.setNumOfDigits(7);
+
+		return setting;
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/impl/ProcessCodeFactoryTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/impl/ProcessCodeFactoryTest.java
@@ -1,0 +1,37 @@
+package org.generationcp.middleware.ruleengine.naming.impl;
+
+import org.generationcp.middleware.ruleengine.naming.expression.FirstExpression;
+import org.generationcp.middleware.ruleengine.naming.expression.SeasonExpression;
+import org.generationcp.middleware.ruleengine.naming.expression.SequenceExpression;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ProcessCodeFactoryTest {
+
+	private static final String KEY1 = "[SEQUENCE]";
+	private static final String KEY2 = "[FIRST]";
+	private static final String[] KEYS = {KEY1, KEY2};
+
+	private final ProcessCodeFactory factory = new ProcessCodeFactory();
+
+	@Before
+	public void init() {
+
+		this.factory.init();
+		this.factory.addExpression(new SeasonExpression());
+		this.factory.addExpression(new SequenceExpression());
+		this.factory.addExpression(new FirstExpression());
+	}
+
+	@Test
+	public void testLookup() {
+		for (final String key : ProcessCodeFactoryTest.KEYS) {
+			Assert.assertNotNull(this.factory.lookup(key));
+			Assert.assertNull(this.factory.lookup(""));
+
+		}
+
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/BaseNamingRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/BaseNamingRuleTest.java
@@ -1,0 +1,28 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import org.generationcp.middleware.ruleengine.naming.service.ProcessCodeService;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.annotation.Resource;
+import java.util.List;
+
+/**
+ * Created by IntelliJ IDEA. User: Daniel Villafuerte Date: 2/13/2015 Time: 6:02 PM
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:BaseNamingRuleTest-context.xml", "classpath:testContext.xml"})
+public abstract class BaseNamingRuleTest {
+
+	@Resource
+	protected ProcessCodeService processCodeService;
+
+	protected AdvancingSource row;
+
+	protected NamingRuleExecutionContext createExecutionContext(List<String> input) {
+		return new NamingRuleExecutionContext(null, this.processCodeService, this.row, null, input);
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/CountRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/CountRuleTest.java
@@ -1,0 +1,151 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.ruleengine.Rule;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.RuleExecutionContext;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CountRuleTest extends BaseNamingRuleTest {
+
+	private Rule rule;
+	private Method breedingMethod;
+	private Integer breedingMethodSnameType;
+	private String name;
+
+	@Before
+	public void setUp() {
+		this.breedingMethodSnameType = 5;
+		this.breedingMethod = new Method();
+		this.breedingMethod.setSnametype(this.breedingMethodSnameType);
+		this.breedingMethod.setSeparator("-");
+		this.breedingMethod.setCount("");
+		this.row = new AdvancingSource();
+		this.row.setBreedingMethod(this.breedingMethod);
+		this.rule = new CountRule();
+
+		this.name = "TestGP";
+	}
+
+	@Test
+	public void testNoCountMethodInRule() {
+		this.breedingMethod.setCount(null);
+
+		List<String> testCurrentInput = new ArrayList<>();
+		testCurrentInput.add(this.name);
+
+		RuleExecutionContext context = this.createExecutionContext(testCurrentInput);
+
+		try {
+
+			this.rule.runRule(context);
+			List<String> output = (List<String>) context.getRuleExecutionOutput();
+			Assert.assertEquals(testCurrentInput.size(), output.size());
+
+			Assert.assertEquals("No changes should be made to current input if no count method is available", this.name, output.get(0));
+
+		} catch (RuleException re) {
+			Assert.fail("Rule failed to run for Count" + this.row.getBreedingMethod().getCount());
+		}
+	}
+
+	@Test
+	public void testNumberCount() {
+		this.row.setPlantsSelected(3);
+		this.setBulking(this.breedingMethod, true);
+
+		List<String> input = new ArrayList<String>();
+
+		input.add(this.name);
+		RuleExecutionContext context = this.createExecutionContext(input);
+
+		try {
+			this.rule.runRule(context);
+			input = (List<String>) context.getRuleExecutionOutput();
+			Assert.assertEquals(1, input.size());
+			Assert.assertEquals("Should return the correct countr", "TestGP", input.get(0));
+
+		} catch (RuleException re) {
+			Assert.fail("Rule failed to run for Count" + this.row.getBreedingMethod().getCount());
+		}
+	}
+
+	@Test
+	public void testNumberCountNoPlantsSelected() {
+		this.row.setPlantsSelected(0);
+		this.setBulking(this.breedingMethod, true);
+
+		List<String> input = new ArrayList<String>();
+		input.add(this.name);
+
+		RuleExecutionContext context = this.createExecutionContext(input);
+
+		try {
+			this.rule.runRule(context);
+
+			input = (List<String>) context.getRuleExecutionOutput();
+
+			Assert.assertEquals(1, input.size());
+			Assert.assertEquals("Should return the correct countr", "TestGP", input.get(0));
+		} catch (RuleException re) {
+			Assert.fail("Rule failed to run for Count" + this.row.getBreedingMethod().getCount());
+		}
+
+	}
+
+	@Test
+	public void testSequenceCountNoPlantsSelected() {
+		this.row.setPlantsSelected(0);
+		this.setBulking(this.breedingMethod, false);
+		List<String> input = new ArrayList<String>();
+		input.add(this.name);
+
+		RuleExecutionContext context = this.createExecutionContext(input);
+		try {
+			input = (List<String>) this.rule.runRule(context);
+			Assert.assertEquals(1, input.size());
+			Assert.assertEquals("Should return the correct countr", "TestGP", input.get(0));
+		} catch (RuleException re) {
+			Assert.fail("Rule failed to run for Count" + this.row.getBreedingMethod().getCount());
+		}
+
+	}
+
+	@Test
+	public void testSequenceCount() {
+		this.row.setPlantsSelected(3);
+		this.row.setBreedingMethod(this.setBulking(this.breedingMethod, false));
+		List<String> input = new ArrayList<String>();
+		input.add(this.name);
+
+		RuleExecutionContext context = this.createExecutionContext(input);
+		try {
+			input = (List<String>) this.rule.runRule(context);
+
+			Assert.assertEquals(1, input.size());
+			Assert.assertEquals("Should return the correct countr", "TestGP", input.get(0));
+		} catch (RuleException re) {
+			Assert.fail("Rule failed to run for Count" + this.row.getBreedingMethod().getCount());
+		}
+
+	}
+
+	private Method setBulking(Method method, boolean isBulking) {
+
+		if (isBulking) {
+			method.setGeneq(TermId.BULKING_BREEDING_METHOD_CLASS.getId());
+		} else {
+			method.setGeneq(TermId.NON_BULKING_BREEDING_METHOD_CLASS.getId());
+		}
+		return method;
+
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/EnforceUniqueNameRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/EnforceUniqueNameRuleTest.java
@@ -1,0 +1,205 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import org.generationcp.middleware.exceptions.MiddlewareQueryException;
+import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.pojo.AdvanceGermplasmChangeDetail;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.MessageSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by IntelliJ IDEA. User: Daniel Villafuerte Date: 2/17/2015 Time: 3:17 PM
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class EnforceUniqueNameRuleTest {
+
+	public static final int TEST_MAX_SEQUENCE = 0;
+	public static final int ENFORCE_RULE_INDEX = 1;
+
+	private EnforceUniqueNameRule dut;
+
+	@Mock
+	private GermplasmDataManager germplasmDataManager;
+
+	@Mock
+	private AdvancingSource source;
+
+	@Mock
+	private Method breedingMethod;
+
+	@Mock
+	private NamingRuleExecutionContext context;
+
+	private List<String> tempData;
+
+	@Before
+	public void setUp() throws Exception {
+		this.dut = new EnforceUniqueNameRule();
+	}
+
+	@Test
+	public void testUniqueNameCheckNoMatch() throws MiddlewareQueryException, RuleException {
+
+		this.setupTestExecutionContext();
+		Mockito.when(this.germplasmDataManager.checkIfMatches(Matchers.anyString())).thenReturn(false);
+		this.dut.runRule(this.context);
+
+		Mockito.verify(this.context, Mockito.never()).setCurrentData(this.tempData);
+		Mockito.verify(this.source, Mockito.never()).setCurrentMaxSequence(EnforceUniqueNameRuleTest.TEST_MAX_SEQUENCE + 1);
+		Mockito.verify(this.source, Mockito.never()).setChangeDetail(Matchers.any(AdvanceGermplasmChangeDetail.class));
+	}
+
+	@Test
+	public void testUniqueNameCheckMatchFoundNoCount() throws MiddlewareQueryException, RuleException {
+
+		this.setupTestExecutionContext();
+		Mockito.when(this.germplasmDataManager.checkIfMatches(Matchers.anyString())).thenReturn(true);
+		this.dut.runRule(this.context);
+
+		// verify that current rule execution state is pointed back to previous stored data
+		Mockito.verify(this.context).setCurrentData(this.tempData);
+		Mockito.verify(this.source).setChangeDetail(Matchers.any(AdvanceGermplasmChangeDetail.class));
+
+		// verify that force unique name generation flag is set
+		Mockito.verify(this.source).setForceUniqueNameGeneration(true);
+		// verify that default count rule is provided so that count rule execution will proceed
+		Mockito.verify(this.breedingMethod).setCount(CountRule.DEFAULT_COUNT);
+	}
+
+	@Test
+	public void testUniqueNameCheckMatchFoundFlagSet() throws MiddlewareQueryException, RuleException {
+
+		this.setupTestExecutionContext();
+		Mockito.when(this.germplasmDataManager.checkIfMatches(Matchers.anyString())).thenReturn(true);
+		Mockito.when(this.source.isForceUniqueNameGeneration()).thenReturn(true);
+		this.dut.runRule(this.context);
+
+		// verify that current rule execution state is pointed back to previous stored data
+		Mockito.verify(this.context).setCurrentData(this.tempData);
+		Mockito.verify(this.source).setChangeDetail(Matchers.any(AdvanceGermplasmChangeDetail.class));
+
+		// verify that max sequence is incremented
+		Mockito.verify(this.source).setCurrentMaxSequence(EnforceUniqueNameRuleTest.TEST_MAX_SEQUENCE + 1);
+
+	}
+
+	@Test
+	public void testUniqueNameCheckMatchFoundIsBulking() throws MiddlewareQueryException, RuleException {
+
+		this.setupTestExecutionContext();
+		Mockito.when(this.germplasmDataManager.checkIfMatches(Matchers.anyString())).thenReturn(true);
+
+		this.dut.runRule(this.context);
+
+		// verify that current rule execution state is pointed back to previous stored data
+		Mockito.verify(this.context).setCurrentData(this.tempData);
+		Mockito.verify(this.source).setChangeDetail(Matchers.any(AdvanceGermplasmChangeDetail.class));
+
+		// verify that force unique name generation flag is set
+		Mockito.verify(this.source).setForceUniqueNameGeneration(true);
+	}
+
+	@Test
+	public void testUniqueNameCheckMatchFoundHasCountNonBulking() throws MiddlewareQueryException, RuleException {
+
+		this.setupTestExecutionContext();
+		Mockito.when(this.germplasmDataManager.checkIfMatches(Matchers.anyString())).thenReturn(true);
+		Mockito.when(this.breedingMethod.getCount()).thenReturn(CountRule.DEFAULT_COUNT);
+
+		this.dut.runRule(this.context);
+
+		// verify that max sequence is incremented
+		Mockito.verify(this.source).setCurrentMaxSequence(EnforceUniqueNameRuleTest.TEST_MAX_SEQUENCE + 1);
+
+		// verify that current rule execution state is pointed back to previous stored data
+		Mockito.verify(this.context).setCurrentData(this.tempData);
+		Mockito.verify(this.source).setChangeDetail(Matchers.any(AdvanceGermplasmChangeDetail.class));
+
+		// verify that flag is not set so as to preserve previous count rule logic when incrementing the count
+		Mockito.verify(this.source, Mockito.never()).setForceUniqueNameGeneration(true);
+	}
+
+	@Test
+	public void testGetNextStepKeyNoMatchFound() throws Exception {
+		this.setupTestExecutionContext();
+
+		// when no duplicate is found, a change detail object is not created in the advancing source. we simulate that state here
+		Mockito.when(this.source.getChangeDetail()).thenReturn(null);
+
+		String nextKey = this.dut.getNextRuleStepKey(this.context);
+
+		Assert.assertNull("Expected next key is null because unique name check is last in sequence and unique name check should pass",
+				nextKey);
+	}
+
+	@Test
+	public void testGetNextStepKeyDuplicateFoundCheckFail() throws Exception {
+		this.setupTestExecutionContext();
+		AdvanceGermplasmChangeDetail detail = Mockito.mock(AdvanceGermplasmChangeDetail.class);
+
+		Mockito.when(this.source.getChangeDetail()).thenReturn(detail);
+		// if a duplicate has been found in previous steps, and a passing name has not yet been found, then the new advance name should
+		// still be null on the germplasm change detail object
+		Mockito.when(detail.getNewAdvanceName()).thenReturn(null);
+
+		String nextKey = this.dut.getNextRuleStepKey(this.context);
+
+		Assert.assertNotNull("Duplicate has been found and check still fails, so next key should not be null", nextKey);
+		Assert.assertEquals("Rule does not pass execution control to CountRule even after failing the check", CountRule.KEY, nextKey);
+	}
+
+	@Test
+	public void testGetNextStepKeyDuplicateFoundCheckPass() throws Exception {
+		this.setupTestExecutionContext();
+		AdvanceGermplasmChangeDetail detail = Mockito.mock(AdvanceGermplasmChangeDetail.class);
+
+		Mockito.when(this.source.getChangeDetail()).thenReturn(detail);
+		// if a duplicate has been found in previous steps, and a passing name has been found, then the new advance name should not be null
+		Mockito.when(detail.getNewAdvanceName()).thenReturn(new String());
+
+		String nextKey = this.dut.getNextRuleStepKey(this.context);
+
+		Assert.assertNull("Duplicate has been found and but check passes, so next key should be null", nextKey);
+
+	}
+
+	protected void setupTestExecutionContext() {
+		List<String> dummySequenceOrder = new ArrayList<>();
+		dummySequenceOrder.add(CountRule.KEY);
+		dummySequenceOrder.add(EnforceUniqueNameRule.KEY);
+
+		List<String> dummyInitialState = new ArrayList<>();
+		dummyInitialState.add("ETFN 1-1");
+		dummyInitialState.add("ETFN 1-2");
+
+		this.tempData = new ArrayList<>();
+		this.tempData.add("ETFN 1-");
+
+		Mockito.when(this.context.getAdvancingSource()).thenReturn(this.source);
+		Mockito.when(this.context.getGermplasmDataManager()).thenReturn(this.germplasmDataManager);
+		Mockito.when(this.context.getExecutionOrder()).thenReturn(dummySequenceOrder);
+		Mockito.when(this.context.getCurrentData()).thenReturn(dummyInitialState);
+		Mockito.when(this.context.getTempData()).thenReturn(this.tempData);
+		Mockito.when(this.context.getMessageSource()).thenReturn(Mockito.mock(MessageSource.class));
+
+		Mockito.when(this.source.getBreedingMethod()).thenReturn(this.breedingMethod);
+		Mockito.when(this.source.getCurrentMaxSequence()).thenReturn(EnforceUniqueNameRuleTest.TEST_MAX_SEQUENCE);
+
+		Mockito.when(this.context.getCurrentExecutionIndex()).thenReturn(EnforceUniqueNameRuleTest.ENFORCE_RULE_INDEX);
+
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/PrefixRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/PrefixRuleTest.java
@@ -1,0 +1,67 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import junit.framework.Assert;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PrefixRuleTest extends BaseNamingRuleTest {
+
+	private PrefixRule rule;
+	private Method breedingMethod;
+	private String testGermplasmName;
+	private Integer breedingMethodSnameType;
+
+	@Before
+	public void setUp() {
+
+		this.breedingMethodSnameType = 5;
+		this.breedingMethod = new Method();
+		this.breedingMethod.setSnametype(this.breedingMethodSnameType);
+		this.row = new AdvancingSource();
+		this.row.setBreedingMethod(this.breedingMethod);
+		this.testGermplasmName = "CMT1234-";
+		this.rule = new PrefixRule();
+	}
+
+	@Test
+	public void testPrefixGenerationSimple() {
+		this.breedingMethod.setPrefix("B");
+		List<String> input = new ArrayList<String>();
+		input.add(this.testGermplasmName);
+
+		try {
+			input = (List<String>) this.rule.runRule(this.createExecutionContext(input));
+		} catch (RuleException re) {
+			Assert.fail("Rule failed to run for Prefix" + this.row.getBreedingMethod().getSeparator());
+		}
+		System.out.println(input.get(0));
+		Assert.assertEquals(1, input.size());
+		Assert.assertEquals("Should return the correct name appended with prefix text", this.testGermplasmName
+				+ this.row.getBreedingMethod().getPrefix(), input.get(0));
+	}
+
+	@Test
+	public void testSeasonCodePrefix() {
+		this.breedingMethod.setPrefix("Wet");
+		this.row.setSeason("Wet");
+		List<String> input = new ArrayList<String>();
+		input.add(this.testGermplasmName);
+		try {
+			input = (List<String>) this.rule.runRule(this.createExecutionContext(input));
+		} catch (RuleException re) {
+			Assert.fail("Rule failed to run for Prefix" + this.row.getBreedingMethod().getSeparator());
+		}
+		System.out.println(input.get(0));
+		Assert.assertEquals(1, input.size());
+		Assert.assertEquals("Should return the correct name appended with prefix text", this.testGermplasmName + this.row.getSeason(),
+				input.get(0));
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/RootNameGeneratorRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/RootNameGeneratorRuleTest.java
@@ -1,0 +1,90 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.pojos.Name;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RootNameGeneratorRuleTest extends BaseNamingRuleTest {
+
+	private RootNameGeneratorRule rootNameGeneratorRule;
+	private Method breedingMethod;
+	private String testGermplasmName;
+	private Integer breedingMethodSnameType;
+
+	@Before
+	public void setUp() {
+		this.breedingMethodSnameType = 5;
+		this.breedingMethod = new Method();
+		this.breedingMethod.setSnametype(this.breedingMethodSnameType);
+		this.row = new AdvancingSource();
+		this.row.setBreedingMethod(this.breedingMethod);
+		this.testGermplasmName = "advance-germplasm-name";
+		this.rootNameGeneratorRule = new RootNameGeneratorRule();
+
+	}
+
+	private Name generateNewName(Integer typeId, Integer nStat) {
+		Name name = new Name();
+		name.setTypeId(typeId);
+		name.setNstat(nStat);
+		name.setNval(this.testGermplasmName);
+		return name;
+	}
+
+	@Test
+	public void testGetGermplasmRootNameWithTheSameSnameTypeWithMethod() {
+		List<Name> names = new ArrayList<Name>();
+		names.add(this.generateNewName(this.breedingMethodSnameType, 1));
+		this.row.setNames(names);
+		List<String> input = new ArrayList<String>();
+
+		try {
+			input = (List<String>) this.rootNameGeneratorRule.runRule(this.createExecutionContext(input));
+		} catch (RuleException re) {
+			Assert.fail("Should return the correct root name if the methd snametype is equal to the names' type id");
+		}
+
+		Assert.assertEquals(1, input.size());
+		Assert.assertEquals("Should return the correct root name if the methd snametype is equal to the names' type id",
+				this.testGermplasmName, input.get(0));
+	}
+
+	// @Test
+	// public void testGetGermplasmRootNameWithTheDifferentSnameTypeWithMethodButWithNstatEqualTo1(){
+	// List<Name> names = new ArrayList<Name>();
+	// names.add(generateNewName(2, 1));
+	// row.setNames(names);
+	// List<String> input = new ArrayList<String>();
+	// try{
+	// rootName = namingConventionService.getGermplasmRootName(breedingMethodSnameType, row);
+	// }catch(RuleException re){
+	// Assert.fail("Should return the correct root name if the methd snametype is equal to the names' type id");
+	// }
+	// Assert.assertEquals("Should return the correct root name if the names' nstat is equal to 1", testGermplasmName, rootName);
+	// }
+
+	// @Test
+	// public void testGetGermplasmRootNameWithTheDifferentSnameTypeWithMethodWithnstatNotEqualTo1(){
+	// List<Name> names = new ArrayList<Name>();
+	// names.add(generateNewName( 2, 0));
+	// row.setNames(names);
+	// row.setGermplasm(new ImportedGermplasm());
+	// boolean throwsException = false;
+	// try{
+	// namingConventionService.getGermplasmRootName(breedingMethodSnameType, row);
+	// }catch(MiddlewareQueryException e){
+	// throwsException = true;
+	// }catch(NoSuchMessageException e){
+	// throwsException = true;
+	// }
+	// Assert.assertTrue("Should throw an exception if there is no germplasm root name retrieved", throwsException);
+	// }
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/SeparatorRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/SeparatorRuleTest.java
@@ -1,0 +1,69 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import junit.framework.Assert;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SeparatorRuleTest extends BaseNamingRuleTest {
+
+	private SeparatorRule rule;
+	private Method breedingMethod;
+	private String testGermplasmName;
+	private Integer breedingMethodSnameType;
+
+	@Before
+	public void setUp() {
+		this.breedingMethodSnameType = 5;
+		this.breedingMethod = new Method();
+		this.breedingMethod.setSnametype(this.breedingMethodSnameType);
+		this.breedingMethod.setSeparator("-");
+		this.row = new AdvancingSource();
+		this.row.setBreedingMethod(this.breedingMethod);
+		this.testGermplasmName = "CMT1234";
+		this.rule = new SeparatorRule();
+
+	}
+
+	@Test
+	public void testGetGermplasmRootNameWithTheSameSnameTypeWithMethod() {
+
+		List<String> input = new ArrayList<String>();
+		input.add(this.testGermplasmName);
+
+		try {
+			input = (List<String>) this.rule.runRule(this.createExecutionContext(input));
+		} catch (RuleException re) {
+			Assert.fail("Rule failed to run for Separator" + this.row.getBreedingMethod().getSeparator());
+		}
+
+		Assert.assertEquals(1, input.size());
+		Assert.assertEquals("Should return the correct name appended with a separator", this.testGermplasmName
+				+ this.row.getBreedingMethod().getSeparator(), input.get(0));
+	}
+
+	@Test
+	public void testGetGermplasmRootNameWithNullSeparator() {
+
+		List<String> input = new ArrayList<String>();
+		input.add(this.testGermplasmName);
+
+		this.breedingMethod.setSeparator(null);
+
+		try {
+			input = (List<String>) this.rule.runRule(this.createExecutionContext(input));
+		} catch (RuleException re) {
+			Assert.fail("Rule failed to run for Separator" + this.row.getBreedingMethod().getSeparator());
+		}
+
+		Assert.assertEquals(1, input.size());
+		Assert.assertEquals("Should return the correct name appended with a blank separator", this.testGermplasmName, input.get(0));
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/SuffixRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/naming/rules/SuffixRuleTest.java
@@ -1,0 +1,53 @@
+
+package org.generationcp.middleware.ruleengine.naming.rules;
+
+import junit.framework.Assert;
+import org.generationcp.middleware.pojos.Method;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.ruleengine.naming.impl.ProcessCodeServiceImpl;
+import org.generationcp.middleware.ruleengine.pojo.AdvancingSource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SuffixRuleTest extends BaseNamingRuleTest {
+
+	private SuffixRule rule;
+	private Method breedingMethod;
+	private String testGermplasmName;
+	private Integer breedingMethodSnameType;
+
+	@Before
+	public void setUp() {
+		this.processCodeService = new ProcessCodeServiceImpl();
+		this.breedingMethodSnameType = 5;
+		this.breedingMethod = new Method();
+		this.breedingMethod.setSnametype(this.breedingMethodSnameType);
+		this.breedingMethod.setSuffix("test-suffix");
+		this.row = new AdvancingSource();
+		this.row.setBreedingMethod(this.breedingMethod);
+		this.testGermplasmName = "CMT1234-B-3-";
+		this.rule = new SuffixRule();
+	}
+
+	@Test
+	public void testPrefixGenerationSimple() {
+
+		List<String> input = new ArrayList<String>();
+		input.add(this.testGermplasmName);
+
+		try {
+			input = (List<String>) this.rule.runRule(this.createExecutionContext(input));
+		} catch (RuleException re) {
+			Assert.fail("Rule failed to run for Prefix" + this.row.getBreedingMethod().getSuffix());
+		}
+
+		Assert.assertEquals(1, input.size());
+		;
+		Assert.assertEquals("Should return the correct name appended with prefix text", this.testGermplasmName
+				+ this.row.getBreedingMethod().getSuffix(), input.get(0));
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/resolver/HabitatDesignationResolverTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/resolver/HabitatDesignationResolverTest.java
@@ -1,0 +1,147 @@
+package org.generationcp.middleware.ruleengine.resolver;
+
+import com.google.common.collect.Lists;
+import org.generationcp.middleware.ContextHolder;
+import org.generationcp.middleware.domain.etl.MeasurementData;
+import org.generationcp.middleware.domain.etl.MeasurementRow;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.etl.StudyDetails;
+import org.generationcp.middleware.domain.etl.Workbook;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.domain.oms.TermSummary;
+import org.generationcp.middleware.domain.ontology.Scale;
+import org.generationcp.middleware.domain.ontology.Variable;
+import org.generationcp.middleware.domain.study.StudyTypeDto;
+import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.generationcp.middleware.ruleengine.resolver.SeasonResolverTest.getMeasurementVariableByTermId;
+import static org.generationcp.middleware.service.api.dataset.ObservationUnitUtils.fromMeasurementRow;
+
+public class HabitatDesignationResolverTest {
+
+	@Mock
+	private OntologyVariableDataManager ontologyVariableDataManager;
+
+	private static final Integer HABITAT_CATEGORY_ID = 3002;
+	private static final String HABITAT_CATEGORY_VALUE = "Habitat_Designation";
+	private static final String PROGRAM_UUID = UUID.randomUUID().toString();
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		ContextHolder.setCurrentCrop("maize");
+		ContextHolder.setCurrentProgram(PROGRAM_UUID);
+
+		final Variable variable = new Variable();
+		final Scale seasonScale = new Scale();
+		final TermSummary categories = new TermSummary(HABITAT_CATEGORY_ID, HABITAT_CATEGORY_VALUE, HABITAT_CATEGORY_VALUE);
+		seasonScale.addCategory(categories);
+		variable.setScale(seasonScale);
+		Mockito.when(this.ontologyVariableDataManager.getVariable(ArgumentMatchers.eq(PROGRAM_UUID),
+			ArgumentMatchers.eq(TermId.HABITAT_DESIGNATION.getId()), ArgumentMatchers.eq(true))).thenReturn(variable);
+	}
+
+	@Test
+	public void testResolveForNurseryWithHabitatVariableAndValue() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(new StudyTypeDto("N"));
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable measurementVariable = new MeasurementVariable();
+		measurementVariable.setTermId(TermId.HABITAT_DESIGNATION.getId());
+		measurementVariable.setValue(HABITAT_CATEGORY_ID.toString());
+
+		workbook.setConditions(Lists.newArrayList(measurementVariable));
+
+		final MeasurementRow trialInstanceObservation = workbook.getTrialObservationByTrialInstanceNo(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final HabitatDesignationResolver habitatDesignationResolver =
+			new HabitatDesignationResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+		final String designation = habitatDesignationResolver.resolve();
+		Assert.assertEquals("Habitat Designation should be resolved to the value of Habitat_Designation variable value in Nursery settings.",
+				HABITAT_CATEGORY_VALUE, designation);
+
+	}
+
+	@Test
+	public void testResolveForTrialWithHabitatVariableAndValue() {
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1HabitatMV = new MeasurementVariable();
+		instance1HabitatMV.setTermId(TermId.HABITAT_DESIGNATION.getId());
+		final MeasurementData instance1Habitat = new MeasurementData();
+		instance1Habitat.setValue(HABITAT_CATEGORY_VALUE);
+		instance1Habitat.setMeasurementVariable(instance1HabitatMV);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final MeasurementData instance1MD = new MeasurementData();
+		instance1MD.setValue("1");
+		instance1MD.setMeasurementVariable(instance1MV);
+
+		final MeasurementRow trialInstanceObservation = new MeasurementRow();
+		trialInstanceObservation.setDataList(Lists.newArrayList(instance1MD, instance1Habitat));
+
+		workbook.setTrialObservations(Lists.newArrayList(trialInstanceObservation));
+		
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final HabitatDesignationResolver habitatDesignationResolver =
+			new HabitatDesignationResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+		final String season = habitatDesignationResolver.resolve();
+		Assert.assertEquals("Habitat Designation should be resolved to the value of Habitat_Designation variable value in environment level settings.",
+				HABITAT_CATEGORY_VALUE, season);
+	}
+	
+	@Test
+	public void testResolveForStudyWithHabitatConditions() {
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1HabitatMV = new MeasurementVariable();
+		instance1HabitatMV.setTermId(TermId.HABITAT_DESIGNATION.getId());
+		instance1HabitatMV.setValue(HABITAT_CATEGORY_VALUE);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		instance1MV.setValue("1");
+		
+		final MeasurementRow trialInstanceObservation = null;
+
+		final List<MeasurementVariable> conditions = new ArrayList<MeasurementVariable>();
+		conditions.add(instance1MV);
+		conditions.add(instance1HabitatMV);
+		workbook.setConditions(conditions );
+
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final HabitatDesignationResolver habitatDesignationResolver =
+			new HabitatDesignationResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+		final String season = habitatDesignationResolver.resolve();
+		Assert.assertEquals("Habitat Designation should be resolved to the value of Habitat_Designation variable value in environment level settings.",
+				HABITAT_CATEGORY_VALUE, season);
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/resolver/LocationResolverTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/resolver/LocationResolverTest.java
@@ -1,0 +1,429 @@
+
+package org.generationcp.middleware.ruleengine.resolver;
+
+import com.google.common.collect.Lists;
+import org.generationcp.middleware.domain.etl.MeasurementData;
+import org.generationcp.middleware.domain.etl.MeasurementRow;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.etl.StudyDetails;
+import org.generationcp.middleware.domain.etl.Workbook;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.domain.study.StudyTypeDto;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.generationcp.middleware.service.api.dataset.ObservationUnitUtils.fromMeasurementRow;
+
+public class LocationResolverTest {
+
+	final Map<String, String> locationIdNameMap = new HashMap<>();
+
+	@Before
+	public void init() {
+		locationIdNameMap.put("1001", "INTERNATIONAL FOOD POLICY RESEARCH INSTITUTE, WASHINGTON - (IFPRI)");
+	}
+
+	@Test
+	public void testResolveForNurseryWithLocationVariableAndValue() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getNurseryDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable locationMV = new MeasurementVariable();
+		locationMV.setTermId(TermId.LOCATION_ABBR.getId());
+		locationMV.setValue("MEX");
+
+		workbook.setConditions(Lists.newArrayList(locationMV));
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location = new LocationResolver(conditions, null, locationIdNameMap).resolve();
+		Assert.assertEquals("Location should be resolved to the value of LOCATION_ABBR variable value in Nursery settings.", "MEX",
+				location);
+	}
+
+	@Test
+	public void testResolveForNurseryWithLocationVariableButNoValue() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getNurseryDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable locationMV = new MeasurementVariable();
+		locationMV.setTermId(TermId.LOCATION_ABBR.getId());
+
+		workbook.setConditions(Lists.newArrayList(locationMV));
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location = new LocationResolver(conditions, null, locationIdNameMap).resolve();
+		Assert.assertEquals("Location should be defaulted to an empty string when LOCATION_ABBR variable is present but has no value.", "",
+				location);
+	}
+
+	@Test
+	public void testLocationForNurseryWithoutLocationVariable() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getNurseryDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location = new LocationResolver(conditions, null, locationIdNameMap).resolve();
+		Assert.assertEquals("Location should be defaulted to an empty string when LOCATION_ABBR variable is not present.", "", location);
+	}
+
+	@Test
+	public void testResolveForNurseryWithLocationAbbreviationAndLocationName() {
+		final String locationAbbr = "MEX";
+		final String nurseryLocation = "INTERNATIONAL FOOD POLICY RESEARCH INSTITUTE, WASHINGTON - (IFPRI)";
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getNurseryDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1LocationAbbrMV = new MeasurementVariable();
+		instance1LocationAbbrMV.setTermId(TermId.LOCATION_ABBR.getId());
+		instance1LocationAbbrMV.setValue(locationAbbr);
+
+		final MeasurementVariable instance1LocationNameMV = new MeasurementVariable();
+		instance1LocationNameMV.setTermId(TermId.TRIAL_LOCATION.getId());
+		instance1LocationNameMV.setValue(nurseryLocation);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		instance1MV.setValue("1");
+
+		workbook.setConditions(Lists.newArrayList(instance1LocationAbbrMV, instance1LocationNameMV, instance1MV));
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location = new LocationResolver(conditions, null, locationIdNameMap).resolve();
+		Assert.assertEquals("Location should be resolved to the value of LOCATION_ABBR variable value in nursery settings.",
+				locationAbbr,
+				location);
+	}
+
+	@Test
+	public void testResolveForNurseryWithoutLocationVariable() {
+		final String trialInstance = "1";
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getNurseryDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		instance1MV.setValue("1");
+
+		workbook.setConditions(Lists.newArrayList(instance1MV));
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location = new LocationResolver(conditions, null, locationIdNameMap).resolve();
+		Assert.assertEquals(
+				"Location should be defaulted to TRIAL_INSTANCE when LOCATION_ABBR and LOCATION_NAME variables are not present in nursery settings.",
+				trialInstance, location);
+	}
+
+	@Test
+	public void testResolveForNurseryWithLocationName() {
+		final String nurseryLocation = "INTERNATIONAL FOOD POLICY RESEARCH INSTITUTE, WASHINGTON - (IFPRI)";
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getNurseryDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1LocationNameMV = new MeasurementVariable();
+		instance1LocationNameMV.setTermId(TermId.TRIAL_LOCATION.getId());
+		instance1LocationNameMV.setValue(nurseryLocation);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		instance1MV.setValue("1");
+
+		workbook.setConditions(Lists.newArrayList(instance1LocationNameMV, instance1MV));
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location = new LocationResolver(conditions, null, locationIdNameMap).resolve();
+		Assert.assertEquals("Location should be resolved to the value of LOCATION_NAME variable value in nursery settings.",
+				nurseryLocation,
+				location);
+	}
+
+	@Test
+	public void testResolveForStudyWithLocationVariableAndValue() {
+		final String locationAbbr = "MEX";
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1LocationAbbrMV = new MeasurementVariable();
+		instance1LocationAbbrMV.setTermId(TermId.LOCATION_ABBR.getId());
+		final MeasurementData instance1LocationAbbrMD = new MeasurementData();
+		instance1LocationAbbrMD.setValue(locationAbbr);
+		instance1LocationAbbrMD.setMeasurementVariable(instance1LocationAbbrMV);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final MeasurementData instance1MD = new MeasurementData();
+		instance1MD.setValue("1");
+		instance1MD.setMeasurementVariable(instance1MV);
+
+		final MeasurementRow instance1Measurements = new MeasurementRow();
+		instance1Measurements.setDataList(Lists.newArrayList(instance1MD, instance1LocationAbbrMD));
+
+		workbook.setTrialObservations(Lists.newArrayList(instance1Measurements));
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location =
+			new LocationResolver(conditions, fromMeasurementRow(instance1Measurements), locationIdNameMap).resolve();
+		Assert.assertEquals("Location should be resolved to the value of LOCATION_ABBR variable value in environment level settings.",
+				locationAbbr,
+				location);
+	}
+
+	@Test
+	public void testResolveForStudyWithLocationVariableButNoValue() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1LocationAbbrMV = new MeasurementVariable();
+		instance1LocationAbbrMV.setTermId(TermId.LOCATION_ABBR.getId());
+		final MeasurementData instance1LocationAbbrMD = new MeasurementData();
+		// No value
+		instance1LocationAbbrMD.setMeasurementVariable(instance1LocationAbbrMV);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final MeasurementData instance1MD = new MeasurementData();
+		instance1MD.setValue("1");
+		instance1MD.setMeasurementVariable(instance1MV);
+
+		final MeasurementRow instance1Measurements = new MeasurementRow();
+		instance1Measurements.setDataList(Lists.newArrayList(instance1MD, instance1LocationAbbrMD));
+
+		workbook.setTrialObservations(Lists.newArrayList(instance1Measurements));
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final MeasurementRow trailInstanceObservation = workbook.getTrialObservationByTrialInstanceNo(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location =
+			new LocationResolver(conditions, fromMeasurementRow(trailInstanceObservation), locationIdNameMap).resolve();
+		Assert.assertEquals(
+				"Location should be defaulted to an empty string when LOCATION_ABBR variable is present in environment level settings, but has no value.",
+				"",
+				location);
+	}
+
+	@Test
+	public void testResolveForStudyWithLocationAbbreviationAndLocationName() {
+		final String locationAbbr = "MEX";
+		final String studyLocation = "INTERNATIONAL FOOD POLICY RESEARCH INSTITUTE, WASHINGTON - (IFPRI)";
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1LocationAbbrMV = new MeasurementVariable();
+		instance1LocationAbbrMV.setTermId(TermId.LOCATION_ABBR.getId());
+		final MeasurementData instance1LocationAbbrMD = new MeasurementData();
+		instance1LocationAbbrMD.setValue(locationAbbr);
+		instance1LocationAbbrMD.setMeasurementVariable(instance1LocationAbbrMV);
+
+		final MeasurementVariable instance1LocationNameMV = new MeasurementVariable();
+		instance1LocationNameMV.setTermId(TermId.TRIAL_LOCATION.getId());
+		final MeasurementData instance1LocationNameMD = new MeasurementData();
+		instance1LocationNameMD.setValue(studyLocation);
+		instance1LocationNameMD.setMeasurementVariable(instance1LocationNameMV);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final MeasurementData instance1MD = new MeasurementData();
+		instance1MD.setValue("1");
+		instance1MD.setMeasurementVariable(instance1MV);
+
+		final MeasurementRow instance1Measurements = new MeasurementRow();
+		instance1Measurements.setDataList(Lists.newArrayList(instance1MD, instance1LocationAbbrMD));
+
+		workbook.setTrialObservations(Lists.newArrayList(instance1Measurements));
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location =
+			new LocationResolver(conditions, fromMeasurementRow(instance1Measurements), locationIdNameMap).resolve();
+		Assert.assertEquals("Location should be resolved to the value of LOCATION_ABBR variable value in environment level settings.",
+				locationAbbr,
+				location);
+	}
+
+	@Test
+	public void testResolveForStudyWithoutLocationVariable() {
+		final String trialInstance = "1";
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final MeasurementData instance1MD = new MeasurementData();
+		instance1MD.setValue(trialInstance);
+		instance1MD.setMeasurementVariable(instance1MV);
+		final MeasurementRow instance1Measurements = new MeasurementRow();
+		instance1Measurements.setDataList(Lists.newArrayList(instance1MD));
+
+		workbook.setTrialObservations(Lists.newArrayList(instance1Measurements));
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location =
+			new LocationResolver(conditions, fromMeasurementRow(instance1Measurements), locationIdNameMap).resolve();
+		Assert.assertEquals(
+				"Location should be defaulted to TRIAL_INSTANCE when LOCATION_ABBR and LOCATION_NAME variables are not present in environment level settings.",
+				trialInstance, location);
+	}
+
+	@Test
+	public void testResolveForStudyWithLocationName() {
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1LocationNameMV = new MeasurementVariable();
+		instance1LocationNameMV.setTermId(TermId.LOCATION_ID.getId());
+		final MeasurementData instance1LocationNameMD = new MeasurementData();
+		instance1LocationNameMD.setValue("1001");
+		instance1LocationNameMD.setMeasurementVariable(instance1LocationNameMV);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final MeasurementData instance1MD = new MeasurementData();
+		instance1MD.setValue("1");
+		instance1MD.setMeasurementVariable(instance1MV);
+
+		final MeasurementRow instance1Measurements = new MeasurementRow();
+		instance1Measurements.setDataList(Lists.newArrayList(instance1MD, instance1LocationNameMD));
+
+		workbook.setTrialObservations(Lists.newArrayList(instance1Measurements));
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location =
+			new LocationResolver(conditions, fromMeasurementRow(instance1Measurements), locationIdNameMap).resolve();
+		Assert.assertEquals("Location should be resolved to the value of LOCATION_NAME variable value in environment level settings.",
+				"INTERNATIONAL FOOD POLICY RESEARCH INSTITUTE, WASHINGTON - (IFPRI)",
+				location);
+	}
+
+	@Test
+	public void testResolveForStudyWithLocationNameFromSettings() {
+		final String studyLocation = "INTERNATIONAL FOOD POLICY RESEARCH INSTITUTE, WASHINGTON - (IFPRI)";
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1LocationNameMV = new MeasurementVariable();
+		instance1LocationNameMV.setTermId(TermId.TRIAL_LOCATION.getId());
+		instance1LocationNameMV.setValue(studyLocation);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final MeasurementData instance1MD = new MeasurementData();
+		instance1MD.setValue("1");
+		instance1MD.setMeasurementVariable(instance1MV);
+
+		final MeasurementRow instance1Measurements = new MeasurementRow();
+		instance1Measurements.setDataList(Lists.newArrayList(instance1MD));
+		workbook.setTrialObservations(Lists.newArrayList(instance1Measurements));
+
+		workbook.setConditions(Lists.newArrayList(instance1LocationNameMV));
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location =
+			new LocationResolver(conditions, fromMeasurementRow(instance1Measurements), locationIdNameMap).resolve();
+		Assert.assertEquals("Location should be resolved to the value of LOCATION_NAME variable value in Study settings.",
+				studyLocation,
+				location);
+	}
+
+	@Test
+	public void testResolveForStudyWithLocationNameFromEnvironmentAndLocationAbbrFromSettings() {
+		final String studyLocation = "INTERNATIONAL FOOD POLICY RESEARCH INSTITUTE, WASHINGTON - (IFPRI)";
+		final String locationAbbr = "MEX";
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable locationMV = new MeasurementVariable();
+		locationMV.setTermId(TermId.LOCATION_ABBR.getId());
+		locationMV.setValue(locationAbbr);
+
+		final MeasurementVariable instance1LocationNameMV = new MeasurementVariable();
+		instance1LocationNameMV.setTermId(TermId.TRIAL_LOCATION.getId());
+		final MeasurementData instance1LocationNameMD = new MeasurementData();
+		instance1LocationNameMD.setValue(studyLocation);
+		instance1LocationNameMD.setMeasurementVariable(instance1LocationNameMV);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final MeasurementData instance1MD = new MeasurementData();
+		instance1MD.setValue("1");
+		instance1MD.setMeasurementVariable(instance1MV);
+
+		final MeasurementRow instance1Measurements = new MeasurementRow();
+		instance1Measurements.setDataList(Lists.newArrayList(instance1MD, instance1LocationNameMD));
+		workbook.setTrialObservations(Lists.newArrayList(instance1Measurements));
+
+		workbook.setConditions(Lists.newArrayList(locationMV));
+
+		final List<MeasurementVariable> conditions = workbook.getConditions();
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final String location =
+			new LocationResolver(conditions, fromMeasurementRow(instance1Measurements), locationIdNameMap).resolve();
+		Assert.assertEquals("Location should be resolved to the value of LOCATION_ABBR variable value in Study settings.",
+				locationAbbr,
+				location);
+	}
+
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/resolver/ProjectPrefixResolverTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/resolver/ProjectPrefixResolverTest.java
@@ -1,0 +1,146 @@
+package org.generationcp.middleware.ruleengine.resolver;
+
+import com.google.common.collect.Lists;
+import org.generationcp.middleware.ContextHolder;
+import org.generationcp.middleware.domain.etl.MeasurementData;
+import org.generationcp.middleware.domain.etl.MeasurementRow;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.etl.StudyDetails;
+import org.generationcp.middleware.domain.etl.Workbook;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.domain.oms.TermSummary;
+import org.generationcp.middleware.domain.ontology.Scale;
+import org.generationcp.middleware.domain.ontology.Variable;
+import org.generationcp.middleware.domain.study.StudyTypeDto;
+import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.generationcp.middleware.ruleengine.resolver.SeasonResolverTest.getMeasurementVariableByTermId;
+import static org.generationcp.middleware.service.api.dataset.ObservationUnitUtils.fromMeasurementRow;
+
+public class ProjectPrefixResolverTest {
+
+	@Mock
+	private OntologyVariableDataManager ontologyVariableDataManager;
+
+	private static final Integer PROJECT_CATEGORY_ID = 3001;
+	private static final String PROJECT_CATEGORY_VALUE = "Project_Prefix";
+	private static final String PROGRAM_UUID = UUID.randomUUID().toString();
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		ContextHolder.setCurrentCrop("maize");
+		ContextHolder.setCurrentProgram(PROGRAM_UUID);
+
+		final Variable variable = new Variable();
+		final Scale seasonScale = new Scale();
+		final TermSummary categories = new TermSummary(PROJECT_CATEGORY_ID, PROJECT_CATEGORY_VALUE, PROJECT_CATEGORY_VALUE);
+		seasonScale.addCategory(categories);
+		variable.setScale(seasonScale);
+		Mockito.when(this.ontologyVariableDataManager.getVariable(ArgumentMatchers.eq(PROGRAM_UUID),
+			ArgumentMatchers.eq(TermId.PROJECT_PREFIX.getId()), ArgumentMatchers.eq(true))).thenReturn(variable);
+	}
+
+	@Test
+	public void testResolveForNurseryWithProgramVariableAndValue() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getNurseryDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable measurementVariable = new MeasurementVariable();
+		measurementVariable.setTermId(TermId.PROJECT_PREFIX.getId());
+		measurementVariable.setValue(PROJECT_CATEGORY_ID.toString());
+
+		workbook.setConditions(Lists.newArrayList(measurementVariable));
+
+		final MeasurementRow trialInstanceObservation = workbook.getTrialObservationByTrialInstanceNo(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final ProjectPrefixResolver projectPrefixResolver =
+			new ProjectPrefixResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+		final String program = projectPrefixResolver.resolve();
+		Assert.assertEquals("Program should be resolved to the value of Project_Prefix variable value in Nursery settings.",
+				PROJECT_CATEGORY_VALUE, program);
+
+	}
+
+	@Test
+	public void testResolveForTrialWithProgramVariableAndValue() {
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1ProgramMV = new MeasurementVariable();
+		instance1ProgramMV.setTermId(TermId.PROJECT_PREFIX.getId());
+		final MeasurementData instance1ProgramMD = new MeasurementData();
+		instance1ProgramMD.setValue(PROJECT_CATEGORY_VALUE);
+		instance1ProgramMD.setMeasurementVariable(instance1ProgramMV);
+
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final MeasurementData instance1MD = new MeasurementData();
+		instance1MD.setValue("1");
+		instance1MD.setMeasurementVariable(instance1MV);
+
+		final MeasurementRow trialInstanceObservation = new MeasurementRow();
+		trialInstanceObservation.setDataList(Lists.newArrayList(instance1MD, instance1ProgramMD));
+
+		workbook.setTrialObservations(Lists.newArrayList(trialInstanceObservation));
+
+		final ProjectPrefixResolver projectPrefixResolver =
+			new ProjectPrefixResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+		final String season = projectPrefixResolver.resolve();
+		Assert.assertEquals("Program should be resolved to the value of Project_Prefix variable value in environment level settings.",
+				PROJECT_CATEGORY_VALUE, season);
+	}
+	
+	@Test
+	public void testResolveForStudyWithProgramVariableConditions() {
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable instance1ProgramMV = new MeasurementVariable();
+		instance1ProgramMV.setTermId(TermId.PROJECT_PREFIX.getId());
+		instance1ProgramMV.setValue(PROJECT_CATEGORY_VALUE);
+		
+		final MeasurementVariable instance1MV = new MeasurementVariable();
+		instance1MV.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		instance1MV.setValue("1");
+		
+		final MeasurementRow trialInstanceObservation = null;
+		
+		final List<MeasurementVariable> conditions = new ArrayList<MeasurementVariable>();
+		conditions.add(instance1MV);
+		conditions.add(instance1ProgramMV);
+		workbook.setConditions(conditions );
+
+		final StudyTypeDto studyType = workbook.getStudyDetails().getStudyType();
+
+		final ProjectPrefixResolver projectPrefixResolver =
+			new ProjectPrefixResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+		final String season = projectPrefixResolver.resolve();
+		Assert.assertEquals("Program should be resolved to the value of Project_Prefix variable value in environment level settings.",
+				PROJECT_CATEGORY_VALUE, season);
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/resolver/SeasonResolverTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/resolver/SeasonResolverTest.java
@@ -1,0 +1,381 @@
+package org.generationcp.middleware.ruleengine.resolver;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.generationcp.middleware.ContextHolder;
+import org.generationcp.middleware.data.initializer.ValueReferenceTestDataInitializer;
+import org.generationcp.middleware.domain.dms.ValueReference;
+import org.generationcp.middleware.domain.etl.MeasurementData;
+import org.generationcp.middleware.domain.etl.MeasurementRow;
+import org.generationcp.middleware.domain.etl.MeasurementVariable;
+import org.generationcp.middleware.domain.etl.StudyDetails;
+import org.generationcp.middleware.domain.etl.Workbook;
+import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.domain.oms.TermSummary;
+import org.generationcp.middleware.domain.ontology.Scale;
+import org.generationcp.middleware.domain.ontology.Variable;
+import org.generationcp.middleware.domain.study.StudyTypeDto;
+import org.generationcp.middleware.manager.ontology.api.OntologyVariableDataManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import javax.annotation.Nullable;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.generationcp.middleware.service.api.dataset.ObservationUnitUtils.fromMeasurementData;
+import static org.generationcp.middleware.service.api.dataset.ObservationUnitUtils.fromMeasurementRow;
+
+public class SeasonResolverTest {
+
+
+	private ValueReferenceTestDataInitializer valueReferenceTestDataInitializer;
+
+	@Mock
+	private OntologyVariableDataManager ontologyVariableDataManager;
+
+	private static final Integer SEASON_CATEGORY_ID = 10290;
+	private static final String SEASON_CATEGORY_NAME_VALUE = "1";
+	private static final String SEASON_CATEGORY_DESCRIPTION_VALUE = "Dry Season";
+	public static final String DESCRIPTION_STRING_NOT_FOUND_IN_POSSIBLE_VALUES = "Description not found in possible values";
+	private static final String PROGRAM_UUID = UUID.randomUUID().toString();
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		ContextHolder.setCurrentCrop("maize");
+		ContextHolder.setCurrentProgram(PROGRAM_UUID);
+
+		final Variable seasonVariable = new Variable();
+		final Scale seasonScale = new Scale();
+		final TermSummary seasonCategory = new TermSummary(SEASON_CATEGORY_ID, SEASON_CATEGORY_NAME_VALUE, SEASON_CATEGORY_DESCRIPTION_VALUE);
+		seasonScale.addCategory(seasonCategory);
+		seasonVariable.setScale(seasonScale);
+		Mockito.when(this.ontologyVariableDataManager.getVariable(ArgumentMatchers.eq(PROGRAM_UUID),
+			ArgumentMatchers.eq(TermId.SEASON_VAR.getId()), ArgumentMatchers.eq(true))).thenReturn(seasonVariable);
+		this.valueReferenceTestDataInitializer = new ValueReferenceTestDataInitializer();
+	}
+
+	@Test
+	public void testResolveForNurseryWithSeasonVariableAndValue() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(new StudyTypeDto("N"));
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable seasonMV = new MeasurementVariable();
+		seasonMV.setTermId(TermId.SEASON_VAR.getId());
+		seasonMV.setValue(SEASON_CATEGORY_ID.toString());
+
+		workbook.setConditions(Lists.newArrayList(seasonMV));
+
+		final MeasurementRow trialInstanceObservation = workbook.getTrialObservationByTrialInstanceNo(TermId.TRIAL_INSTANCE_FACTOR.getId());
+
+		final SeasonResolver seasonResolver =
+			new SeasonResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+
+		final String season = seasonResolver.resolve();
+		Assert.assertEquals("Season should be resolved to the value of Crop_season_Code variable value in Nursery settings.",
+				SEASON_CATEGORY_NAME_VALUE, season);
+
+	}
+
+	@Test
+	public void testResolveForNurseryWithSeasonVariableButNoValue() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getNurseryDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable seasonMV = new MeasurementVariable();
+		seasonMV.setTermId(TermId.SEASON_VAR.getId());
+		// Variable presnet but no value
+
+		workbook.setConditions(Lists.newArrayList(seasonMV));
+
+		final MeasurementRow trialInstanceObservation = workbook.getTrialObservationByTrialInstanceNo(TermId.TRIAL_INSTANCE_FACTOR.getId());
+
+		final SeasonResolver seasonResolver =
+			new SeasonResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+
+		final String season = seasonResolver.resolve();
+
+		final SimpleDateFormat formatter = new SimpleDateFormat("YYYYMM");
+		final String currentYearAndMonth = formatter.format(new java.util.Date());
+
+		Assert.assertEquals(
+				"Season should be defaulted to current year and month when Crop_season_Code variable is present but has no value.",
+				currentYearAndMonth, season);
+	}
+
+	@Test
+	public void testResolveForNurseryWithoutSeasonVariable() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getNurseryDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementRow trialInstanceObservation = workbook.getTrialObservationByTrialInstanceNo(TermId.TRIAL_INSTANCE_FACTOR.getId());
+
+		final SeasonResolver seasonResolver =
+			new SeasonResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+
+		final String season = seasonResolver.resolve();
+
+		final SimpleDateFormat formatter = new SimpleDateFormat("YYYYMM");
+		final String currentYearAndMonth = formatter.format(new java.util.Date());
+
+		Assert.assertEquals("Season should be defaulted to current year and month when Crop_season_Code variable is not present.",
+				currentYearAndMonth,
+				season);
+	}
+
+	@Test
+	public void testResolveForTrialWithSeasonVariableAndValue() {
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable firstInstanceSeasonMeasurementVariable = new MeasurementVariable();
+		firstInstanceSeasonMeasurementVariable.setTermId(TermId.SEASON_VAR.getId());
+		firstInstanceSeasonMeasurementVariable.setPossibleValues(this.createTestPossibleValuesForSeasonVariable());
+		final MeasurementData instance1SeasonMD = new MeasurementData();
+		instance1SeasonMD.setValue(SEASON_CATEGORY_DESCRIPTION_VALUE);
+		instance1SeasonMD.setMeasurementVariable(firstInstanceSeasonMeasurementVariable);
+
+		final MeasurementVariable firstInstanceMeasurementVariable = new MeasurementVariable();
+		firstInstanceMeasurementVariable.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final MeasurementData firstInstanceMeasurementData = new MeasurementData();
+		firstInstanceMeasurementData.setValue("1");
+		firstInstanceMeasurementData.setMeasurementVariable(firstInstanceMeasurementVariable);
+
+		final MeasurementRow trialInstanceObservation = new MeasurementRow();
+		trialInstanceObservation.setDataList(Lists.newArrayList(firstInstanceMeasurementData, instance1SeasonMD));
+
+		workbook.setTrialObservations(Lists.newArrayList(trialInstanceObservation));
+
+		final SeasonResolver seasonResolver =
+			new SeasonResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+
+		final String season = seasonResolver.resolve();
+		Assert.assertEquals("Season should be resolved to the value of Crop_season_Code variable value in environment level settings.",
+				SEASON_CATEGORY_NAME_VALUE, season);
+	}
+
+	@Test
+	public void testResolveForStudyWithSeasonVariableButNoValue() {
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable firstInstanceSeasonMeasurementVariable = new MeasurementVariable();
+		firstInstanceSeasonMeasurementVariable.setTermId(TermId.SEASON_VAR.getId());
+		final MeasurementData instance1SeasonMD = new MeasurementData();
+		// Variable present but has no value
+		instance1SeasonMD.setMeasurementVariable(firstInstanceSeasonMeasurementVariable);
+
+		final MeasurementVariable firstInstanceMeasurementVariable = new MeasurementVariable();
+		firstInstanceMeasurementVariable.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		final MeasurementData firstInstanceMeasurementData = new MeasurementData();
+		firstInstanceMeasurementData.setValue("1");
+		firstInstanceMeasurementData.setMeasurementVariable(firstInstanceMeasurementVariable);
+
+		final MeasurementRow trialInstanceObservation = new MeasurementRow();
+		trialInstanceObservation.setDataList(Lists.newArrayList(firstInstanceMeasurementData, instance1SeasonMD));
+
+		workbook.setTrialObservations(Lists.newArrayList(trialInstanceObservation));
+
+		final SeasonResolver seasonResolver =
+			new SeasonResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+
+		final String season = seasonResolver.resolve();
+
+		final SimpleDateFormat formatter = new SimpleDateFormat("YYYYMM");
+		final String currentYearAndMonth = formatter.format(new java.util.Date());
+
+		Assert.assertEquals(
+				"Season should be defaulted to current year and month when Crop_season_Code variable in environment level settings, is present but has no value.",
+				currentYearAndMonth, season);
+	}
+
+	@Test
+	public void testResolveForStudyWithoutSeasonVariable() {
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final SimpleDateFormat formatter = new SimpleDateFormat("YYYYMM");
+		final String currentYearAndMonth = formatter.format(new java.util.Date());
+
+		final MeasurementRow trialInstanceObservation = workbook.getTrialObservationByTrialInstanceNo(TermId.TRIAL_INSTANCE_FACTOR.getId());
+
+		final SeasonResolver seasonResolver =
+			new SeasonResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+
+		final String season = seasonResolver.resolve();
+		Assert.assertEquals(
+				"Season should be defaulted to current year and month when Crop_season_Code variable is not present in environment level settings.",
+				currentYearAndMonth, season);
+	}
+
+	@Test
+	public void testGetValueFromStudyInstanceMeasurementDataSeasonDesscriptionIsPresentInPossibleValues() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable firstInstanceSeasonMeasurementVariable = new MeasurementVariable();
+		firstInstanceSeasonMeasurementVariable.setTermId(TermId.SEASON_VAR.getId());
+		firstInstanceSeasonMeasurementVariable.setPossibleValues(this.createTestPossibleValuesForSeasonVariable());
+		final MeasurementData firstInstanceSeasonMeasurementData = new MeasurementData();
+		firstInstanceSeasonMeasurementData.setValue(SEASON_CATEGORY_DESCRIPTION_VALUE);
+		firstInstanceSeasonMeasurementData.setMeasurementVariable(firstInstanceSeasonMeasurementVariable);
+
+		final MeasurementRow trialInstanceObservation = new MeasurementRow();
+		trialInstanceObservation.setDataList(Lists.newArrayList(firstInstanceSeasonMeasurementData));
+
+		workbook.setTrialObservations(Lists.newArrayList(trialInstanceObservation));
+
+		final SeasonResolver seasonResolver =
+			new SeasonResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+
+		Assert.assertEquals("The method should return the Season Name, not the Season Description.", SEASON_CATEGORY_NAME_VALUE,
+			seasonResolver.getValueFromObservationUnitData(fromMeasurementData(firstInstanceSeasonMeasurementData)));
+
+	}
+
+	@Test
+	public void testGetValueFromStudyInstanceMeasurementDataSeasonDesscriptionDoesNotExistInPossibleValues() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable firstInstanceSeasonMeasurementVariable = new MeasurementVariable();
+		firstInstanceSeasonMeasurementVariable.setTermId(TermId.SEASON_VAR.getId());
+		firstInstanceSeasonMeasurementVariable.setPossibleValues(this.createTestPossibleValuesForSeasonVariable());
+		final MeasurementData firstInstanceSeasonMeasurementData = new MeasurementData();
+		firstInstanceSeasonMeasurementData.setValue(DESCRIPTION_STRING_NOT_FOUND_IN_POSSIBLE_VALUES);
+		firstInstanceSeasonMeasurementData.setMeasurementVariable(firstInstanceSeasonMeasurementVariable);
+
+		final MeasurementRow trialInstanceObservation = new MeasurementRow();
+		trialInstanceObservation.setDataList(Lists.newArrayList(firstInstanceSeasonMeasurementData));
+		workbook.setTrialObservations(Lists.newArrayList(trialInstanceObservation));
+
+		final SeasonResolver seasonResolver =
+			new SeasonResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+
+		Assert.assertEquals("The method should return the Season Measurement Data value as it is since the value is not found in possible values.",
+			DESCRIPTION_STRING_NOT_FOUND_IN_POSSIBLE_VALUES,
+			seasonResolver.getValueFromObservationUnitData(fromMeasurementData(firstInstanceSeasonMeasurementData)));
+
+	}
+
+	@Test
+	public void testFindValueReferenceByDescriptionPossibleValues() {
+
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementRow trialInstanceObservation = workbook.getTrialObservationByTrialInstanceNo(TermId.TRIAL_INSTANCE_FACTOR.getId());
+
+		final SeasonResolver seasonResolver =
+			new SeasonResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+
+		final Optional<ValueReference> result1 = seasonResolver.findValueReferenceByDescription(SEASON_CATEGORY_DESCRIPTION_VALUE, null);
+		Assert.assertFalse(result1.isPresent());
+
+		final Optional<ValueReference> result2 = seasonResolver.findValueReferenceByDescription(SEASON_CATEGORY_DESCRIPTION_VALUE, this.createTestPossibleValuesForSeasonVariable());
+		Assert.assertTrue(result2.isPresent());
+
+		final Optional<ValueReference> result3 = seasonResolver.findValueReferenceByDescription(DESCRIPTION_STRING_NOT_FOUND_IN_POSSIBLE_VALUES, this.createTestPossibleValuesForSeasonVariable());
+		Assert.assertFalse(result3.isPresent());
+
+
+	}
+
+	@Test
+	public void testResolveForStudyWithSeasonVariableConditions() {
+		final Workbook workbook = new Workbook();
+		final StudyDetails studyDetails = new StudyDetails();
+		studyDetails.setStudyType(StudyTypeDto.getTrialDto());
+		workbook.setStudyDetails(studyDetails);
+
+		final MeasurementVariable firstInstanceSeasonMeasurementVariable = new MeasurementVariable();
+		firstInstanceSeasonMeasurementVariable.setTermId(TermId.SEASON_VAR.getId());
+		firstInstanceSeasonMeasurementVariable.setPossibleValues(this.createTestPossibleValuesForSeasonVariable());
+		firstInstanceSeasonMeasurementVariable.setValue(SEASON_CATEGORY_DESCRIPTION_VALUE);
+
+		final MeasurementVariable firstInstanceMeasurementVariable = new MeasurementVariable();
+		firstInstanceMeasurementVariable.setTermId(TermId.TRIAL_INSTANCE_FACTOR.getId());
+		firstInstanceMeasurementVariable.setValue("1");
+		
+		final MeasurementRow trialInstanceObservation = null;
+				
+		final List<MeasurementVariable> conditions = new ArrayList<MeasurementVariable>();
+		conditions.add(firstInstanceSeasonMeasurementVariable);
+		conditions.add(firstInstanceMeasurementVariable);
+		workbook.setConditions(conditions);
+
+		final SeasonResolver seasonResolver =
+			new SeasonResolver(this.ontologyVariableDataManager, workbook.getConditions(),
+				fromMeasurementRow(trialInstanceObservation), getMeasurementVariableByTermId(trialInstanceObservation));
+
+		final String season = seasonResolver.resolve();
+		Assert.assertEquals("Season should be resolved to the value of Crop_season_Code variable value in environment level settings.",
+				SEASON_CATEGORY_NAME_VALUE, season);
+	}
+	
+	private List<ValueReference> createTestPossibleValuesForSeasonVariable() {
+		final List<ValueReference> possibleValues = new ArrayList<>();
+		possibleValues.add(this.valueReferenceTestDataInitializer.createValueReference(SEASON_CATEGORY_ID, SEASON_CATEGORY_NAME_VALUE, SEASON_CATEGORY_DESCRIPTION_VALUE));
+		return possibleValues;
+	}
+
+	protected static Map<Integer, MeasurementVariable> getMeasurementVariableByTermId(final MeasurementRow trialInstanceObservation) {
+		if (trialInstanceObservation == null) {
+            return new HashMap<>();
+		}
+		return Maps.uniqueIndex(trialInstanceObservation.getMeasurementVariables(), new Function<MeasurementVariable, Integer>() {
+
+			@Nullable
+			@Override
+			public Integer apply(@Nullable final MeasurementVariable measurementVariable) {
+				return measurementVariable.getTermId();
+			}
+		});
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/stockid/BreederIdentifierRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/stockid/BreederIdentifierRuleTest.java
@@ -1,0 +1,54 @@
+
+package org.generationcp.middleware.ruleengine.stockid;
+
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BreederIdentifierRuleTest {
+
+	private static final String TEST_BREEDER_IDENTIFIER = "DV";
+
+	@Mock
+	private BreederIdentifierGenerationStrategy generationStrategy;
+
+	@InjectMocks
+	private BreederIdentifierRule unitUnderTest;
+	private StockIDGenerationRuleExecutionContext ruleContext;
+
+	@Before
+	public void setUp() {
+		ruleContext = new StockIDGenerationRuleExecutionContext(new ArrayList<String>());
+	}
+
+	@Test
+	public void testPresetBreederIdentifierAvailable() throws RuleException {
+		ruleContext.setBreederIdentifier(TEST_BREEDER_IDENTIFIER);
+
+		unitUnderTest.runRule(ruleContext);
+
+		Mockito.verify(generationStrategy, Mockito.never()).generateBreederIdentifier();
+		Assert.assertEquals("Expected rule to provide the breeder identifier present in context", TEST_BREEDER_IDENTIFIER,
+				ruleContext.getRuleExecutionOutput());
+
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testBreederIdentifierNotAvailable() throws RuleException {
+		unitUnderTest.runRule(ruleContext);
+	}
+
+	@Test
+	public void testKey() {
+		Assert.assertEquals(BreederIdentifierRule.KEY, unitUnderTest.getKey());
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/stockid/StockIDSeparatorRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/stockid/StockIDSeparatorRuleTest.java
@@ -1,0 +1,46 @@
+
+package org.generationcp.middleware.ruleengine.stockid;
+
+import junit.framework.Assert;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+public class StockIDSeparatorRuleTest {
+
+	private static final String TEST_SEPARATOR = "|";
+
+	private StockIDSeparatorRule unitUnderTest;
+	private StockIDGenerationRuleExecutionContext ruleContext;
+
+	@Before
+	public void setUp() {
+		unitUnderTest = new StockIDSeparatorRule();
+		ruleContext = new StockIDGenerationRuleExecutionContext(new ArrayList<String>());
+	}
+
+	@Test
+	public void testNoSuppliedSeparator() throws RuleException {
+		unitUnderTest.runRule(ruleContext);
+
+		Assert.assertEquals("Expected rule to output the default separator", StockIDSeparatorRule.DEFAULT_SEPARATOR,
+				ruleContext.getRuleExecutionOutput());
+	}
+
+	@Test
+	public void testSeparatorSupplied() throws RuleException {
+		ruleContext.setSeparator(TEST_SEPARATOR);
+
+		unitUnderTest.runRule(ruleContext);
+
+		Assert.assertEquals("Expected the rule to output the separator provided in the context", TEST_SEPARATOR,
+				ruleContext.getRuleExecutionOutput());
+	}
+
+	@Test
+	public void testGetKey() {
+		Assert.assertEquals(StockIDSeparatorRule.KEY, unitUnderTest.getKey());
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/stockid/StockNotationNumberRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/stockid/StockNotationNumberRuleTest.java
@@ -1,0 +1,41 @@
+
+package org.generationcp.middleware.ruleengine.stockid;
+
+import junit.framework.Assert;
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.generationcp.middleware.service.api.inventory.LotService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class StockNotationNumberRuleTest {
+
+	private static final int TEST_NOTATION_NUMBER = 3;
+
+	private StockNotationNumberRule unitUnderTest;
+	private StockIDGenerationRuleExecutionContext ruleContext;
+	private LotService lotService;
+
+	@Before
+	public void setUp() throws Exception {
+		unitUnderTest = new StockNotationNumberRule();
+
+		lotService = Mockito.mock(LotService.class);
+		ruleContext = new StockIDGenerationRuleExecutionContext(null, lotService);
+		ruleContext.setBreederIdentifier("DV");
+	}
+
+	@Test
+	public void testStockNotation() throws RuleException {
+		Mockito.when(this.lotService.getCurrentNotationNumberForBreederIdentifier(Mockito.anyString())).thenReturn(TEST_NOTATION_NUMBER);
+
+		unitUnderTest.runRule(ruleContext);
+		Assert.assertEquals("Unable to output the incremented value of the current notation number for input", new Integer(
+				TEST_NOTATION_NUMBER + 1).toString(), ruleContext.getRuleExecutionOutput());
+	}
+
+	@Test
+	public void testGetKey() {
+		Assert.assertEquals(StockNotationNumberRule.KEY, unitUnderTest.getKey());
+	}
+}

--- a/src/test/java/org/generationcp/middleware/ruleengine/stockid/StockSequenceRuleTest.java
+++ b/src/test/java/org/generationcp/middleware/ruleengine/stockid/StockSequenceRuleTest.java
@@ -1,0 +1,50 @@
+
+package org.generationcp.middleware.ruleengine.stockid;
+
+import org.generationcp.middleware.ruleengine.RuleException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class StockSequenceRuleTest {
+
+	private StockSequenceRule unitUnderTest;
+	private StockIDGenerationRuleExecutionContext ruleContext;
+
+	private final static Long NEW_SEQUENCE_NUMBER = new Long(1);
+
+	@Before
+	public void setUp() {
+		unitUnderTest = new StockSequenceRule();
+		ruleContext = new StockIDGenerationRuleExecutionContext(new ArrayList<String>());
+	}
+
+	@Test
+	public void testSequenceOutputNewSequence() throws RuleException {
+		Long sequence = (Long) unitUnderTest.runRule(ruleContext);
+
+		assertEquals(sequence, NEW_SEQUENCE_NUMBER);
+		assertEquals("Expected the rule output to use a new sequence if no start sequence provided", NEW_SEQUENCE_NUMBER,
+				ruleContext.getSequenceNumber());
+
+	}
+
+	@Test
+	public void testSequenceOutputExistingSequence() throws RuleException {
+		Long existingSequenceNumber = 5L;
+		ruleContext.setSequenceNumber(existingSequenceNumber);
+
+		Long newSequenceNumber = (Long) unitUnderTest.runRule(ruleContext);
+		assertEquals("Expected the rule output to increment the value of the existing sequence", new Long(existingSequenceNumber + 1),
+				newSequenceNumber);
+
+	}
+
+	@Test
+	public void testGetKey() {
+		assertEquals(StockSequenceRule.KEY, unitUnderTest.getKey());
+	}
+}

--- a/src/test/resources/BaseNamingRuleTest-context.xml
+++ b/src/test/resources/BaseNamingRuleTest-context.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xmlns:aop="http://www.springframework.org/schema/aop"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+			http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+			http://www.springframework.org/schema/context
+			http://www.springframework.org/schema/context/spring-context-4.1.xsd
+			http://www.springframework.org/schema/aop
+			http://www.springframework.org/schema/aop/spring-aop-4.1.xsd">
+
+	<!-- Declare property file locations  -->
+	<context:property-placeholder location="classpath:test.properties, classpath:crossing.properties" />
+
+
+   	<bean class="org.generationcp.middleware.ruleengine.naming.expression.ComponentPostProcessor">
+        <property name="ruleFactory" ref="ruleFactory"/>
+		<property name="processCodeFactory" ref="processCodeFactory" />
+    </bean>
+
+    <bean id="ruleFactory" class="org.generationcp.middleware.ruleengine.ProcessCodeRuleFactory"
+          init-method="init"/>
+
+    <bean id="ruleConfigProvider"
+          class="org.generationcp.middleware.ruleengine.provider.PropertyFileRuleConfigurationProvider">
+        <property name="ruleSequenceConfiguration">
+            <map>
+                <entry key="naming" value="${naming.rules}"/>
+            </map>
+        </property>
+    </bean>
+	<bean id="ruleService" class="org.generationcp.middleware.ruleengine.impl.RulesServiceImpl" />
+
+	<bean id="germplasmNamingService" class="org.generationcp.middleware.ruleengine.naming.impl.GermplasmNamingServiceImpl" />
+
+    <!--
+            This component scan automatically registers all implementations of the Rule interface into the Spring context.
+            In conjunction with the RulesPostProcessor above, this automatically populates the map in the RuleFactory
+             -->
+	<context:component-scan base-package="org.generationcp.middleware.ruleengine.naming" />
+	<context:component-scan base-package="org.generationcp.middleware.ruleengine.naming.expression" />
+
+	<bean id="processCodeFactory"
+		  class="org.generationcp.middleware.ruleengine.naming.impl.ProcessCodeFactory"
+		  init-method="init"/>
+
+	<!-- Singleton bean as there is nothing request specific in here. -->
+	<bean id="germplasmNamingProperties" class="org.generationcp.middleware.ruleengine.service.GermplasmNamingProperties">
+		<property name="germplasmOriginStudiesDefault" value="${germplasm.origin.studies.default}"/>
+		<property name="germplasmOriginStudiesWheat" value="${germplasm.origin.studies.wheat}"/>
+		<property name="germplasmOriginStudiesMaize" value="${germplasm.origin.studies.maize}"/>
+        <property name="breedersCrossIDStudy" value="${breeders.cross.id.study}" />
+	</bean>
+
+    <bean id="breedersCrossIDGenerator" class="org.generationcp.middleware.ruleengine.generator.BreedersCrossIDGenerator">
+	</bean>
+
+<!--	<bean id="workbenchHibernateSessionProvider"-->
+<!--		  class="org.generationcp.middleware.hibernate.HibernateSessionPerRequestProvider"-->
+<!--		  scope="request" destroy-method="close">-->
+<!--		<property name="sessionFactory" ref="WORKBENCH_SessionFactory" />-->
+
+<!--		&lt;!&ndash; JDK Standard Proxy around this request scoped bean, so we can use-->
+<!--			it on longer scoped beans &ndash;&gt;-->
+<!--		<aop:scoped-proxy proxy-target-class="false" />-->
+<!--	</bean>-->
+
+<!--	<bean id="roleService"-->
+<!--		  class="org.generationcp.middleware.api.role.RoleServiceImpl"-->
+<!--		  destroy-method="close">-->
+<!--		<constructor-arg ref="workbenchHibernateSessionProvider" />-->
+<!--	</bean>-->
+
+<!--	<bean id="permissionService"-->
+<!--		  class="org.generationcp.middleware.service.api.permission.PermissionServiceImpl"-->
+<!--		  destroy-method="close">-->
+<!--		<constructor-arg ref="workbenchHibernateSessionProvider" />-->
+<!--	</bean>-->
+
+<!--	<bean id="programServiceMw"-->
+<!--			  class="org.generationcp.middleware.api.program.ProgramServiceImpl">-->
+<!--        <constructor-arg ref="workbenchHibernateSessionProvider"/>-->
+<!--    </bean>-->
+
+<!--	<bean id="managerFactoryProvider"-->
+<!--		  class="org.generationcp.commons.hibernate.DynamicManagerFactoryProviderConcurrency">-->
+<!--		<constructor-arg ref="programServiceMw" />-->
+<!--		<property name="pedigreeProfile" value="${pedigree.profile}"/>-->
+<!--	</bean>-->
+
+<!--	<bean id="managerFactory" name="managerFactory" factory-bean="managerFactoryProvider"-->
+<!--		factory-method="createInstance" scope="request">-->
+<!--		<aop:scoped-proxy />-->
+<!--	</bean>-->
+
+<!--	<bean id="ontologyVariableManager" factory-bean="managerFactory"-->
+<!--		  factory-method="getOntologyVariableDataManager" scope="request">-->
+<!--		<aop:scoped-proxy />-->
+<!--	</bean>-->
+
+<!--	<bean id="studyDataManager" factory-bean="managerFactory"-->
+<!--		  factory-method="getNewStudyDataManager" scope="request">-->
+<!--		<aop:scoped-proxy />-->
+<!--	</bean>-->
+
+<!--	<bean id="germplasmDataManager" factory-bean="managerFactory"-->
+<!--		  factory-method="getGermplasmDataManager" scope="request">-->
+<!--		<aop:scoped-proxy />-->
+<!--	</bean>-->
+
+<!--    <bean id="keySequenceRegisterService" factory-bean="managerFactory"-->
+<!--		  factory-method="getKeySequenceRegisterService" scope="request">-->
+<!--        <aop:scoped-proxy />-->
+<!--    </bean>-->
+
+<!--	<bean id="pedigreeDataManager" factory-bean="managerFactory"-->
+<!--		  factory-method="getPedigreeDataManager" scope="request">-->
+<!--		<aop:scoped-proxy />-->
+<!--	</bean>-->
+
+<!--	<bean id="contextUtil" class="org.generationcp.commons.spring.util.ContextUtil"-->
+<!--		  scope="request">-->
+<!--		<aop:scoped-proxy />-->
+<!--	</bean>-->
+
+<!--	<bean id="datasetService" factory-bean="managerFactory"-->
+<!--		  factory-method="getDatasetMiddlewareService" scope="request">-->
+<!--		<aop:scoped-proxy proxy-target-class="false" />-->
+<!--	</bean>-->
+
+
+<!--	<bean id="studyInstanceService" factory-bean="managerFactory" factory-method="studyInstanceMiddlewareService"-->
+<!--		  scope="request">-->
+<!--		<aop:scoped-proxy/>-->
+<!--	</bean>-->
+
+<!--	<bean id="experimentModelGenerator" factory-bean="managerFactory" factory-method="getExperimentModelGenerator"-->
+<!--		  scope="request">-->
+<!--		<aop:scoped-proxy/>-->
+<!--	</bean>-->
+
+<!--	<bean id="experimentDesignService" factory-bean="managerFactory" factory-method="getExperimentDesignService"-->
+<!--		  scope="request">-->
+<!--		<aop:scoped-proxy/>-->
+<!--	</bean>-->
+
+</beans>


### PR DESCRIPTION
Besides a lot of code was moved, it is important to mention that all usages of org.generation.commons.spring.util.ContextUtil were replaced using org.generationcp.middleware.ContextHolder methods